### PR TITLE
Editing Message of Previous Commits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,16 @@ enum Commands {
         yes: bool,
     },
 
+    /// Edit the message of an existing commit
+    EditMessage {
+        /// Commit OID to edit
+        commit: String,
+
+        /// New commit message
+        #[arg(long)]
+        edit: String,
+    },
+
     /// Launch the h5i web dashboard in your browser
     Serve {
         /// Port to listen on
@@ -1244,6 +1254,26 @@ fn main() -> anyhow::Result<()> {
                 "{} {} {}",
                 SUCCESS,
                 style("Revert commit created:").green(),
+                style(new_oid).magenta().bold()
+            );
+        }
+
+        Commands::EditMessage { commit, edit } => {
+            let repo = H5iRepository::open(".")?;
+            let oid = Oid::from_str(&commit)?;
+
+            println!(
+                "{} {} {}",
+                STEP,
+                style("Editing commit message for").cyan().bold(),
+                style(&commit[..8.min(commit.len())]).magenta(),
+            );
+
+            let new_oid = repo.edit_commit_message(oid, &edit)?;
+            println!(
+                "{} {} {}",
+                SUCCESS,
+                style("New commit OID:").green(),
                 style(new_oid).magenta().bold()
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1269,7 +1269,7 @@ fn main() -> anyhow::Result<()> {
                 style(&commit[..8.min(commit.len())]).magenta(),
             );
 
-            let new_oid = repo.edit_commit_message(oid, &edit)?;
+            let (new_oid, _oid_map) = repo.edit_commit_message(oid, &edit)?;
             println!(
                 "{} {} {}",
                 SUCCESS,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -36,9 +36,12 @@ pub struct H5iCommitRecord {
     pub crdt_states: Option<HashMap<String, String>>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
     /// OIDs of commits that causally triggered this commit.
-    /// e.g. this commit fixes a bug introduced by `caused_by[0]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub caused_by: Vec<String>,
+    /// OIDs of commits that this commit causally triggered.
+    /// Inverse of `caused_by` — populated automatically at commit time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub causes: Vec<String>,
     /// Structured design decisions recorded at commit time via `--decisions`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub decisions: Vec<Decision>,
@@ -278,14 +281,16 @@ impl H5iCommitRecord {
         H5iCommitRecord {
             git_oid: oid.to_string(),
             parent_oid,
-            ai_metadata: None,  // Standard Git commits do not contain AI metadata
-            test_metrics: None, // Standard Git commits do not contain testing metrics
-            ast_hashes: None,   // Standard Git commits do not contain AST hashes
+            ai_metadata: None,
+            test_metrics: None,
+            ast_hashes: None,
             crdt_states: None,
             timestamp,
             caused_by: vec![],
+            causes: vec![],
             decisions: vec![],
         }
+
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -290,7 +290,6 @@ impl H5iCommitRecord {
             causes: vec![],
             decisions: vec![],
         }
-
     }
 }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1822,6 +1822,8 @@ impl H5iRepository {
         Ok(self.git_repo.head()?.peel_to_commit()?.id())
     }
 
+    // Provides opportunity to edit the message of a previously made commit.
+    // Returns the OID of the newly edited commit.
     pub fn edit_commit_message(&self, oid: Oid, new_message: &str) -> Result<Oid, H5iError> {
         let workdir = self
             .git_repo

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1822,6 +1822,19 @@ impl H5iRepository {
         Ok(self.git_repo.head()?.peel_to_commit()?.id())
     }
 
+    pub fn edit_commit_message(&self, oid: Oid, new_message: &str) -> Result<Oid, H5iError> {
+        let commit = self.git_repo.find_commit(oid)?;
+        commit.amend(
+            Some("HEAD"),
+            None,
+            None,
+            None,
+            Some(new_message),
+            None,
+        )?;
+        Ok(self.git_repo.head()?.peel_to_commit()?.id())
+    }
+
     /// Resolves the current `HEAD` reference and returns the associated commit.
     ///
     /// This method resolves symbolic references and ensures that the

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1842,6 +1842,22 @@ impl H5iRepository {
             .current_dir(workdir)
             .output()
             .map_err(H5iError::Io)?;
+        
+
+        let output = std::process::Command::new("git")
+            .args([...])
+            .current_dir(workdir)
+            .output()
+            .map_err(H5iError::Io)?;
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!("filter-branch stdout: {stdout}");
+        eprintln!("filter-branch stderr: {stderr}");
+        eprintln!("filter-branch exit: {}", output.status);
+
+
+        if !output.status.success() {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -3280,7 +3280,7 @@ mod integration_tests {
         Ok(())
     }
 
-    // Testcase to edit a commit that does not have dependent commits
+    // Testcase to rewrite message of commit without dependent commits
     #[test]
     fn test_edit_commit_message() {
         let dir = tempdir().unwrap();
@@ -3288,10 +3288,10 @@ mod integration_tests {
         let git_repo = repo.git();
         let sig = Signature::now("h5i-test", "test@h5i.io").unwrap();
 
-        let file_path = dir.path().join("funct.rs");
-        fs::write(&file_path, "fn funct() {}").unwrap();
+        let file_path = dir.path().join("foo.rs");
+        fs::write(&file_path, "fn foo() {}").unwrap();
         let mut index = git_repo.index().unwrap();
-        index.add_path(std::path::Path::new("funct.rs")).unwrap();
+        index.add_path(std::path::Path::new("foo.rs")).unwrap();
         index.write().unwrap();
 
         let oid = repo
@@ -3306,7 +3306,7 @@ mod integration_tests {
         assert_eq!(updated_commit.message().unwrap().trim(), "rewritten message");
     }
 
-    // Testcase to edit a commit that has dependent commits
+    // Testcase to rewrite message of commit with dependent commits
     #[test]
     fn test_edit_commit_message_non_head() {
         let dir = tempdir().unwrap();
@@ -3314,19 +3314,19 @@ mod integration_tests {
         let git_repo = repo.git();
         let sig = Signature::now("h5i-test", "test@h5i.io").unwrap();
 
-        let file_path = dir.path().join("funct.rs");
-        fs::write(&file_path, "fn funct() {}").unwrap();
+        let file_path = dir.path().join("foo.rs");
+        fs::write(&file_path, "fn foo() {}").unwrap();
         let mut index = git_repo.index().unwrap();
-        index.add_path(std::path::Path::new("funct.rs")).unwrap();
+        index.add_path(std::path::Path::new("foo.rs")).unwrap();
         index.write().unwrap();
 
         let first_oid = repo
             .commit("original message", &sig, &sig, None, TestSource::None, None, vec![], vec![])
             .expect("first commit failed");
 
-        fs::write(&file_path, "fn funct() {} fn funct2() {}").unwrap();
+        fs::write(&file_path, "fn foo() {} fn bar() {}").unwrap();
         let mut index = git_repo.index().unwrap();
-        index.add_path(std::path::Path::new("funct.rs")).unwrap();
+        index.add_path(std::path::Path::new("foo.rs")).unwrap();
         index.write().unwrap();
 
         repo.commit("second commit", &sig, &sig, None, TestSource::None, None, vec![], vec![])

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1898,8 +1898,14 @@ impl H5iRepository {
     }
 
     // Provides opportunity to edit the message of a previously made commit.
-    // Returns the OID of the newly edited commit.
-    pub fn edit_commit_message(&self, oid: Oid, new_message: &str) -> Result<Oid, H5iError> {
+    // Returns the OID of the newly edited commit and a map of all old → new OIDs
+    // for every commit that was rewritten (including descendants of the target).
+    // Callers that hold OIDs to downstream commits must remap them using this map.
+    pub fn edit_commit_message(
+        &self,
+        oid: Oid,
+        new_message: &str,
+    ) -> Result<(Oid, HashMap<git2::Oid, git2::Oid>), H5iError> {
         // ── Phase 1: BFS from HEAD to find the target ────────────────────
         // `path` is ordered [target, ..., HEAD].
 
@@ -2126,7 +2132,7 @@ impl H5iRepository {
             self.git_repo.set_head_detached(new_head_oid)?;
         }
 
-        Ok(new_target_oid)
+        Ok((new_target_oid, oid_map))
     }
 
     /// Resolves the current `HEAD` reference and returns the associated commit.
@@ -3576,7 +3582,7 @@ mod integration_tests {
             .commit("original message", &sig, &sig, None, TestSource::None, None, vec![], vec![])
             .expect("commit failed");
 
-        let new_oid = repo
+        let (new_oid, _oid_map) = repo
             .edit_commit_message(oid, "rewritten message")
             .expect("edit_commit_message failed");
 
@@ -3610,7 +3616,7 @@ mod integration_tests {
         repo.commit("second commit", &sig, &sig, None, TestSource::None, None, vec![], vec![])
             .expect("second commit failed");
 
-        let new_oid = repo
+        let (new_oid, _oid_map) = repo
             .edit_commit_message(first_oid, "rewritten first message")
             .expect("edit_commit_message failed");
 
@@ -3717,11 +3723,14 @@ mod integration_tests {
             vec![],
         )?;
 
-        // Rewrite first commit's message — its OID changes
-        let new_first_oid = repo.edit_commit_message(first_oid, "rewritten first commit")?;
+        // Rewrite first commit's message — its OID changes, and second's OID changes too
+        let (new_first_oid, oid_map) = repo.edit_commit_message(first_oid, "rewritten first commit")?;
+
+        // second_oid was also rewritten because its parent changed; get the new OID from the map
+        let new_second_oid_from_map = *oid_map.get(&second_oid).expect("second_oid must be in oid_map");
 
         // The second commit's caused_by should now reference the new OID
-        let second_record = repo.load_h5i_record(second_oid)?;
+        let second_record = repo.load_h5i_record(new_second_oid_from_map)?;
         assert!(
             second_record.caused_by.contains(&new_first_oid.to_string()),
             "second commit's caused_by should be updated to new first OID"
@@ -3731,11 +3740,11 @@ mod integration_tests {
             "second commit's caused_by should not contain old first OID"
         );
 
-        // The rewritten first commit's causes should still reference the second commit
+        // The rewritten first commit's causes should reference the new second commit OID
         let new_first_record = repo.load_h5i_record(new_first_oid)?;
         assert!(
-            new_first_record.causes.contains(&second_oid.to_string()),
-            "rewritten first commit's causes should still reference second commit"
+            new_first_record.causes.contains(&new_second_oid_from_map.to_string()),
+            "rewritten first commit's causes should reference the new second commit OID"
         );
 
         Ok(())

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -3279,4 +3279,65 @@ mod integration_tests {
 
         Ok(())
     }
+
+    // Testcase to edit a commit that does not have dependent commits
+    #[test]
+    fn test_edit_commit_message() {
+        let dir = tempdir().unwrap();
+        let repo = setup_integration_context(dir.path());
+        let git_repo = repo.git();
+        let sig = Signature::now("h5i-test", "test@h5i.io").unwrap();
+
+        let file_path = dir.path().join("funct.rs");
+        fs::write(&file_path, "fn funct() {}").unwrap();
+        let mut index = git_repo.index().unwrap();
+        index.add_path(std::path::Path::new("funct.rs")).unwrap();
+        index.write().unwrap();
+
+        let oid = repo
+            .commit("original message", &sig, &sig, None, TestSource::None, None, vec![], vec![])
+            .expect("commit failed");
+
+        let new_oid = repo
+            .edit_commit_message(oid, "rewritten message")
+            .expect("edit_commit_message failed");
+
+        let updated_commit = git_repo.find_commit(new_oid).unwrap();
+        assert_eq!(updated_commit.message().unwrap().trim(), "rewritten message");
+    }
+
+    // Testcase to edit a commit that has dependent commits
+    #[test]
+    fn test_edit_commit_message_non_head() {
+        let dir = tempdir().unwrap();
+        let repo = setup_integration_context(dir.path());
+        let git_repo = repo.git();
+        let sig = Signature::now("h5i-test", "test@h5i.io").unwrap();
+
+        let file_path = dir.path().join("funct.rs");
+        fs::write(&file_path, "fn funct() {}").unwrap();
+        let mut index = git_repo.index().unwrap();
+        index.add_path(std::path::Path::new("funct.rs")).unwrap();
+        index.write().unwrap();
+
+        let first_oid = repo
+            .commit("original message", &sig, &sig, None, TestSource::None, None, vec![], vec![])
+            .expect("first commit failed");
+
+        fs::write(&file_path, "fn funct() {} fn funct2() {}").unwrap();
+        let mut index = git_repo.index().unwrap();
+        index.add_path(std::path::Path::new("funct.rs")).unwrap();
+        index.write().unwrap();
+
+        repo.commit("second commit", &sig, &sig, None, TestSource::None, None, vec![], vec![])
+            .expect("second commit failed");
+
+        let new_oid = repo
+            .edit_commit_message(first_oid, "rewritten first message")
+            .expect("edit_commit_message failed");
+
+        let updated_commit = git_repo.find_commit(new_oid).unwrap();
+        assert_eq!(updated_commit.message().unwrap().trim(), "rewritten first message");
+    }
+
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1823,16 +1823,32 @@ impl H5iRepository {
     }
 
     pub fn edit_commit_message(&self, oid: Oid, new_message: &str) -> Result<Oid, H5iError> {
-        let commit = self.git_repo.find_commit(oid)?;
-        commit.amend(
-            Some("HEAD"),
-            None,
-            None,
-            None,
-            Some(new_message),
-            None,
-        )?;
-        Ok(self.git_repo.head()?.peel_to_commit()?.id())
+        let workdir = self
+            .git_repo
+            .workdir()
+            .ok_or_else(|| H5iError::InvalidPath("Cannot edit message in a bare repository".into()))?;
+
+        let output = std::process::Command::new("git")
+            .args([
+                "filter-branch",
+                "-f",
+                "--msg-filter",
+                &format!("if test \"$GIT_COMMIT\" = \"{oid}\"; then echo \"{new_message}\"; else cat; fi"),
+                "--",
+                "--all",
+            ])
+            .current_dir(workdir)
+            .output()
+            .map_err(H5iError::Io)?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(H5iError::Git(git2::Error::from_str(&format!(
+                "git filter-branch failed: {stderr}"
+            ))));
+        }
+
+        Ok(oid)
     }
 
     /// Resolves the current `HEAD` reference and returns the associated commit.

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -244,14 +244,37 @@ impl H5iRepository {
                 Some(crdt_states)
             },
             timestamp: chrono::Utc::now(),
-            caused_by: resolved_caused_by,
+            caused_by: resolved_caused_by.clone(),
+            causes: vec![],
             decisions,
         };
         let metadata_json = serde_json::to_string(&record)?;
         self.git_repo
             .note(author, committer, Some(H5I_NOTES_REF), commit_oid, &metadata_json, true)?;
 
+        // 4. For each commit listed in caused_by, push this commit's OID into
+        //    that commit's `causes` list so the inverse link is always stored.
+        for cause_oid_str in &resolved_caused_by {
+            if let Ok(cause_oid) = git2::Oid::from_str(cause_oid_str) {
+                if let Ok(mut cause_record) = self.load_h5i_record(cause_oid) {
+                    if !cause_record.causes.contains(&commit_oid.to_string()) {
+                        cause_record.causes.push(commit_oid.to_string());
+                        let updated_json = serde_json::to_string(&cause_record)?;
+                        self.git_repo.note(
+                            author,
+                            committer,
+                            Some(H5I_NOTES_REF),
+                            cause_oid,
+                            &updated_json,
+                            true,
+                        )?;
+                    }
+                }
+            }
+        }
+
         Ok(commit_oid)
+
     }
 
     /// Reads local binary deltas from .git/h5i/delta and encodes them for the Note.
@@ -1337,6 +1360,59 @@ impl H5iRepository {
 
         Ok(())
     }
+
+    fn rewrite_note_oid(
+        &self,
+        old_oid: git2::Oid,
+        new_oid: git2::Oid,
+    ) -> Result<(), H5iError> {
+        let note = match self.git_repo.find_note(Some(H5I_NOTES_REF), old_oid) {
+            Ok(n) => n,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(()),
+            Err(e) => return Err(H5iError::Git(e)),
+        };
+
+        let raw = note
+            .message()
+            .ok_or_else(|| H5iError::Metadata(format!("Empty note on {}", old_oid)))?;
+
+        let mut record: H5iCommitRecord = serde_json::from_str(raw)?;
+        record.git_oid = new_oid.to_string();
+        let updated_json = serde_json::to_string(&record)?;
+
+        let sig = self
+            .git_repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("h5i", "h5i@local").unwrap());
+
+        self.git_repo.note(
+            &sig,
+            &sig,
+            Some(H5I_NOTES_REF),
+            new_oid,
+            &updated_json,
+            true,
+        )?;
+
+        self.git_repo
+            .note_delete(old_oid, Some(H5I_NOTES_REF), &sig, &sig)?;
+
+        Ok(())
+    }
+
+    fn delete_h5i_note(&self, oid: git2::Oid) -> Result<(), H5iError> {
+        let sig = self
+            .git_repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("h5i", "h5i@local").unwrap());
+
+        match self.git_repo.note_delete(oid, Some(H5I_NOTES_REF), &sig, &sig) {
+            Ok(_) => Ok(()),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+            Err(e) => Err(H5iError::Git(e)),
+        }
+    }
+
 }
 
 // ============================================================
@@ -1825,49 +1901,173 @@ impl H5iRepository {
     // Provides opportunity to edit the message of a previously made commit.
     // Returns the OID of the newly edited commit.
     pub fn edit_commit_message(&self, oid: Oid, new_message: &str) -> Result<Oid, H5iError> {
-        let workdir = self
-            .git_repo
-            .workdir()
-            .ok_or_else(|| H5iError::InvalidPath("Cannot edit message in a bare repository".into()))?;
+        // ── Phase 1: BFS from HEAD to find the target ────────────────────
+        // `path` is ordered [target, ..., HEAD].
 
-        let output = std::process::Command::new("git")
-            .args([
-                "filter-branch",
-                "-f",
-                "--msg-filter",
-                &format!("if test \"$GIT_COMMIT\" = \"{oid}\"; then echo \"{new_message}\"; else cat; fi"),
-                "--",
-                "--all",
-            ])
-            .current_dir(workdir)
-            .output()
-            .map_err(H5iError::Io)?;
+        let head_commit = self.get_head_commit()?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(H5iError::Git(git2::Error::from_str(&format!(
-                "git filter-branch failed: {stderr}"
-            ))));
-        }
+        let path: Vec<git2::Oid> = if head_commit.id() == oid {
+            vec![oid]
+        } else {
+            let mut found: Option<Vec<git2::Oid>> = None;
+            let mut queue: std::collections::VecDeque<(git2::Oid, Vec<git2::Oid>)> =
+                std::collections::VecDeque::new();
+            let mut visited: std::collections::HashSet<git2::Oid> =
+                std::collections::HashSet::new();
 
-        // Force git2 to reload the repository state after filter-branch rewrites history
-        let workdir_path = workdir.to_path_buf();
-        drop(output);
-        let fresh_repo = git2::Repository::open(&workdir_path)?;
+            queue.push_back((head_commit.id(), vec![head_commit.id()]));
+            visited.insert(head_commit.id());
 
-        let mut revwalk = fresh_repo.revwalk()?;
-        revwalk.push_head()?;
-        for id in revwalk {
-            let id = id?;
-            let commit = fresh_repo.find_commit(id)?;
-            if commit.message().unwrap_or("").trim() == new_message {
-                return Ok(id);
+            'bfs: while let Some((current_oid, current_path)) = queue.pop_front() {
+                let commit = self.git_repo.find_commit(current_oid)?;
+                for i in 0..commit.parent_count() {
+                    let parent_oid = commit.parent_id(i)?;
+                    if parent_oid == oid {
+                        let mut p = current_path.clone();
+                        p.push(parent_oid);
+                        found = Some(p);
+                        break 'bfs;
+                    }
+                    if visited.insert(parent_oid) {
+                        let mut p = current_path.clone();
+                        p.push(parent_oid);
+                        queue.push_back((parent_oid, p));
+                    }
+                }
             }
+
+            match found {
+                Some(mut p) => {
+                    p.reverse(); // now [target, ..., HEAD]
+                    p
+                }
+                None => {
+                    return Err(H5iError::Git(git2::Error::from_str(&format!(
+                        "Commit {} is not reachable from HEAD",
+                        oid
+                    ))));
+                }
+            }
+        };
+
+        // ── Phase 2: Rewrite the target commit ───────────────────────────
+
+        let target_commit = self.git_repo.find_commit(oid)?;
+
+        let parent_commits: Vec<git2::Commit> = (0..target_commit.parent_count())
+            .map(|i| target_commit.parent(i).map_err(H5iError::Git))
+            .collect::<Result<Vec<_>, _>>()?;
+        let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+
+        let new_target_oid = self.git_repo.commit(
+            None,
+            &target_commit.author(),
+            &target_commit.committer(),
+            new_message,
+            &target_commit.tree()?,
+            &parent_refs,
+        )?;
+
+        self.rewrite_note_oid(oid, new_target_oid)?;
+
+        // ── Phase 3: Rewrite each ancestor back up to HEAD ───────────────
+
+        let mut oid_map: std::collections::HashMap<git2::Oid, git2::Oid> =
+            std::collections::HashMap::new();
+        oid_map.insert(oid, new_target_oid);
+
+        let mut previous_new_oid = new_target_oid;
+
+        for &old_oid in path.iter().skip(1) {
+            let old_commit = self.git_repo.find_commit(old_oid)?;
+
+            let new_parents: Vec<git2::Commit> = (0..old_commit.parent_count())
+                .map(|i| {
+                    let p_oid = old_commit.parent_id(i)?;
+                    let remapped = oid_map.get(&p_oid).copied().unwrap_or(p_oid);
+                    self.git_repo.find_commit(remapped)
+                })
+                .collect::<Result<Vec<_>, git2::Error>>()?;
+            let new_parent_refs: Vec<&git2::Commit> = new_parents.iter().collect();
+
+            let new_oid = self.git_repo.commit(
+                None,
+                &old_commit.author(),
+                &old_commit.committer(),
+                old_commit.message().unwrap_or(""),
+                &old_commit.tree()?,
+                &new_parent_refs,
+            )?;
+
+            oid_map.insert(old_oid, new_oid);
+            self.rewrite_note_oid(old_oid, new_oid)?;
+
+            // Use the `causes` field on the rewritten note (already moved to
+            // new_oid by rewrite_note_oid) to find every commit that declared
+            // old_oid in its `caused_by`, and update those records in-place.
+            let old_oid_str = old_oid.to_string();
+            let new_oid_str = new_oid.to_string();
+
+            if let Ok(record) = self.load_h5i_record(new_oid) {
+                for dep_oid_str in &record.causes {
+                    if let Ok(dep_oid) = git2::Oid::from_str(dep_oid_str) {
+                        let live_dep_oid = oid_map.get(&dep_oid).copied().unwrap_or(dep_oid);
+                        if let Ok(mut dep_record) = self.load_h5i_record(live_dep_oid) {
+                            let mut changed = false;
+                            for entry in dep_record.caused_by.iter_mut() {
+                                if *entry == old_oid_str {
+                                    *entry = new_oid_str.clone();
+                                    changed = true;
+                                }
+                            }
+                            if changed {
+                                let updated_json = serde_json::to_string(&dep_record)?;
+                                let sig = self.git_repo.signature().unwrap_or_else(|_| {
+                                    git2::Signature::now("h5i", "h5i@local").unwrap()
+                                });
+                                self.git_repo.note(
+                                    &sig,
+                                    &sig,
+                                    Some(H5I_NOTES_REF),
+                                    live_dep_oid,
+                                    &updated_json,
+                                    true,
+                                )?;
+                            }
+                        }
+                    }
+                }
+            }
+
+            previous_new_oid = new_oid;
         }
 
-        Err(H5iError::Git(git2::Error::from_str("Could not find rewritten commit")))
-    }
+        // ── Phase 4: Advance HEAD to the new tip ─────────────────────────
 
+        let new_head_oid = previous_new_oid;
+        let head_ref = self.git_repo.head()?;
+
+        if head_ref.is_branch() {
+            let branch_name = head_ref
+                .shorthand()
+                .ok_or_else(|| H5iError::Git(git2::Error::from_str("Cannot read branch name")))?;
+            let full_ref = format!("refs/heads/{}", branch_name);
+            let new_head_commit = self.git_repo.find_commit(new_head_oid)?;
+            self.git_repo.reference(
+                &full_ref,
+                new_head_oid,
+                true,
+                &format!("h5i: rewrite message of {}", &oid.to_string()[..8]),
+            )?;
+            self.git_repo
+                .checkout_tree(new_head_commit.as_object(), None)?;
+            self.git_repo.set_head(&full_ref)?;
+        } else {
+            self.git_repo.set_head_detached(new_head_oid)?;
+        }
+
+        Ok(new_target_oid)
+    }
 
     /// Resolves the current `HEAD` reference and returns the associated commit.
     ///

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1849,15 +1849,28 @@ impl H5iRepository {
         eprintln!("filter-branch stderr: {stderr}");
         eprintln!("filter-branch exit: {}", output.status);
 
-
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(H5iError::Git(git2::Error::from_str(&format!(
                 "git filter-branch failed: {stderr}"
             ))));
         }
 
-        Ok(oid)
+        // Force git2 to reload the repository state after filter-branch rewrites history
+        let workdir_path = workdir.to_path_buf();
+        drop(output);
+        let fresh_repo = git2::Repository::open(&workdir_path)?;
+
+        let mut revwalk = fresh_repo.revwalk()?;
+        revwalk.push_head()?;
+        for id in revwalk {
+            let id = id?;
+            let commit = fresh_repo.find_commit(id)?;
+            if commit.message().unwrap_or("").trim() == new_message {
+                return Ok(id);
+            }
+        }
+
+        Err(H5iError::Git(git2::Error::from_str("Could not find rewritten commit")))
     }
 
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1843,12 +1843,6 @@ impl H5iRepository {
             .output()
             .map_err(H5iError::Io)?;
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        eprintln!("filter-branch stdout: {stdout}");
-        eprintln!("filter-branch stderr: {stderr}");
-        eprintln!("filter-branch exit: {}", output.status);
-
         if !output.status.success() {
             return Err(H5iError::Git(git2::Error::from_str(&format!(
                 "git filter-branch failed: {stderr}"

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1844,6 +1844,7 @@ impl H5iRepository {
             .map_err(H5iError::Io)?;
 
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(H5iError::Git(git2::Error::from_str(&format!(
                 "git filter-branch failed: {stderr}"
             ))));

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1842,13 +1842,6 @@ impl H5iRepository {
             .current_dir(workdir)
             .output()
             .map_err(H5iError::Io)?;
-        
-
-        let output = std::process::Command::new("git")
-            .args([...])
-            .current_dir(workdir)
-            .output()
-            .map_err(H5iError::Io)?;
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1856,8 +1849,6 @@ impl H5iRepository {
         eprintln!("filter-branch stderr: {stderr}");
         eprintln!("filter-branch exit: {}", output.status);
 
-
-        if !output.status.success() {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1853,6 +1853,7 @@ impl H5iRepository {
         Ok(oid)
     }
 
+
     /// Resolves the current `HEAD` reference and returns the associated commit.
     ///
     /// This method resolves symbolic references and ensures that the

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -274,7 +274,6 @@ impl H5iRepository {
         }
 
         Ok(commit_oid)
-
     }
 
     /// Reads local binary deltas from .git/h5i/delta and encodes them for the Note.
@@ -2002,17 +2001,83 @@ impl H5iRepository {
             oid_map.insert(old_oid, new_oid);
             self.rewrite_note_oid(old_oid, new_oid)?;
 
-            // Use the `causes` field on the rewritten note (already moved to
-            // new_oid by rewrite_note_oid) to find every commit that declared
-            // old_oid in its `caused_by`, and update those records in-place.
-            let old_oid_str = old_oid.to_string();
-            let new_oid_str = new_oid.to_string();
+            previous_new_oid = new_oid;
+        }
 
+        // ── Phase 4: Fix up all causal metadata using the completed oid_map ──
+        //
+        // Now that every rewritten OID is known, do a single pass over every
+        // rewritten commit's note and:
+        //   a) update `caused_by` entries that reference any old OID
+        //   b) update `causes` entries that reference any old OID
+        //   c) update the records of commits outside `path` whose `caused_by`
+        //      referenced any old OID (using the `causes` field to find them)
+
+        let sig = self
+            .git_repo
+            .signature()
+            .unwrap_or_else(|_| git2::Signature::now("h5i", "h5i@local").unwrap());
+
+        // Collect the set of new OIDs so we know which notes to patch.
+        let new_oids: Vec<git2::Oid> = oid_map.values().copied().collect();
+
+        // a+b) Patch caused_by and causes inside every rewritten note.
+        for &new_oid in &new_oids {
+            if let Ok(mut record) = self.load_h5i_record(new_oid) {
+                let mut changed = false;
+
+                for entry in record.caused_by.iter_mut() {
+                    if let Ok(e_oid) = git2::Oid::from_str(entry) {
+                        if let Some(&mapped) = oid_map.get(&e_oid) {
+                            *entry = mapped.to_string();
+                            changed = true;
+                        }
+                    }
+                }
+
+                for entry in record.causes.iter_mut() {
+                    if let Ok(e_oid) = git2::Oid::from_str(entry) {
+                        if let Some(&mapped) = oid_map.get(&e_oid) {
+                            *entry = mapped.to_string();
+                            changed = true;
+                        }
+                    }
+                }
+
+                if changed {
+                    let updated_json = serde_json::to_string(&record)?;
+                    self.git_repo.note(
+                        &sig,
+                        &sig,
+                        Some(H5I_NOTES_REF),
+                        new_oid,
+                        &updated_json,
+                        true,
+                    )?;
+                }
+            }
+        }
+
+        // c) For every old OID that was rewritten, find all commits outside
+        //    `path` whose `caused_by` referenced that old OID, and update them.
+        //    These commits are listed in the `causes` field of the rewritten note.
+        for &new_oid in &new_oids {
             if let Ok(record) = self.load_h5i_record(new_oid) {
+                // Find the old OID this new_oid was rewritten from.
+                let old_oid = match oid_map.iter().find(|(_, &v)| v == new_oid) {
+                    Some((&k, _)) => k,
+                    None => continue,
+                };
+                let old_oid_str = old_oid.to_string();
+                let new_oid_str = new_oid.to_string();
+
                 for dep_oid_str in &record.causes {
                     if let Ok(dep_oid) = git2::Oid::from_str(dep_oid_str) {
-                        let live_dep_oid = oid_map.get(&dep_oid).copied().unwrap_or(dep_oid);
-                        if let Ok(mut dep_record) = self.load_h5i_record(live_dep_oid) {
+                        // Skip if this dependent was itself rewritten (handled above).
+                        if oid_map.contains_key(&dep_oid) {
+                            continue;
+                        }
+                        if let Ok(mut dep_record) = self.load_h5i_record(dep_oid) {
                             let mut changed = false;
                             for entry in dep_record.caused_by.iter_mut() {
                                 if *entry == old_oid_str {
@@ -2022,14 +2087,11 @@ impl H5iRepository {
                             }
                             if changed {
                                 let updated_json = serde_json::to_string(&dep_record)?;
-                                let sig = self.git_repo.signature().unwrap_or_else(|_| {
-                                    git2::Signature::now("h5i", "h5i@local").unwrap()
-                                });
                                 self.git_repo.note(
                                     &sig,
                                     &sig,
                                     Some(H5I_NOTES_REF),
-                                    live_dep_oid,
+                                    dep_oid,
                                     &updated_json,
                                     true,
                                 )?;
@@ -2038,11 +2100,9 @@ impl H5iRepository {
                     }
                 }
             }
-
-            previous_new_oid = new_oid;
         }
 
-        // ── Phase 4: Advance HEAD to the new tip ─────────────────────────
+        // ── Phase 5: Advance HEAD to the new tip ─────────────────────────
 
         let new_head_oid = previous_new_oid;
         let head_ref = self.git_repo.head()?;
@@ -3215,13 +3275,14 @@ mod tests {
 
                 let record = H5iCommitRecord {
                     git_oid: oid.to_string(),
-                    parent_oid: None, // Simplified for test
+                    parent_oid: None,
                     ai_metadata: None,
                     test_metrics: None,
                     ast_hashes: None,
                     crdt_states: Some(crdt_states),
                     timestamp: chrono::Utc::now(),
                     caused_by: vec![],
+                    causes: vec![],
                     decisions: vec![],
                 };
 
@@ -3405,6 +3466,7 @@ mod integration_tests {
                 crdt_states: Some(crdt_states),
                 timestamp: chrono::Utc::now(),
                 caused_by: vec![],
+                causes: vec![],
                 decisions: vec![],
             };
 
@@ -3554,6 +3616,129 @@ mod integration_tests {
 
         let updated_commit = git_repo.find_commit(new_oid).unwrap();
         assert_eq!(updated_commit.message().unwrap().trim(), "rewritten first message");
+    }
+
+    // Testcase: caused_by populates causes on the referenced commit
+    #[test]
+    fn test_caused_by_populates_causes() -> crate::error::Result<()> {
+        let dir = tempdir().unwrap();
+        let repo = setup_integration_context(dir.path());
+        let git_repo = repo.git();
+        let sig = Signature::now("h5i-test", "test@h5i.io")?;
+
+        // First commit
+        let file_path = dir.path().join("foo.rs");
+        fs::write(&file_path, "fn foo() {}")?;
+        let mut index = git_repo.index()?;
+        index.add_path(std::path::Path::new("foo.rs"))?;
+        index.write()?;
+        let first_oid = repo.commit(
+            "first commit",
+            &sig,
+            &sig,
+            None,
+            crate::metadata::TestSource::None,
+            None,
+            vec![],
+            vec![],
+        )?;
+
+        // Second commit caused by first
+        fs::write(&file_path, "fn foo() {} fn bar() {}")?;
+        let mut index = git_repo.index()?;
+        index.add_path(std::path::Path::new("foo.rs"))?;
+        index.write()?;
+        let second_oid = repo.commit(
+            "second commit",
+            &sig,
+            &sig,
+            None,
+            crate::metadata::TestSource::None,
+            None,
+            vec![first_oid.to_string()],
+            vec![],
+        )?;
+
+        // The first commit's `causes` should now contain the second commit's OID
+        let first_record = repo.load_h5i_record(first_oid)?;
+        assert!(
+            first_record.causes.contains(&second_oid.to_string()),
+            "first commit's causes should contain second commit OID"
+        );
+
+        // The second commit's `caused_by` should contain the first commit's OID
+        let second_record = repo.load_h5i_record(second_oid)?;
+        assert!(
+            second_record.caused_by.contains(&first_oid.to_string()),
+            "second commit's caused_by should contain first commit OID"
+        );
+
+        Ok(())
+    }
+
+    // Testcase: edit_commit_message updates caused_by on dependent commits
+    #[test]
+    fn test_edit_commit_message_updates_causal_metadata() -> crate::error::Result<()> {
+        let dir = tempdir().unwrap();
+        let repo = setup_integration_context(dir.path());
+        let git_repo = repo.git();
+        let sig = Signature::now("h5i-test", "test@h5i.io")?;
+
+        // First commit
+        let file_path = dir.path().join("foo.rs");
+        fs::write(&file_path, "fn foo() {}")?;
+        let mut index = git_repo.index()?;
+        index.add_path(std::path::Path::new("foo.rs"))?;
+        index.write()?;
+        let first_oid = repo.commit(
+            "first commit",
+            &sig,
+            &sig,
+            None,
+            crate::metadata::TestSource::None,
+            None,
+            vec![],
+            vec![],
+        )?;
+
+        // Second commit caused by first
+        fs::write(&file_path, "fn foo() {} fn bar() {}")?;
+        let mut index = git_repo.index()?;
+        index.add_path(std::path::Path::new("foo.rs"))?;
+        index.write()?;
+        let second_oid = repo.commit(
+            "second commit",
+            &sig,
+            &sig,
+            None,
+            crate::metadata::TestSource::None,
+            None,
+            vec![first_oid.to_string()],
+            vec![],
+        )?;
+
+        // Rewrite first commit's message — its OID changes
+        let new_first_oid = repo.edit_commit_message(first_oid, "rewritten first commit")?;
+
+        // The second commit's caused_by should now reference the new OID
+        let second_record = repo.load_h5i_record(second_oid)?;
+        assert!(
+            second_record.caused_by.contains(&new_first_oid.to_string()),
+            "second commit's caused_by should be updated to new first OID"
+        );
+        assert!(
+            !second_record.caused_by.contains(&first_oid.to_string()),
+            "second commit's caused_by should not contain old first OID"
+        );
+
+        // The rewritten first commit's causes should still reference the second commit
+        let new_first_record = repo.load_h5i_record(new_first_oid)?;
+        assert!(
+            new_first_record.causes.contains(&second_oid.to_string()),
+            "rewritten first commit's causes should still reference second commit"
+        );
+
+        Ok(())
     }
 
 }


### PR DESCRIPTION
Currently, `h5i` does not provide functionality for editing the message of previously-made commits. As projects develop, and as different aspects of past commits grow more relevant to current development, this immutable property may be an inconvenience.

To address this issue, the `edit-message` function provides functionality for editing the message of a previously-made commit. The function may be called as follows:

    h5i edit-message <oid> --edit <new message>

The function returns the new OID of the commit whose message was edited.

Commits with or without dependencies may be edited. If the commit whose message was edited has dependencies, the parent OID of each dependency is updated accordingly.

Example usage:
```
$ h5i log
commit 8ae70031018fc596eacede251391cf69130feac4
Author:    Srivarun Kankanala <sk5767@columbia.edu>

    test commit 2, dependent on test commit 1

────────────────────────────────────────────────────────────
commit b945b7bc3f1c6c409b193f3122a437755dfe7d06
Author:    Srivarun Kankanala <sk5767@columbia.edu>

    test commit 1

────────────────────────────────────────────────────────────

$ h5i edit-message b945b7bc3f1c6c409b193f3122a437755dfe7d06 --edit "new message"
 Editing commit message for b945b7bc
 New commit OID: f2afb521550377ef1c8928e5338d46877866d25c

$ h5i log
commit 0c4f991ce3c7be437aabfdfc90ff1c343006cf04
Author:    Srivarun Kankanala <sk5767@columbia.edu>

    test commit 2, dependent on test commit 1

────────────────────────────────────────────────────────────
commit f2afb521550377ef1c8928e5338d46877866d25c
Author:    Srivarun Kankanala <sk5767@columbia.edu>

    new message

────────────────────────────────────────────────────────────

$ h5i edit-message 0c4f991ce3c7be437aabfdfc90ff1c343006cf04 --edit "test commit 2, dependent on new message commit"
 Editing commit message for 0c4f991c
 New commit OID: 209ab5640f7e7439ae6730eafedfa505b96da784

$ h5i log
commit 209ab5640f7e7439ae6730eafedfa505b96da784
Author:    Srivarun Kankanala <sk5767@columbia.edu>

    test commit 2, dependent on new message commit

────────────────────────────────────────────────────────────
commit f2afb521550377ef1c8928e5338d46877866d25c
Author:    Srivarun Kankanala <sk5767@columbia.edu>

    new message

────────────────────────────────────────────────────────────
```

Attached are screenshots of the `h5i` UI after each of the calls to `edit-message` in the example above. 

Intial:
<img width="953" height="482" alt="First Call" src="https://github.com/user-attachments/assets/e387ebd0-4230-4286-80d8-f1074e0a6f54" />

First Call:
<img width="953" height="482" alt="Second Call" src="https://github.com/user-attachments/assets/9db48f6f-66e7-4ea1-b44d-3653f37d30ea" />

Second Call:
<img width="955" height="481" alt="Third Call" src="https://github.com/user-attachments/assets/190d8982-71dd-4b67-af91-d6a25dd151e6" />

Comprehensive testcases are included in CI.