### PR TITLE
feat(capture): capture verbatim human prompt via UserPromptSubmit hoo…

### DIFF
--- a/.claude/h5i.md
+++ b/.claude/h5i.md
@@ -89,8 +89,14 @@ git add <file1> <file2> …   # never `git add .`
 
 Then commit via Bash:
 ```bash
-h5i capture commit -m "…" --model claude-sonnet-4-6 --agent claude-code --prompt "…"
+h5i capture commit -m "…" --model claude-sonnet-4-6 --agent claude-code
 ```
+
+**Do not pass `--intent` (or the old `--prompt`).** In Claude Code the verbatim
+human prompt is captured automatically by the `UserPromptSubmit` hook and wins
+over any agent-supplied intent — write a clear commit message and let the hook
+record what the human actually asked. `--intent` stays as a fallback only for
+Codex, CI, scripts, or manual commits where no prompt-capture hook runs.
 
 (Or the `h5i_commit` MCP tool if the MCP server is configured.)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,16 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "h5i hook prompt",
+            "type": "command"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
       {
         "hooks": [
           {
-            "command": "h5i hook run",
+            "command": "h5i claude sync",
             "type": "command"
           }
         ],
@@ -36,16 +36,6 @@
         ]
       }
     ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "command": "h5i hook prompt",
-            "type": "command"
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [
@@ -58,7 +48,17 @@
       {
         "hooks": [
           {
-            "command": "h5i hook stop",
+            "command": "h5i claude finish",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "h5i hook prompt",
             "type": "command"
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,7 +58,7 @@
       {
         "hooks": [
           {
-            "command": "h5i hook prompt",
+            "command": "h5i claude prompt",
             "type": "command"
           }
         ]

--- a/.claude/skills/h5i-workflow/SKILL.md
+++ b/.claude/skills/h5i-workflow/SKILL.md
@@ -126,8 +126,9 @@ Always use `h5i capture commit` instead of `git commit`, and record AI provenanc
 ```bash
 h5i capture commit -m "<message>" \
   --model claude-opus-4-8 \
-  --agent claude-code \
-  --prompt "<the user's original request>"
+  --agent claude-code
+# Do not pass --intent in Claude Code: the human prompt is auto-captured by the
+# UserPromptSubmit hook and takes precedence. --intent is a fallback for Codex/CI.
 ```
 
 Add `--tests` when tests were added or modified, `--ast` to snapshot structure,

--- a/.claude/skills/h5i-workflow/SKILL.md
+++ b/.claude/skills/h5i-workflow/SKILL.md
@@ -51,7 +51,7 @@ h5i recall context trace --kind ACT "<what you changed and where>"
 h5i recall context trace --kind NOTE "TODO: <what to revisit>"
 ```
 
-> If the **PostToolUse** hook (`h5i hook run`) is installed, ACT/OBSERVE traces
+> If the **PostToolUse** hook (`h5i claude sync`) is installed, ACT/OBSERVE traces
 > are emitted automatically on every Edit/Write/Read. You should still add
 > **THINK** and **NOTE** entries by hand — those capture intent the hook can't infer.
 > Use `--ephemeral` for scratch notes that should be cleared on the next commit.
@@ -128,7 +128,9 @@ h5i capture commit -m "<message>" \
   --model claude-opus-4-8 \
   --agent claude-code
 # Do not pass --intent in Claude Code: the human prompt is auto-captured by the
-# UserPromptSubmit hook and takes precedence. --intent is a fallback for Codex/CI.
+# UserPromptSubmit hook and takes precedence. In Codex, `h5i codex finish`
+# records the raw prompt from session JSONL when installed as the Stop hook.
+# --intent is a fallback for CI/scripts/manual commits.
 ```
 
 Add `--tests` when tests were added or modified, `--ast` to snapshot structure,

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -14,5 +14,5 @@ type = "command"
 [[hooks.Stop]]
 
 [[hooks.Stop.hooks]]
-command = "h5i codex finish"
+command = "h5i codex finish --quiet"
 type = "command"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,10 +1,3 @@
-[[hooks.PostToolUse]]
-matcher = "Edit|Write|Read"
-
-[[hooks.PostToolUse.hooks]]
-command = "h5i hook run"
-type = "command"
-
 [[hooks.PreToolUse]]
 matcher = "Bash"
 
@@ -21,5 +14,5 @@ type = "command"
 [[hooks.Stop]]
 
 [[hooks.Stop.hooks]]
-command = "h5i hook stop"
+command = "h5i codex finish"
 type = "command"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,10 @@ CI runs clippy (`-D warnings`), `cargo build --verbose` then `cargo test --verbo
 ```
 h5i init
 h5i session --file <path>
-h5i capture commit --message <msg> [--prompt <text>] [--model <name>] [--agent <id>] [--tests] [--ast] [--audit] [--force]
+h5i capture commit --message <msg> [--intent <text>] [--model <name>] [--agent <id>] [--tests] [--ast] [--audit] [--force]
+                                   # --intent is a fallback (Codex/CI/manual); in Claude Code the
+                                   # human prompt is auto-captured by the UserPromptSubmit hook.
+                                   # (--prompt is a back-compat alias for --intent.)
 h5i recall log [--limit N]
 h5i recall blame <file> [--mode line|ast]
 h5i resolve <ours> <theirs> <file>

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 
 use crate::ctx;
 use crate::error::H5iError;
+use crate::repository::H5iRepository;
 
 #[derive(Debug, Clone)]
 pub struct CodexSyncResult {
@@ -72,11 +73,15 @@ pub fn sync_context(workdir: &Path) -> Result<Option<CodexSyncResult>, H5iError>
 
     let mut observed = 0usize;
     let mut acted = 0usize;
+    let h5i_repo = H5iRepository::open(workdir)?;
 
     for line in raw.lines().skip(start_line) {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
             continue;
         };
+        if let Some(prompt) = extract_human_prompt(&value) {
+            h5i_repo.record_human_prompt(prompt, Some(&session_id))?;
+        }
         for event in extract_events(&value, workdir) {
             ctx::append_log(workdir, event.kind, &event.message, false)?;
             match event.kind {
@@ -155,6 +160,19 @@ fn session_cwd_matches(session_path: &Path, workdir: &Path) -> bool {
             None => false,
         }
     })
+}
+
+fn extract_human_prompt(value: &Value) -> Option<&str> {
+    if value.get("type").and_then(Value::as_str) != Some("event_msg") {
+        return None;
+    }
+    if value.pointer("/payload/type").and_then(Value::as_str) != Some("user_message") {
+        return None;
+    }
+    value
+        .pointer("/payload/message")
+        .and_then(Value::as_str)
+        .filter(|prompt| !prompt.trim().is_empty())
 }
 
 fn extract_events(value: &Value, workdir: &Path) -> Vec<TraceEvent> {
@@ -422,7 +440,10 @@ fn normalize_display_path(workdir: &Path, path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_events, extract_patch_events, extract_shell_cmd_events, TraceEvent};
+    use super::{
+        extract_events, extract_human_prompt, extract_patch_events, extract_shell_cmd_events,
+        TraceEvent,
+    };
     use serde_json::json;
     use tempfile::tempdir;
 
@@ -475,6 +496,36 @@ mod tests {
         assert_eq!(events[0].message, "read src/main.rs");
         assert_eq!(events[1].message, "searched . for \"Codex\"");
         assert_eq!(events[2].message, "listed files under .");
+    }
+
+    #[test]
+    fn extract_human_prompt_reads_codex_user_message() {
+        let event = json!({
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "Please fix the retry loop exactly as described."
+            }
+        });
+
+        assert_eq!(
+            extract_human_prompt(&event),
+            Some("Please fix the retry loop exactly as described.")
+        );
+    }
+
+    #[test]
+    fn extract_human_prompt_ignores_synthetic_context_messages() {
+        let event = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{ "type": "input_text", "text": "# AGENTS.md instructions" }]
+            }
+        });
+
+        assert_eq!(extract_human_prompt(&event), None);
     }
 
     // ── custom_tool_call / apply_patch (current Codex format) ────────────────

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -3721,8 +3721,10 @@ h5i context commit "Fixed token validation" \
 
 # ── Session end (mandatory) ─────────────────────────────────────────
 h5i commit -m "fix token validation regex" \
-  --model <model> --agent claude-code \
-  --prompt "<the user's original request>"    # records AI provenance in git
+  --model <model> --agent claude-code         # records AI provenance in git;
+                                              # the human prompt is auto-captured
+                                              # by the UserPromptSubmit hook, so no
+                                              # --intent is needed in Claude Code
 h5i notes analyze                             # links this session to HEAD commit
 ```
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -14,6 +14,9 @@ const CORE_HOOKS: &[(&str, Option<&str>, &str)] = &[
     ("SessionStart", None, "h5i hook session-start"),
     ("PostToolUse", Some("Edit|Write|Read"), "h5i hook run"),
     ("Stop", None, "h5i hook stop"),
+    // Capture the verbatim human prompt so `h5i capture commit` records what
+    // the human actually typed, not the agent's paraphrase.
+    ("UserPromptSubmit", None, "h5i hook prompt"),
 ];
 
 /// The opt-in Bash capture-wrap entry (PreToolUse: rewrites the command
@@ -117,6 +120,11 @@ pub fn merge_codex_config_toml(existing: &str, wrap_bash: bool) -> Result<String
         .ok_or_else(|| H5iError::Metadata("config 'hooks' is not a table".into()))?;
 
     for &(event, matcher, command) in CORE_HOOKS {
+        // UserPromptSubmit is a Claude-Code-only event; Codex has no equivalent,
+        // so skip it rather than write dead config into config.toml.
+        if event == "UserPromptSubmit" {
+            continue;
+        }
         ensure_toml_hook_entry(hooks_table, event, matcher, command)?;
     }
     if let Some(arr) = hooks_table
@@ -339,6 +347,10 @@ mod tests {
         );
         assert_eq!(commands_under(&v, "PostToolUse"), vec!["h5i hook run"]);
         assert_eq!(commands_under(&v, "Stop"), vec!["h5i hook stop"]);
+        assert_eq!(
+            commands_under(&v, "UserPromptSubmit"),
+            vec!["h5i hook prompt"]
+        );
         assert!(!out.contains("wrap-bash"));
         // The Edit|Write|Read matcher rides along with `h5i hook run`.
         assert_eq!(
@@ -375,7 +387,7 @@ mod tests {
         // (managed scope pins observation, it does not commandeer the agent's
         // own SessionStart/PostToolUse/Stop wiring).
         assert_eq!(commands_under(&v, "PreToolUse"), vec!["h5i hook wrap-bash"]);
-        for event in ["SessionStart", "PostToolUse", "Stop"] {
+        for event in ["SessionStart", "PostToolUse", "Stop", "UserPromptSubmit"] {
             assert!(
                 v.pointer(&format!("/hooks/{event}")).is_none(),
                 "managed settings must not carry the {event} core hook"
@@ -409,6 +421,9 @@ command = "h5i msg hook"
         assert!(out.contains("command = \"h5i hook stop\""));
         assert!(out.contains("command = \"h5i msg hook\""));
         assert!(!out.contains("wrap-bash"));
+        // UserPromptSubmit is Claude-only; Codex config must not carry it.
+        assert!(!out.contains("UserPromptSubmit"));
+        assert!(!out.contains("h5i hook prompt"));
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -12,8 +12,8 @@ use toml::value::Table;
 /// output).
 const CORE_HOOKS: &[(&str, Option<&str>, &str)] = &[
     ("SessionStart", None, "h5i hook session-start"),
-    ("PostToolUse", Some("Edit|Write|Read"), "h5i hook run"),
-    ("Stop", None, "h5i hook stop"),
+    ("PostToolUse", Some("Edit|Write|Read"), "h5i claude sync"),
+    ("Stop", None, "h5i claude finish"),
     // Capture the verbatim human prompt so `h5i capture commit` records what
     // the human actually typed, not the agent's paraphrase.
     ("UserPromptSubmit", None, "h5i hook prompt"),
@@ -23,6 +23,10 @@ const CORE_HOOKS: &[(&str, Option<&str>, &str)] = &[
 /// into `h5i capture run` via updatedInput).
 const WRAP_BASH_HOOK: (&str, Option<&str>, &str) =
     ("PreToolUse", Some("Bash"), "h5i hook wrap-bash");
+
+const CODEX_STOP_HOOK: &str = "h5i codex finish";
+const LEGACY_CLAUDE_RUN_HOOK: &str = "h5i hook run";
+const LEGACY_CLAUDE_STOP_HOOK: &str = "h5i hook stop";
 
 /// The retired PostToolUse Bash observation hook: superseded by wrap-bash
 /// (which captures AND token-reduces). The subcommand no longer exists, so
@@ -59,6 +63,15 @@ pub fn merge_hook_settings_json(existing: &str, wrap_bash: bool) -> Result<Strin
 
     for &(event, matcher, command) in CORE_HOOKS {
         ensure_hook_entry(hooks_obj, event, matcher, command)?;
+    }
+    if let Some(arr) = hooks_obj
+        .get_mut("PostToolUse")
+        .and_then(|v| v.as_array_mut())
+    {
+        arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_RUN_HOOK));
+    }
+    if let Some(arr) = hooks_obj.get_mut("Stop").and_then(|v| v.as_array_mut()) {
+        arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_STOP_HOOK));
     }
     if let Some(arr) = hooks_obj
         .get_mut("PostToolUse")
@@ -119,12 +132,27 @@ pub fn merge_codex_config_toml(existing: &str, wrap_bash: bool) -> Result<String
         .as_table_mut()
         .ok_or_else(|| H5iError::Metadata("config 'hooks' is not a table".into()))?;
 
+    if let Some(arr) = hooks_table.get_mut("Stop").and_then(|v| v.as_array_mut()) {
+        arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CLAUDE_STOP_HOOK));
+    }
+    if let Some(arr) = hooks_table
+        .get_mut("PostToolUse")
+        .and_then(|v| v.as_array_mut())
+    {
+        arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CLAUDE_RUN_HOOK));
+    }
+
     for &(event, matcher, command) in CORE_HOOKS {
-        // UserPromptSubmit is a Claude-Code-only event; Codex has no equivalent,
-        // so skip it rather than write dead config into config.toml.
-        if event == "UserPromptSubmit" {
+        // UserPromptSubmit and PostToolUse are Claude-Code-specific here:
+        // Codex prompt/tool provenance is mined from session JSONL by
+        // `h5i codex finish`, installed below as the Stop hook.
+        if matches!(event, "UserPromptSubmit" | "PostToolUse") {
             continue;
         }
+        let command = match event {
+            "Stop" => CODEX_STOP_HOOK,
+            _ => command,
+        };
         ensure_toml_hook_entry(hooks_table, event, matcher, command)?;
     }
     if let Some(arr) = hooks_table
@@ -345,14 +373,14 @@ mod tests {
             commands_under(&v, "SessionStart"),
             vec!["h5i hook session-start"]
         );
-        assert_eq!(commands_under(&v, "PostToolUse"), vec!["h5i hook run"]);
-        assert_eq!(commands_under(&v, "Stop"), vec!["h5i hook stop"]);
+        assert_eq!(commands_under(&v, "PostToolUse"), vec!["h5i claude sync"]);
+        assert_eq!(commands_under(&v, "Stop"), vec!["h5i claude finish"]);
         assert_eq!(
             commands_under(&v, "UserPromptSubmit"),
             vec!["h5i hook prompt"]
         );
         assert!(!out.contains("wrap-bash"));
-        // The Edit|Write|Read matcher rides along with `h5i hook run`.
+        // The Edit|Write|Read matcher rides along with `h5i claude sync`.
         assert_eq!(
             v.pointer("/hooks/PostToolUse/0/matcher")
                 .and_then(|m| m.as_str()),
@@ -417,8 +445,9 @@ command = "h5i msg hook"
         let v: toml::Value = toml::from_str(&out).unwrap();
         assert_eq!(v["model"].as_str(), Some("gpt-5.4"));
         assert!(out.contains("command = \"h5i hook session-start\""));
-        assert!(out.contains("command = \"h5i hook run\""));
-        assert!(out.contains("command = \"h5i hook stop\""));
+        assert!(!out.contains("command = \"h5i hook run\""));
+        assert!(out.contains("command = \"h5i codex finish\""));
+        assert!(!out.contains("command = \"h5i hook stop\""));
         assert!(out.contains("command = \"h5i msg hook\""));
         assert!(!out.contains("wrap-bash"));
         // UserPromptSubmit is Claude-only; Codex config must not carry it.
@@ -471,7 +500,7 @@ command = "h5i msg hook"
         );
         let stop = commands_under(&v, "Stop");
         assert!(stop.contains(&"h5i msg hook --block".to_string()));
-        assert!(stop.contains(&"h5i hook stop".to_string()));
+        assert!(stop.contains(&"h5i claude finish".to_string()));
     }
 
     #[test]
@@ -497,9 +526,9 @@ command = "h5i msg hook"
         let out = merge_hook_settings_json(existing, false).unwrap();
         let v: Value = serde_json::from_str(&out).unwrap();
         let cmds = commands_under(&v, "PostToolUse");
-        // The unrelated `run-custom` survives next to the managed `h5i hook run`.
+        // The unrelated `run-custom` survives next to the managed `h5i claude sync`.
         assert!(cmds.contains(&"h5i hook run-custom".to_string()));
-        assert!(cmds.contains(&"h5i hook run".to_string()));
+        assert!(cmds.contains(&"h5i claude sync".to_string()));
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -25,13 +25,6 @@ const WRAP_BASH_HOOK: (&str, Option<&str>, &str) =
     ("PreToolUse", Some("Bash"), "h5i hook wrap-bash");
 
 const CODEX_STOP_HOOK: &str = "h5i codex finish --quiet";
-const LEGACY_CODEX_STOP_HOOK: &str = "h5i codex finish";
-const LEGACY_CLAUDE_RUN_HOOK: &str = "h5i hook run";
-const LEGACY_CLAUDE_STOP_HOOK: &str = "h5i hook stop";
-/// The UserPromptSubmit handler moved from the shared `hook` group to the
-/// Claude-specific `claude` group (`h5i claude prompt`) — it is Claude-only
-/// logic. The merge strips the old command so re-running setup migrates it.
-const LEGACY_CLAUDE_PROMPT_HOOK: &str = "h5i hook prompt";
 
 /// The retired PostToolUse Bash observation hook: superseded by wrap-bash
 /// (which captures AND token-reduces). The subcommand no longer exists, so
@@ -68,21 +61,6 @@ pub fn merge_hook_settings_json(existing: &str, wrap_bash: bool) -> Result<Strin
 
     for &(event, matcher, command) in CORE_HOOKS {
         ensure_hook_entry(hooks_obj, event, matcher, command)?;
-    }
-    if let Some(arr) = hooks_obj
-        .get_mut("PostToolUse")
-        .and_then(|v| v.as_array_mut())
-    {
-        arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_RUN_HOOK));
-    }
-    if let Some(arr) = hooks_obj.get_mut("Stop").and_then(|v| v.as_array_mut()) {
-        arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_STOP_HOOK));
-    }
-    if let Some(arr) = hooks_obj
-        .get_mut("UserPromptSubmit")
-        .and_then(|v| v.as_array_mut())
-    {
-        arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_PROMPT_HOOK));
     }
     if let Some(arr) = hooks_obj
         .get_mut("PostToolUse")
@@ -142,17 +120,6 @@ pub fn merge_codex_config_toml(existing: &str, wrap_bash: bool) -> Result<String
     let hooks_table = hooks
         .as_table_mut()
         .ok_or_else(|| H5iError::Metadata("config 'hooks' is not a table".into()))?;
-
-    if let Some(arr) = hooks_table.get_mut("Stop").and_then(|v| v.as_array_mut()) {
-        arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CLAUDE_STOP_HOOK));
-        arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CODEX_STOP_HOOK));
-    }
-    if let Some(arr) = hooks_table
-        .get_mut("PostToolUse")
-        .and_then(|v| v.as_array_mut())
-    {
-        arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CLAUDE_RUN_HOOK));
-    }
 
     for &(event, matcher, command) in CORE_HOOKS {
         // UserPromptSubmit and PostToolUse are Claude-Code-specific here:
@@ -541,107 +508,6 @@ command = "h5i msg hook"
         // The unrelated `run-custom` survives next to the managed `h5i claude sync`.
         assert!(cmds.contains(&"h5i hook run-custom".to_string()));
         assert!(cmds.contains(&"h5i claude sync".to_string()));
-    }
-
-    #[test]
-    fn legacy_claude_hooks_migrated_to_new_commands() {
-        // A settings.json wired by an older h5i (the `h5i hook run` /
-        // `h5i hook stop` era) must be migrated in place: the legacy commands
-        // are stripped and the renamed `h5i claude sync` / `h5i claude finish`
-        // installed — with no duplicates left behind.
-        let existing = r#"{
-            "hooks": {
-                "PostToolUse": [ { "matcher": "Edit|Write|Read", "hooks": [ { "type": "command", "command": "h5i hook run" } ] } ],
-                "Stop": [ { "hooks": [ { "type": "command", "command": "h5i hook stop" } ] } ],
-                "UserPromptSubmit": [ { "hooks": [ { "type": "command", "command": "h5i hook prompt" } ] } ]
-            }
-        }"#;
-        let out = merge_hook_settings_json(existing, false).unwrap();
-        let v: Value = serde_json::from_str(&out).unwrap();
-
-        let prompt = commands_under(&v, "UserPromptSubmit");
-        assert!(
-            !prompt.contains(&"h5i hook prompt".to_string()),
-            "legacy UserPromptSubmit command should be removed: {prompt:?}"
-        );
-        assert_eq!(
-            prompt.iter().filter(|c| *c == "h5i claude prompt").count(),
-            1,
-            "exactly one migrated prompt hook expected: {prompt:?}"
-        );
-
-        let post = commands_under(&v, "PostToolUse");
-        assert!(
-            !post.contains(&"h5i hook run".to_string()),
-            "legacy PostToolUse command should be removed: {post:?}"
-        );
-        assert_eq!(
-            post.iter().filter(|c| *c == "h5i claude sync").count(),
-            1,
-            "exactly one migrated sync hook expected: {post:?}"
-        );
-
-        let stop = commands_under(&v, "Stop");
-        assert!(
-            !stop.contains(&"h5i hook stop".to_string()),
-            "legacy Stop command should be removed: {stop:?}"
-        );
-        assert_eq!(
-            stop.iter().filter(|c| *c == "h5i claude finish").count(),
-            1,
-            "exactly one migrated finish hook expected: {stop:?}"
-        );
-    }
-
-    #[test]
-    fn legacy_codex_stop_hook_migrated_to_quiet_codex_finish() {
-        // Codex's Stop hook was also `h5i hook stop`; migration must replace it
-        // with the Codex-specific quiet finish and not leave the legacy command
-        // behind (and never introduce a Claude-only UserPromptSubmit).
-        let existing = r#"
-[hooks]
-Stop = [ { hooks = [ { type = "command", command = "h5i hook stop" } ] } ]
-"#;
-        let out = merge_codex_config_toml(existing, false).unwrap();
-        assert!(
-            !out.contains("h5i hook stop"),
-            "legacy codex Stop command should be removed: {out}"
-        );
-        assert!(
-            out.contains("h5i codex finish --quiet"),
-            "codex Stop should migrate to `h5i codex finish --quiet`: {out}"
-        );
-        assert_eq!(
-            out.matches("h5i codex finish --quiet").count(),
-            1,
-            "exactly one migrated codex finish hook expected: {out}"
-        );
-        assert!(
-            !out.contains("UserPromptSubmit"),
-            "UserPromptSubmit is Claude-only and must not appear in codex config: {out}"
-        );
-    }
-
-    #[test]
-    fn unquiet_codex_stop_hook_migrated_to_quiet_finish() {
-        let existing = r#"
-[hooks]
-Stop = [ { hooks = [ { type = "command", command = "h5i codex finish" } ] } ]
-"#;
-        let out = merge_codex_config_toml(existing, false).unwrap();
-        assert!(
-            !out.contains("command = \"h5i codex finish\""),
-            "unquiet codex Stop command should be removed: {out}"
-        );
-        assert!(
-            out.contains("h5i codex finish --quiet"),
-            "quiet codex Stop command should be installed: {out}"
-        );
-        assert_eq!(
-            out.matches("h5i codex finish --quiet").count(),
-            1,
-            "exactly one quiet codex finish hook expected: {out}"
-        );
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -24,7 +24,8 @@ const CORE_HOOKS: &[(&str, Option<&str>, &str)] = &[
 const WRAP_BASH_HOOK: (&str, Option<&str>, &str) =
     ("PreToolUse", Some("Bash"), "h5i hook wrap-bash");
 
-const CODEX_STOP_HOOK: &str = "h5i codex finish";
+const CODEX_STOP_HOOK: &str = "h5i codex finish --quiet";
+const LEGACY_CODEX_STOP_HOOK: &str = "h5i codex finish";
 const LEGACY_CLAUDE_RUN_HOOK: &str = "h5i hook run";
 const LEGACY_CLAUDE_STOP_HOOK: &str = "h5i hook stop";
 /// The UserPromptSubmit handler moved from the shared `hook` group to the
@@ -144,6 +145,7 @@ pub fn merge_codex_config_toml(existing: &str, wrap_bash: bool) -> Result<String
 
     if let Some(arr) = hooks_table.get_mut("Stop").and_then(|v| v.as_array_mut()) {
         arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CLAUDE_STOP_HOOK));
+        arr.retain(|entry| !toml_entry_has_command(entry, LEGACY_CODEX_STOP_HOOK));
     }
     if let Some(arr) = hooks_table
         .get_mut("PostToolUse")
@@ -456,7 +458,7 @@ command = "h5i msg hook"
         assert_eq!(v["model"].as_str(), Some("gpt-5.4"));
         assert!(out.contains("command = \"h5i hook session-start\""));
         assert!(!out.contains("command = \"h5i hook run\""));
-        assert!(out.contains("command = \"h5i codex finish\""));
+        assert!(out.contains("command = \"h5i codex finish --quiet\""));
         assert!(!out.contains("command = \"h5i hook stop\""));
         assert!(out.contains("command = \"h5i msg hook\""));
         assert!(!out.contains("wrap-bash"));
@@ -592,10 +594,10 @@ command = "h5i msg hook"
     }
 
     #[test]
-    fn legacy_codex_stop_hook_migrated_to_codex_finish() {
+    fn legacy_codex_stop_hook_migrated_to_quiet_codex_finish() {
         // Codex's Stop hook was also `h5i hook stop`; migration must replace it
-        // with the Codex-specific `h5i codex finish` and not leave the legacy
-        // command behind (and never introduce a Claude-only UserPromptSubmit).
+        // with the Codex-specific quiet finish and not leave the legacy command
+        // behind (and never introduce a Claude-only UserPromptSubmit).
         let existing = r#"
 [hooks]
 Stop = [ { hooks = [ { type = "command", command = "h5i hook stop" } ] } ]
@@ -606,17 +608,39 @@ Stop = [ { hooks = [ { type = "command", command = "h5i hook stop" } ] } ]
             "legacy codex Stop command should be removed: {out}"
         );
         assert!(
-            out.contains("h5i codex finish"),
-            "codex Stop should migrate to `h5i codex finish`: {out}"
+            out.contains("h5i codex finish --quiet"),
+            "codex Stop should migrate to `h5i codex finish --quiet`: {out}"
         );
         assert_eq!(
-            out.matches("h5i codex finish").count(),
+            out.matches("h5i codex finish --quiet").count(),
             1,
             "exactly one migrated codex finish hook expected: {out}"
         );
         assert!(
             !out.contains("UserPromptSubmit"),
             "UserPromptSubmit is Claude-only and must not appear in codex config: {out}"
+        );
+    }
+
+    #[test]
+    fn unquiet_codex_stop_hook_migrated_to_quiet_finish() {
+        let existing = r#"
+[hooks]
+Stop = [ { hooks = [ { type = "command", command = "h5i codex finish" } ] } ]
+"#;
+        let out = merge_codex_config_toml(existing, false).unwrap();
+        assert!(
+            !out.contains("command = \"h5i codex finish\""),
+            "unquiet codex Stop command should be removed: {out}"
+        );
+        assert!(
+            out.contains("h5i codex finish --quiet"),
+            "quiet codex Stop command should be installed: {out}"
+        );
+        assert_eq!(
+            out.matches("h5i codex finish --quiet").count(),
+            1,
+            "exactly one quiet codex finish hook expected: {out}"
         );
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -16,7 +16,7 @@ const CORE_HOOKS: &[(&str, Option<&str>, &str)] = &[
     ("Stop", None, "h5i claude finish"),
     // Capture the verbatim human prompt so `h5i capture commit` records what
     // the human actually typed, not the agent's paraphrase.
-    ("UserPromptSubmit", None, "h5i hook prompt"),
+    ("UserPromptSubmit", None, "h5i claude prompt"),
 ];
 
 /// The opt-in Bash capture-wrap entry (PreToolUse: rewrites the command
@@ -27,6 +27,10 @@ const WRAP_BASH_HOOK: (&str, Option<&str>, &str) =
 const CODEX_STOP_HOOK: &str = "h5i codex finish";
 const LEGACY_CLAUDE_RUN_HOOK: &str = "h5i hook run";
 const LEGACY_CLAUDE_STOP_HOOK: &str = "h5i hook stop";
+/// The UserPromptSubmit handler moved from the shared `hook` group to the
+/// Claude-specific `claude` group (`h5i claude prompt`) — it is Claude-only
+/// logic. The merge strips the old command so re-running setup migrates it.
+const LEGACY_CLAUDE_PROMPT_HOOK: &str = "h5i hook prompt";
 
 /// The retired PostToolUse Bash observation hook: superseded by wrap-bash
 /// (which captures AND token-reduces). The subcommand no longer exists, so
@@ -72,6 +76,12 @@ pub fn merge_hook_settings_json(existing: &str, wrap_bash: bool) -> Result<Strin
     }
     if let Some(arr) = hooks_obj.get_mut("Stop").and_then(|v| v.as_array_mut()) {
         arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_STOP_HOOK));
+    }
+    if let Some(arr) = hooks_obj
+        .get_mut("UserPromptSubmit")
+        .and_then(|v| v.as_array_mut())
+    {
+        arr.retain(|entry| !entry_has_command(entry, LEGACY_CLAUDE_PROMPT_HOOK));
     }
     if let Some(arr) = hooks_obj
         .get_mut("PostToolUse")
@@ -377,7 +387,7 @@ mod tests {
         assert_eq!(commands_under(&v, "Stop"), vec!["h5i claude finish"]);
         assert_eq!(
             commands_under(&v, "UserPromptSubmit"),
-            vec!["h5i hook prompt"]
+            vec!["h5i claude prompt"]
         );
         assert!(!out.contains("wrap-bash"));
         // The Edit|Write|Read matcher rides along with `h5i claude sync`.
@@ -452,7 +462,7 @@ command = "h5i msg hook"
         assert!(!out.contains("wrap-bash"));
         // UserPromptSubmit is Claude-only; Codex config must not carry it.
         assert!(!out.contains("UserPromptSubmit"));
-        assert!(!out.contains("h5i hook prompt"));
+        assert!(!out.contains("h5i claude prompt"));
     }
 
     #[test]
@@ -529,6 +539,85 @@ command = "h5i msg hook"
         // The unrelated `run-custom` survives next to the managed `h5i claude sync`.
         assert!(cmds.contains(&"h5i hook run-custom".to_string()));
         assert!(cmds.contains(&"h5i claude sync".to_string()));
+    }
+
+    #[test]
+    fn legacy_claude_hooks_migrated_to_new_commands() {
+        // A settings.json wired by an older h5i (the `h5i hook run` /
+        // `h5i hook stop` era) must be migrated in place: the legacy commands
+        // are stripped and the renamed `h5i claude sync` / `h5i claude finish`
+        // installed — with no duplicates left behind.
+        let existing = r#"{
+            "hooks": {
+                "PostToolUse": [ { "matcher": "Edit|Write|Read", "hooks": [ { "type": "command", "command": "h5i hook run" } ] } ],
+                "Stop": [ { "hooks": [ { "type": "command", "command": "h5i hook stop" } ] } ],
+                "UserPromptSubmit": [ { "hooks": [ { "type": "command", "command": "h5i hook prompt" } ] } ]
+            }
+        }"#;
+        let out = merge_hook_settings_json(existing, false).unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+
+        let prompt = commands_under(&v, "UserPromptSubmit");
+        assert!(
+            !prompt.contains(&"h5i hook prompt".to_string()),
+            "legacy UserPromptSubmit command should be removed: {prompt:?}"
+        );
+        assert_eq!(
+            prompt.iter().filter(|c| *c == "h5i claude prompt").count(),
+            1,
+            "exactly one migrated prompt hook expected: {prompt:?}"
+        );
+
+        let post = commands_under(&v, "PostToolUse");
+        assert!(
+            !post.contains(&"h5i hook run".to_string()),
+            "legacy PostToolUse command should be removed: {post:?}"
+        );
+        assert_eq!(
+            post.iter().filter(|c| *c == "h5i claude sync").count(),
+            1,
+            "exactly one migrated sync hook expected: {post:?}"
+        );
+
+        let stop = commands_under(&v, "Stop");
+        assert!(
+            !stop.contains(&"h5i hook stop".to_string()),
+            "legacy Stop command should be removed: {stop:?}"
+        );
+        assert_eq!(
+            stop.iter().filter(|c| *c == "h5i claude finish").count(),
+            1,
+            "exactly one migrated finish hook expected: {stop:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_codex_stop_hook_migrated_to_codex_finish() {
+        // Codex's Stop hook was also `h5i hook stop`; migration must replace it
+        // with the Codex-specific `h5i codex finish` and not leave the legacy
+        // command behind (and never introduce a Claude-only UserPromptSubmit).
+        let existing = r#"
+[hooks]
+Stop = [ { hooks = [ { type = "command", command = "h5i hook stop" } ] } ]
+"#;
+        let out = merge_codex_config_toml(existing, false).unwrap();
+        assert!(
+            !out.contains("h5i hook stop"),
+            "legacy codex Stop command should be removed: {out}"
+        );
+        assert!(
+            out.contains("h5i codex finish"),
+            "codex Stop should migrate to `h5i codex finish`: {out}"
+        );
+        assert_eq!(
+            out.matches("h5i codex finish").count(),
+            1,
+            "exactly one migrated codex finish hook expected: {out}"
+        );
+        assert!(
+            !out.contains("UserPromptSubmit"),
+            "UserPromptSubmit is Claude-only and must not appear in codex config: {out}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,7 +273,8 @@ fn msg_session_note(workdir: &Path) -> Option<String> {
 
 /// Codex turn-delivery: surface unread messages for the Codex identity and
 /// mark them read. Best-effort — never fails the host command. Folded into
-/// `h5i codex prelude` / `sync` / `finish` since Codex has no Stop hook.
+/// `h5i codex prelude` / `sync` / `finish`; `h5i hook setup --target codex`
+/// installs `h5i codex finish` as the Stop hook.
 fn deliver_codex_inbox(workdir: &Path) {
     let Ok(repo) = H5iRepository::open(workdir) else {
         return;
@@ -889,11 +890,16 @@ enum Commands {
         dry_run: bool,
     },
 
-    /// Manage Claude Code hooks for automatic prompt capture and context tracing.
+    /// Manage agent hook setup for automatic prompt capture and context tracing.
     /// Run `h5i hook setup` to print install instructions.
-    /// Run `h5i hook run` (or just `h5i hook`) as the PostToolUse handler in .claude/settings.json.
     #[command(subcommand)]
     Hook(HookCommands),
+
+    /// Claude Code integration hook handlers
+    Claude {
+        #[command(subcommand)]
+        action: ClaudeCommands,
+    },
 
     /// Codex integration helpers for context restore, trace sync, and closeout
     Codex {
@@ -2203,20 +2209,9 @@ enum HookCommands {
         wrap_bash: bool,
     },
 
-    /// Run as the PostToolUse handler: reads JSON from stdin, emits h5i context traces.
-    /// Register in .claude/settings.json as: { "command": "h5i hook run" }
-    Run,
-
-    /// Run as the SessionStart handler: injects prior context into Claude's context window.
-    /// Prints the current context summary + relevant prior reasoning to stdout,
-    /// which Claude Code surfaces to the model at the start of each session.
-    /// Register in .claude/settings.json under "SessionStart" hooks.
+    /// Run as the shared SessionStart handler: injects prior context into the agent context window.
+    /// Register under "SessionStart" hooks as `h5i hook session-start`.
     SessionStart,
-
-    /// Run as the Stop handler: auto-checkpoints the context workspace before the session ends.
-    /// Summarises recent OBSERVE/THINK/ACT entries and calls `h5i context commit`.
-    /// Register in .claude/settings.json under "Stop" hooks.
-    Stop,
 
     /// OPTIONAL PreToolUse handler for the Bash tool: rewrites the command into
     /// a `h5i capture run` wrapper (via updatedInput, Claude Code ≥ 2.0.10), so
@@ -2236,6 +2231,15 @@ enum HookCommands {
     /// on any error, so it never blocks the turn.
     /// Register in .claude/settings.json under "UserPromptSubmit" hooks.
     Prompt,
+}
+
+#[derive(Subcommand)]
+enum ClaudeCommands {
+    /// Run as Claude Code's PostToolUse handler: reads JSON from stdin and emits traces.
+    Sync,
+
+    /// Run as Claude Code's Stop handler: mines reasoning and checkpoints context.
+    Finish,
 }
 
 #[derive(Subcommand)]
@@ -2573,11 +2577,13 @@ h5i claims prune                   # drop stale claims
 
 ```bash
 git add <exact paths>
-h5i capture commit -m "…" --agent codex --intent "<the human's ask>"
+h5i capture commit -m "…" --agent codex
 ```
 
-Codex has no `UserPromptSubmit` hook, so pass `--intent` with the human's
-request — it is the fallback that fills the provenance prompt field.
+When `h5i hook setup --write --target codex` has installed the Stop hook,
+`h5i codex finish` records the raw human prompt from the Codex session JSONL.
+`--intent` remains a fallback for CI/scripts/manual commits where no Codex
+session sync runs.
 
 Add flags when relevant:
 - `--tests`  — tests were added or modified
@@ -5305,7 +5311,7 @@ fn main() -> anyhow::Result<()> {
             println!("  {}", style("Quick-start:").bold());
             println!(
                 "    {}  capture AI provenance on every commit",
-                style("h5i commit -m \"…\" --agent <claude-code|codex>  (--intent for Codex/CI)").cyan()
+                style("h5i commit -m \"…\" --agent <claude-code|codex>  (--intent fallback for CI/scripts)").cyan()
             );
             println!(
                 "    {}  snapshot agent memory after a session",
@@ -6518,14 +6524,19 @@ fn main() -> anyhow::Result<()> {
                     );
                 }
                 println!(
-                    "   {} {}   ·   {} {} ({})   ·   {} {}",
+                    "   {} {}   ·   {} {} ({})",
                     style("SessionStart:").dim(),
                     style("h5i hook session-start").bold(),
-                    style("PostToolUse:").dim(),
-                    style("h5i hook run").bold(),
+                    style("Claude PostToolUse:").dim(),
+                    style("h5i claude sync").bold(),
                     style("Edit|Write|Read").dim(),
-                    style("Stop:").dim(),
-                    style("h5i hook stop").bold(),
+                );
+                println!(
+                    "   {} {}   ·   {} {}",
+                    style("Claude Stop:").dim(),
+                    style("h5i claude finish").bold(),
+                    style("Codex Stop:").dim(),
+                    style("h5i codex finish").bold(),
                 );
                 if wrap_bash {
                     println!(
@@ -6638,7 +6649,7 @@ fn main() -> anyhow::Result<()> {
         "hooks": [
           {
             "type": "command",
-            "command": "h5i hook run"
+            "command": "h5i claude sync"
           }
         ]
       }
@@ -6648,7 +6659,7 @@ fn main() -> anyhow::Result<()> {
         "hooks": [
           {
             "type": "command",
-            "command": "h5i hook stop"
+            "command": "h5i claude finish"
           }
         ]
       }
@@ -6789,7 +6800,9 @@ fn main() -> anyhow::Result<()> {
             );
         }
 
-        Commands::Hook(HookCommands::Run) => {
+        Commands::Claude {
+            action: ClaudeCommands::Sync,
+        } => {
             use std::io::Read as _;
             // Read JSON from stdin (Claude Code sends PostToolUse payload here).
             let mut raw = String::new();
@@ -6990,7 +7003,9 @@ fn main() -> anyhow::Result<()> {
             }
         }
 
-        Commands::Hook(HookCommands::Stop) => {
+        Commands::Claude {
+            action: ClaudeCommands::Finish,
+        } => {
             let workdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
             // 1. Mine the Claude session JSONL for key decisions + omissions and
             //    emit them as THINK/NOTE trace entries. The agent never has to

--- a/src/main.rs
+++ b/src/main.rs
@@ -663,7 +663,7 @@ enum Commands {
 
         /// The agent's stated intent for this change (the ask being fulfilled).
         /// Optional fallback: in Claude Code the verbatim human prompt is
-        /// captured automatically by the `h5i hook prompt` (UserPromptSubmit)
+        /// captured automatically by the `h5i claude prompt` (UserPromptSubmit)
         /// hook and takes precedence, so you normally don't pass this. Provide it
         /// for Codex, CI, scripts, or manual commits where no prompt-capture hook
         /// runs. `--prompt` is kept as a backward-compatible alias.
@@ -2222,15 +2222,6 @@ enum HookCommands {
     /// Register in .claude/settings.json under "PreToolUse" with matcher "Bash".
     WrapBash,
 
-    /// Run as the UserPromptSubmit handler: reads the hook JSON from stdin and
-    /// records the *verbatim* human prompt into `.git/.h5i/pending_context.json`,
-    /// accumulating across turns. `h5i capture commit` then uses this raw human
-    /// prompt as the recorded prompt — it wins over an agent-authored `--intent`
-    /// — so AI provenance reflects what the human actually asked rather than the
-    /// agent's paraphrase. No-ops outside an h5i-initialized repo and fails open
-    /// on any error, so it never blocks the turn.
-    /// Register in .claude/settings.json under "UserPromptSubmit" hooks.
-    Prompt,
 }
 
 #[derive(Subcommand)]
@@ -2240,6 +2231,16 @@ enum ClaudeCommands {
 
     /// Run as Claude Code's Stop handler: mines reasoning and checkpoints context.
     Finish,
+
+    /// Run as the UserPromptSubmit handler: reads the hook JSON from stdin and
+    /// records the *verbatim* human prompt into `.git/.h5i/pending_context.json`,
+    /// accumulating across turns. `h5i capture commit` then uses this raw human
+    /// prompt as the recorded prompt — it wins over an agent-authored `--intent`
+    /// — so AI provenance reflects what the human actually asked rather than the
+    /// agent's paraphrase. No-ops outside an h5i-initialized repo and fails open
+    /// on any error, so it never blocks the turn.
+    /// Register in .claude/settings.json under "UserPromptSubmit" hooks.
+    Prompt,
 }
 
 #[derive(Subcommand)]
@@ -6577,7 +6578,7 @@ fn main() -> anyhow::Result<()> {
                         "   {} prompt capture (UserPromptSubmit → {}) is now wired; the MCP\n\
                          \x20    server stays manual — run {} for those instructions.",
                         style("→").dim(),
-                        style("h5i hook prompt").bold(),
+                        style("h5i claude prompt").bold(),
                         style("h5i hook setup").bold(),
                     );
                 }
@@ -6629,7 +6630,7 @@ fn main() -> anyhow::Result<()> {
         "hooks": [
           {
             "type": "command",
-            "command": "h5i hook prompt"
+            "command": "h5i claude prompt"
           }
         ]
       }
@@ -6951,7 +6952,9 @@ fn main() -> anyhow::Result<()> {
             );
         }
 
-        Commands::Hook(HookCommands::Prompt) => {
+        Commands::Claude {
+            action: ClaudeCommands::Prompt,
+        } => {
             use std::io::Read as _;
             // Read the UserPromptSubmit payload from stdin. Fail open on any
             // problem so we never block the human's turn (and emit no stdout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2256,6 +2256,10 @@ enum CodexCommands {
         /// Optional summary for the context checkpoint
         #[arg(long)]
         summary: Option<String>,
+
+        /// Suppress stdout for hook use
+        #[arg(long)]
+        quiet: bool,
     },
 }
 
@@ -7055,22 +7059,29 @@ fn main() -> anyhow::Result<()> {
                     // Turn-delivery analog: check the inbox after a work burst.
                     deliver_codex_inbox(&workdir);
                 }
-                CodexCommands::Finish { summary } => {
+                CodexCommands::Finish { summary, quiet } => {
                     match codex::sync_context(&workdir)? {
-                        Some(result) => println!(
-                            "{} Synced Codex session {} ({} OBSERVE, {} ACT)",
-                            SUCCESS,
-                            style(&result.session_id).magenta(),
-                            result.observed,
-                            result.acted,
-                        ),
-                        None => println!(
-                            "{} No Codex session found in ~/.codex/sessions for this repo.",
-                            WARN
-                        ),
+                        Some(result) if !quiet => {
+                            println!(
+                                "{} Synced Codex session {} ({} OBSERVE, {} ACT)",
+                                SUCCESS,
+                                style(&result.session_id).magenta(),
+                                result.observed,
+                                result.acted,
+                            );
+                        }
+                        None if !quiet => {
+                            println!(
+                                "{} No Codex session found in ~/.codex/sessions for this repo.",
+                                WARN
+                            );
+                        }
+                        _ => {}
                     }
-                    auto_checkpoint_context(&workdir, summary.as_deref(), false)?;
-                    deliver_codex_inbox(&workdir);
+                    auto_checkpoint_context(&workdir, summary.as_deref(), quiet)?;
+                    if !quiet {
+                        deliver_codex_inbox(&workdir);
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,9 +660,14 @@ enum Commands {
         #[arg(short, long)]
         message: String,
 
-        // Prompt
-        #[arg(long)]
-        prompt: Option<String>,
+        /// The agent's stated intent for this change (the ask being fulfilled).
+        /// Optional fallback: in Claude Code the verbatim human prompt is
+        /// captured automatically by the `h5i hook prompt` (UserPromptSubmit)
+        /// hook and takes precedence, so you normally don't pass this. Provide it
+        /// for Codex, CI, scripts, or manual commits where no prompt-capture hook
+        /// runs. `--prompt` is kept as a backward-compatible alias.
+        #[arg(long, alias = "prompt")]
+        intent: Option<String>,
 
         /// The name of the AI model that assisted in these changes
         #[arg(long)]
@@ -2221,6 +2226,16 @@ enum HookCommands {
     /// every failure path emits nothing, so the original command runs untouched.
     /// Register in .claude/settings.json under "PreToolUse" with matcher "Bash".
     WrapBash,
+
+    /// Run as the UserPromptSubmit handler: reads the hook JSON from stdin and
+    /// records the *verbatim* human prompt into `.git/.h5i/pending_context.json`,
+    /// accumulating across turns. `h5i capture commit` then uses this raw human
+    /// prompt as the recorded prompt — it wins over an agent-authored `--intent`
+    /// — so AI provenance reflects what the human actually asked rather than the
+    /// agent's paraphrase. No-ops outside an h5i-initialized repo and fails open
+    /// on any error, so it never blocks the turn.
+    /// Register in .claude/settings.json under "UserPromptSubmit" hooks.
+    Prompt,
 }
 
 #[derive(Subcommand)]
@@ -2342,8 +2357,14 @@ git add <file1> <file2> …   # never `git add .`
 
 Then commit via Bash:
 ```bash
-h5i capture commit -m "…" --model claude-sonnet-4-6 --agent claude-code --prompt "…"
+h5i capture commit -m "…" --model claude-sonnet-4-6 --agent claude-code
 ```
+
+**Do not pass `--intent` (or the old `--prompt`).** In Claude Code the verbatim
+human prompt is captured automatically by the `UserPromptSubmit` hook and wins
+over any agent-supplied intent — so just write a clear commit message and let the
+hook record what the human actually asked. (`--intent` stays as a fallback for
+Codex, CI, scripts, or manual commits where no prompt-capture hook runs.)
 
 (Or the `h5i_commit` MCP tool if the MCP server is configured.)
 
@@ -2552,8 +2573,11 @@ h5i claims prune                   # drop stale claims
 
 ```bash
 git add <exact paths>
-h5i capture commit -m "…" --agent codex --prompt "…"
+h5i capture commit -m "…" --agent codex --intent "<the human's ask>"
 ```
+
+Codex has no `UserPromptSubmit` hook, so pass `--intent` with the human's
+request — it is the fallback that fills the provenance prompt field.
 
 Add flags when relevant:
 - `--tests`  — tests were added or modified
@@ -4124,7 +4148,7 @@ fn noun_table(noun: &str) -> (&'static str, &'static [NounVerb], &'static [&'sta
                     verb: "commit",
                     summary: "Git commit + AI provenance (prompt, model, tokens, tests, decisions).",
                     legacy: "h5i commit",
-                    example: "h5i capture commit -m \"fix retry loop\" \\\n        --model claude-sonnet-4-6 --agent claude-code \\\n        --prompt \"add exponential backoff\" --tests",
+                    example: "h5i capture commit -m \"fix retry loop\" \\\n        --model claude-sonnet-4-6 --agent claude-code --tests",
                 },
                 NounVerb {
                     verb: "claim",
@@ -5281,7 +5305,7 @@ fn main() -> anyhow::Result<()> {
             println!("  {}", style("Quick-start:").bold());
             println!(
                 "    {}  capture AI provenance on every commit",
-                style("h5i commit -m \"…\" --prompt \"…\" --agent <claude-code|codex>").cyan()
+                style("h5i commit -m \"…\" --agent <claude-code|codex>  (--intent for Codex/CI)").cyan()
             );
             println!(
                 "    {}  snapshot agent memory after a session",
@@ -5317,7 +5341,7 @@ fn main() -> anyhow::Result<()> {
 
         Commands::Commit {
             message,
-            prompt,
+            intent,
             model,
             agent,
             tests,
@@ -5368,10 +5392,20 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            // Resolution order: CLI flag > environment variable > pending_context.json
+            // Resolution order: captured raw human prompt (UserPromptSubmit
+            // hook) > --intent flag > $H5I_INTENT/$H5I_PROMPT > pending.prompt.
+            // The verbatim human prompt wins so provenance records what the
+            // human actually asked, not the agent's paraphrase.
             let pending = repo.read_pending_context()?;
-            let prompt = prompt
-                .or_else(|| std::env::var("H5I_PROMPT").ok())
+            let prompt = pending
+                .as_ref()
+                .and_then(|c| c.human_prompt.clone())
+                .or(intent)
+                .or_else(|| {
+                    std::env::var("H5I_INTENT")
+                        .or_else(|_| std::env::var("H5I_PROMPT"))
+                        .ok()
+                })
                 .or_else(|| pending.as_ref().and_then(|c| c.prompt.clone()));
             let model = model
                 .or_else(|| std::env::var("H5I_MODEL").ok())
@@ -6529,9 +6563,10 @@ fn main() -> anyhow::Result<()> {
                     .any(|(target, _, _)| *target == HookTarget::Claude)
                 {
                     println!(
-                        "   {} prompt capture (UserPromptSubmit) and the MCP server stay manual —\n\
-                         \x20    run {} for those instructions.",
+                        "   {} prompt capture (UserPromptSubmit → {}) is now wired; the MCP\n\
+                         \x20    server stays manual — run {} for those instructions.",
                         style("→").dim(),
+                        style("h5i hook prompt").bold(),
                         style("h5i hook setup").bold(),
                     );
                 }
@@ -6553,48 +6588,20 @@ fn main() -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            let hook_script = r#"#!/usr/bin/env bash
-# h5i Claude Code hook — writes the user prompt to .git/.h5i/pending_context.json
-# so that `h5i commit` can pick it up automatically without --prompt.
-set -euo pipefail
-GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
-H5I_DIR="$GIT_ROOT/.git/.h5i"
-[ -d "$H5I_DIR" ] || exit 0
-jq -c '{
-  prompt: .prompt,
-  model: (env.H5I_MODEL // "claude-sonnet-4-6"),
-  agent_id: (env.H5I_AGENT_ID // "claude-code"),
-  session_id: .session_id
-}' > "$H5I_DIR/pending_context.json"
-"#;
-
             println!(
-                "{} {} writes the SessionStart/PostToolUse/Stop wiring below into\n\
-                 .claude/settings.json for you ({} for ~/.claude, {} to capture-wrap\n\
-                 Bash). The steps below cover the rest (prompt capture, MCP).\n",
+                "{} {} writes the SessionStart/PostToolUse/Stop/UserPromptSubmit\n\
+                 wiring below into .claude/settings.json for you ({} for ~/.claude,\n\
+                 {} to capture-wrap Bash). Prompt capture is native now — no jq\n\
+                 script needed. The step below only matters if you wire it by hand.\n",
                 style("Tip:").bold(),
                 style("h5i hook setup --write").cyan().bold(),
                 style("--scope user").bold(),
                 style("--wrap-bash").bold(),
             );
 
-            println!("{}", style("── Step 0: Installl `jq` ──").bold());
-            println!(
-                "If you don't have {} installed, run the following command:\n\n{}\n",
-                style("jq").yellow(),
-                style("apt install jq").dim()
-            );
-
-            println!("{}", style("── Step 1: Save hook script ──").bold());
-            println!(
-                "Save the following script to {} and make it executable:\n",
-                style("~/.claude/hooks/h5i-capture-prompt.sh").yellow()
-            );
-            println!("{}", style(hook_script).dim());
-
             println!(
                 "{}",
-                style("── Step 2: Add to ~/.claude/settings.json ──").bold()
+                style("── Add to ~/.claude/settings.json ──").bold()
             );
             println!(
                 "Add (or merge) the {} block into your {}:\n",
@@ -6611,7 +6618,7 @@ jq -c '{
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/h5i-capture-prompt.sh"
+            "command": "h5i hook prompt"
           }
         ]
       }
@@ -6666,6 +6673,12 @@ jq -c '{
             );
             println!("         auto-checkpoints the context workspace milestone.",);
             println!("         You never have to call `h5i context trace` by hand.");
+            println!(
+                "  {} — captures the verbatim human prompt so {} records",
+                style("UserPromptSubmit").yellow(),
+                style("h5i capture commit").yellow()
+            );
+            println!("         what you actually typed, not the agent's paraphrase.");
 
             println!();
             println!(
@@ -6772,7 +6785,7 @@ jq -c '{
             println!(
                 "\n{} also work without hooks — {} / H5I_MODEL / H5I_AGENT_ID are read automatically at commit time.",
                 style("Env vars").bold(),
-                style("H5I_PROMPT").yellow()
+                style("H5I_INTENT").yellow()
             );
         }
 
@@ -6923,6 +6936,43 @@ jq -c '{
                     "hookSpecificOutput": hook_output
                 })
             );
+        }
+
+        Commands::Hook(HookCommands::Prompt) => {
+            use std::io::Read as _;
+            // Read the UserPromptSubmit payload from stdin. Fail open on any
+            // problem so we never block the human's turn (and emit no stdout,
+            // which Claude Code would otherwise inject as added context).
+            let mut raw = String::new();
+            std::io::stdin().read_to_string(&mut raw).unwrap_or(0);
+            if raw.trim().is_empty() {
+                return Ok(());
+            }
+            let Ok(data) = serde_json::from_str::<serde_json::Value>(&raw) else {
+                return Ok(());
+            };
+            let prompt = data.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+            if prompt.trim().is_empty() {
+                return Ok(());
+            }
+            let session_id = data.get("session_id").and_then(|v| v.as_str());
+
+            let workdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            // Only record inside a git repo that already has h5i initialized —
+            // never create `.git/.h5i` just because the global hook fired in
+            // some unrelated repo.
+            let Ok(git_repo) = git2::Repository::discover(&workdir) else {
+                return Ok(());
+            };
+            let Ok(h5i_root) = storage::h5i_root_for_repo(&git_repo) else {
+                return Ok(());
+            };
+            if !h5i_root.exists() {
+                return Ok(());
+            }
+            if let Ok(repo) = H5iRepository::open(&workdir) {
+                let _ = repo.record_human_prompt(prompt, session_id);
+            }
         }
 
         Commands::Hook(HookCommands::SessionStart) => {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -432,6 +432,36 @@ mod tests {
     }
 
     #[test]
+    fn pending_context_without_human_prompt_field_parses() {
+        // A `pending_context.json` written before the `human_prompt` field
+        // existed must still deserialize (the `#[serde(default)]` contract),
+        // leaving `human_prompt` as None rather than failing the parse.
+        let legacy = r#"{
+            "prompt": "agent paraphrase",
+            "model": "claude-opus-4-8",
+            "agent_id": "claude-code",
+            "session_id": "sess-legacy"
+        }"#;
+        let ctx: PendingContext = serde_json::from_str(legacy).expect("legacy pending parses");
+        assert_eq!(ctx.prompt.as_deref(), Some("agent paraphrase"));
+        assert_eq!(ctx.model.as_deref(), Some("claude-opus-4-8"));
+        assert_eq!(ctx.session_id.as_deref(), Some("sess-legacy"));
+        assert!(
+            ctx.human_prompt.is_none(),
+            "missing human_prompt field should default to None"
+        );
+
+        // And a current file with the field round-trips.
+        let ctx = PendingContext {
+            human_prompt: Some("what the human typed".into()),
+            ..Default::default()
+        };
+        let raw = serde_json::to_string(&ctx).unwrap();
+        let back: PendingContext = serde_json::from_str(&raw).unwrap();
+        assert_eq!(back.human_prompt.as_deref(), Some("what the human typed"));
+    }
+
+    #[test]
     fn test_minimal_from_git_root_commit() {
         let (_dir, repo) = setup_git_repo();
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -375,6 +375,14 @@ pub struct PendingContext {
     pub model: Option<String>,
     pub agent_id: Option<String>,
     pub session_id: Option<String>,
+    /// Verbatim human prompt(s) captured by the `UserPromptSubmit` hook,
+    /// accumulated across turns since the last commit. This is the *raw* text
+    /// the human typed — not an agent paraphrase — and it wins over the
+    /// agent-authored `--prompt`/`$H5I_PROMPT` at commit time, so provenance
+    /// records what the human actually asked. `#[serde(default)]` keeps older
+    /// pending files (written before this field existed) parseable.
+    #[serde(default)]
+    pub human_prompt: Option<String>,
 }
 
 pub fn count_tokens(text: &str, model: &str) -> Result<usize, String> {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -641,7 +641,8 @@ impl H5iRepository {
                     );
                 }
             }
-            println!("\n    {}\n", style(commit.message().unwrap_or("")).bold());
+            println!("{:<10}", style("Message:").dim());
+            println!("    {}\n", style(commit.message().unwrap_or("")).bold());
             println!("{}", style("─".repeat(60)).dim());
         }
         Ok(())

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1396,6 +1396,44 @@ impl H5iRepository {
         Ok(())
     }
 
+    /// Persists the pending context to `.git/.h5i/pending_context.json`.
+    pub fn write_pending_context(&self, ctx: &PendingContext) -> Result<(), H5iError> {
+        fs::create_dir_all(&self.h5i_root)?;
+        let path = self.h5i_root.join("pending_context.json");
+        let raw = serde_json::to_string_pretty(ctx).map_err(|e| {
+            H5iError::Metadata(format!("Failed to serialize pending_context.json: {e}"))
+        })?;
+        fs::write(&path, raw)?;
+        Ok(())
+    }
+
+    /// Records a verbatim human prompt (from the `UserPromptSubmit` hook) into
+    /// the pending context, **accumulating** across turns since the last
+    /// commit — a commit often follows several human messages, and we want the
+    /// whole ask, not just the latest line. Empty/blank prompts are ignored.
+    /// The accumulated `human_prompt` wins over an agent-authored `--prompt` at
+    /// commit time, so the recorded prompt is what the human actually typed
+    /// rather than the agent's paraphrase.
+    pub fn record_human_prompt(
+        &self,
+        prompt: &str,
+        session_id: Option<&str>,
+    ) -> Result<(), H5iError> {
+        let prompt = prompt.trim();
+        if prompt.is_empty() {
+            return Ok(());
+        }
+        let mut ctx = self.read_pending_context()?.unwrap_or_default();
+        ctx.human_prompt = Some(match ctx.human_prompt.take() {
+            Some(prev) if !prev.trim().is_empty() => format!("{prev}\n\n{prompt}"),
+            _ => prompt.to_string(),
+        });
+        if let Some(sid) = session_id.filter(|s| !s.is_empty()) {
+            ctx.session_id = Some(sid.to_string());
+        }
+        self.write_pending_context(&ctx)
+    }
+
     /// Returns a list of commits enriched with h5i AI metadata, suitable for
     /// intent-based search. Commits without h5i records are included but will
     /// have `None` for prompt/model/agent_id.
@@ -3280,6 +3318,40 @@ mod tests {
         assert!(shadow.is_none(), "dry-run must not create a shadow ref");
         let paths: Vec<&str> = changed.iter().map(|(p, _)| p.as_str()).collect();
         assert!(paths.contains(&"bar.txt"), "bar.txt should appear as deleted");
+    }
+
+    #[test]
+    fn record_human_prompt_accumulates_across_turns() {
+        let dir = tempdir().unwrap();
+        Repository::init(dir.path()).unwrap();
+        let h5i = H5iRepository::open(dir.path()).unwrap();
+
+        // No pending file yet → nothing to read.
+        assert!(h5i.read_pending_context().unwrap().is_none());
+
+        // Blank prompts are ignored (no file written).
+        h5i.record_human_prompt("   ", Some("sess-1")).unwrap();
+        assert!(h5i.read_pending_context().unwrap().is_none());
+
+        // First real prompt is stored verbatim, with the session id.
+        h5i.record_human_prompt("fix the retry loop", Some("sess-1"))
+            .unwrap();
+        let ctx = h5i.read_pending_context().unwrap().unwrap();
+        assert_eq!(ctx.human_prompt.as_deref(), Some("fix the retry loop"));
+        assert_eq!(ctx.session_id.as_deref(), Some("sess-1"));
+
+        // A second turn appends (the whole ask, not just the latest line).
+        h5i.record_human_prompt("also add a test", Some("sess-1"))
+            .unwrap();
+        let ctx = h5i.read_pending_context().unwrap().unwrap();
+        assert_eq!(
+            ctx.human_prompt.as_deref(),
+            Some("fix the retry loop\n\nalso add a test")
+        );
+
+        // Clearing (as a commit does) drops the accumulated prompt.
+        h5i.clear_pending_context().unwrap();
+        assert!(h5i.read_pending_context().unwrap().is_none());
     }
 
     #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -980,7 +980,10 @@ fn hook_setup_write_default_writes_claude_and_codex_configs() {
         "{config}"
     );
     assert!(!config.contains("command = \"h5i hook run\""), "{config}");
-    assert!(config.contains("command = \"h5i codex finish\""), "{config}");
+    assert!(
+        config.contains("command = \"h5i codex finish --quiet\""),
+        "{config}"
+    );
     assert!(!config.contains("command = \"h5i hook stop\""), "{config}");
     assert!(
         config.contains("command = \"h5i hook wrap-bash\""),
@@ -1174,6 +1177,26 @@ fn codex_sync_replays_session_activity_into_context() {
     assert!(
         s.contains("edited src/main.rs"),
         "context trace missing edit: {s}"
+    );
+}
+
+#[test]
+fn codex_finish_quiet_emits_no_stdout_for_stop_hook() {
+    let repo = Repo::new();
+    repo.h5i_ok(&["init"]);
+    repo.h5i_ok(&["context", "init", "--goal", "codex stop hook test"]);
+
+    let home = TempDir::new().unwrap();
+    let out = repo.h5i_with_home(home.path(), &["codex", "finish", "--quiet"]);
+    assert!(
+        out.status.success(),
+        "codex finish --quiet failed: {}",
+        stderr(&out)
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "codex Stop hook command must not emit non-JSON stdout: {}",
+        stdout(&out)
     );
 }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -367,6 +367,10 @@ fn prompt_hook_capture_wins_over_agent_intent() {
         "commit should record the captured human prompt: {s}"
     );
     assert!(
+        s.contains("Message:"),
+        "log output should mark where the commit message begins: {s}"
+    );
+    assert!(
         !s.contains("agent paraphrase that should not win"),
         "agent intent must not override the captured human prompt: {s}"
     );

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -299,6 +299,111 @@ fn commit_with_ai_provenance() {
     );
 }
 
+/// Feed a JSON payload to `h5i claude prompt` on stdin (the UserPromptSubmit
+/// handler), returning its output. Mirrors how Claude Code invokes the hook.
+fn run_prompt_hook(repo: &Repo, payload: &serde_json::Value) -> Output {
+    Command::new(H5I)
+        .args(["claude", "prompt"])
+        .current_dir(repo.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(stdin) = child.stdin.as_mut() {
+                let _ = stdin.write_all(payload.to_string().as_bytes());
+            }
+            child.wait_with_output()
+        })
+        .expect("claude prompt failed to spawn")
+}
+
+#[test]
+fn prompt_hook_capture_wins_over_agent_intent() {
+    let repo = Repo::new();
+    repo.h5i_ok(&["init"]);
+
+    // The UserPromptSubmit hook fires with the verbatim human prompt.
+    let out = run_prompt_hook(
+        &repo,
+        &serde_json::json!({
+            "session_id": "sess-xyz",
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "fix the flaky retry loop in the client",
+        }),
+    );
+    assert!(
+        out.status.success() && !stderr(&out).contains("panic"),
+        "claude prompt failed: {}",
+        stderr(&out)
+    );
+
+    // Commit, passing an agent-authored intent that must LOSE to the captured
+    // human prompt.
+    fs::write(repo.path().join("client.rs"), "fn retry() {}").unwrap();
+    run_ok(
+        Command::new("git")
+            .args(["add", "client.rs"])
+            .current_dir(repo.path()),
+    );
+    repo.h5i_ok(&[
+        "commit",
+        "-m",
+        "harden retry",
+        "--model",
+        "claude-opus-4-8",
+        "--agent",
+        "claude-code",
+        "--intent",
+        "agent paraphrase that should not win",
+    ]);
+
+    // The recorded provenance prompt (surfaced by `h5i log`) must be the
+    // captured human prompt, not the agent's intent.
+    let s = stdout(&repo.h5i_ok(&["log", "--limit", "1"]));
+    assert!(
+        s.contains("fix the flaky retry loop in the client"),
+        "commit should record the captured human prompt: {s}"
+    );
+    assert!(
+        !s.contains("agent paraphrase that should not win"),
+        "agent intent must not override the captured human prompt: {s}"
+    );
+}
+
+#[test]
+fn agent_intent_used_when_no_human_prompt_captured() {
+    let repo = Repo::new();
+    repo.h5i_ok(&["init"]);
+
+    // No UserPromptSubmit hook fired — the agent-supplied --intent is the
+    // fallback and should be recorded as the provenance prompt.
+    fs::write(repo.path().join("a.rs"), "fn main() {}").unwrap();
+    run_ok(
+        Command::new("git")
+            .args(["add", "a.rs"])
+            .current_dir(repo.path()),
+    );
+    repo.h5i_ok(&[
+        "commit",
+        "-m",
+        "add main",
+        "--model",
+        "claude-opus-4-8",
+        "--agent",
+        "claude-code",
+        "--intent",
+        "implement the entrypoint",
+    ]);
+
+    let s = stdout(&repo.h5i_ok(&["log", "--limit", "1"]));
+    assert!(
+        s.contains("implement the entrypoint"),
+        "agent intent should be recorded when no human prompt was captured: {s}"
+    );
+}
+
 // ─── log ────────────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -855,9 +855,9 @@ fn hook_setup_write_default_writes_claude_and_codex_configs() {
         claude.contains("\"command\": \"h5i hook session-start\""),
         "{claude}"
     );
-    assert!(claude.contains("\"command\": \"h5i hook run\""), "{claude}");
+    assert!(claude.contains("\"command\": \"h5i claude sync\""), "{claude}");
     assert!(
-        claude.contains("\"command\": \"h5i hook stop\""),
+        claude.contains("\"command\": \"h5i claude finish\""),
         "{claude}"
     );
     assert!(
@@ -870,8 +870,9 @@ fn hook_setup_write_default_writes_claude_and_codex_configs() {
         config.contains("command = \"h5i hook session-start\""),
         "{config}"
     );
-    assert!(config.contains("command = \"h5i hook run\""), "{config}");
-    assert!(config.contains("command = \"h5i hook stop\""), "{config}");
+    assert!(!config.contains("command = \"h5i hook run\""), "{config}");
+    assert!(config.contains("command = \"h5i codex finish\""), "{config}");
+    assert!(!config.contains("command = \"h5i hook stop\""), "{config}");
     assert!(
         config.contains("command = \"h5i hook wrap-bash\""),
         "{config}"


### PR DESCRIPTION
…k; rename --prompt to --intent

Add a native `h5i hook prompt` (UserPromptSubmit) that records the raw human prompt into pending_context.json, accumulating across turns. At commit time the captured human prompt now wins over the agent-supplied intent, so AI provenance reflects what the human actually asked rather than the agent's paraphrase.

Rename the `--prompt` flag to `--intent` (with `--prompt` kept as a back-compat alias and $H5I_INTENT added alongside $H5I_PROMPT). `--intent` is now documented as the fallback for Codex/CI/manual commits where no prompt-capture hook runs; the Claude flow drops it.

Wire UserPromptSubmit into CORE_HOOKS (excluded from the Codex TOML merge) and this repo's .claude/settings.json. Update CLAUDE.md, .claude/h5i.md, the ctx prelude, and the h5i-workflow skill accordingly.