### PR TITLE
Tighten pitch deck to 13 investor-lite slides

### DIFF
--- a/.claude/h5i.md
+++ b/.claude/h5i.md
@@ -14,11 +14,20 @@ Apply these automatically, without being asked.
 
 ### Context workspace
 
-**At the start of every non-trivial task:**
+**At the start of every non-trivial task**, check the current goal and pin
+status (cheap — just a goal line), then (re)set the goal:
 ```bash
-# If no workspace exists yet, initialize one:
+h5i recall context goal        # prints the goal + warns if context is PINNED to a stale branch
 h5i recall context init --goal "<one-line summary of what you are about to do>"
 ```
+Run `init` **even if a workspace already exists** — it is idempotent: it updates
+the goal in place and keeps the existing context branch and milestones. A session
+often resumes with a *stale* goal left over from a previous task (the SessionStart
+hook will show it); always re-point the goal at what you are about to do now,
+rather than skipping `init` because a workspace exists. If `context goal` reports
+the context is **pinned** to a branch other than your current git branch, your
+traces are landing on the wrong branch — run `h5i recall context unpin` to resume
+tracking the git branch.
 
 **You do not need to call `h5i recall context trace` yourself.** h5i's hooks derive
 the trace automatically:

--- a/docs/pitch/index.html
+++ b/docs/pitch/index.html
@@ -663,7 +663,7 @@
   <div style="width:100%;max-width:1000px;">
     <div class="hero-badge">Infrastructure for AI agent teams</div>
     <h1 style="font-size:clamp(2.6rem,5.4vw,4.8rem);">Run many coding agents.<br><span class="shine-text">Merge one auditable result</span></h1>
-    <p class="lede" style="max-width:820px;margin-top:20px;font-size:1.28rem;">h5i is the <span class="cyan">Git-native workspace layer for AI agent teams</span>. Each agent works in its own isolated sandbox, submits a sealed independent attempt, and a neutral verifier picks one winner — every prompt, command, message, and verdict versioned in your repo.</p>
+    <p class="lede" style="max-width:820px;margin-top:20px;font-size:1.28rem;">h5i gives each coding agent an <span class="cyan">isolated workspace</span>, seals independent attempts, and lets a <span class="cyan">neutral verifier</span> merge one auditable winner — in Git.</p>
 
     <div class="g4" style="margin-top:30px;">
       <div class="role"><span class="ra">architect</span><span class="rn">Design</span><span class="rd">shapes the approach</span></div>
@@ -677,132 +677,86 @@
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 2 — The Historical Pattern (ML ensembles)
+     SLIDE 2 — Why now (ML ensemble precedent → coding agents)
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:24px;">
   <div style="width:100%;max-width:980px;">
-    <div class="section-tag">The historical pattern</div>
-    <h2>In ML, the win came from<br><span class="red">combining models</span> — not one model.</h2>
-    <p class="lede" style="max-width:820px;">Robust performance rarely came from trusting a single estimator. Ensemble methods are explicitly designed to combine diverse models to improve generalization and robustness — and a decade of competition culture made stacking, blending, and ensembles the default winning pattern.</p>
+    <div class="section-tag">Why now</div>
+    <h2>AI agents are becoming<br><span class="red">production labor</span>.</h2>
+    <p class="lede" style="max-width:820px;">Coding agents ship real changes daily. ML already learned the next step: robustness comes from <span class="cyan">combining diverse attempts</span> — never from trusting one.</p>
 
-    <div class="g2" style="margin-top:26px;align-items:stretch;gap:22px;">
+    <div class="g2" style="margin-top:24px;align-items:stretch;gap:22px;">
       <div class="card" style="border-color:var(--border-red);background:rgba(224,36,27,0.04);">
         <span class="pill red">one model</span>
-        <h3 style="margin-top:10px;">High variance, brittle</h3>
-        <p class="feat-desc" style="margin-top:6px;">A single estimator overfits its own blind spots. One bad assumption skews the whole prediction.</p>
+        <h3 style="margin-top:10px;">Brittle</h3>
+        <p class="feat-desc" style="margin-top:6px;">A single run overfits its own blind spots. One bad assumption skews everything.</p>
       </div>
       <div class="card" style="border-color:rgba(98,201,140,0.3);background:rgba(98,201,140,0.035);">
         <span class="pill green">ensemble</span>
-        <h3 style="margin-top:10px;">Lower variance, robust</h3>
-        <p class="feat-desc" style="margin-top:6px;">Many diverse estimators, combined. Independent errors cancel; the aggregate generalizes better than any member.</p>
+        <h3 style="margin-top:10px;">Robust</h3>
+        <p class="feat-desc" style="margin-top:6px;">Many diverse attempts, combined. Independent errors cancel; the aggregate beats any member.</p>
       </div>
     </div>
 
-    <div class="g3" style="margin-top:18px;">
-      <div class="card-sm"><span class="mono red">bagging</span><p style="margin-top:6px;font-size:0.95rem;">Average independent learners to cut variance.</p><a class="cite" href="https://doi.org/10.1007/BF00058655" target="_blank" rel="noopener" title="Bagging Predictors — Breiman, 1996">Breiman, 1996 ↗</a></div>
-      <div class="card-sm"><span class="mono red">boosting</span><p style="margin-top:6px;font-size:0.95rem;">Stage learners so each fixes the last one's misses.</p><a class="cite" href="https://doi.org/10.1006/jcss.1997.1504" target="_blank" rel="noopener" title="A Decision-Theoretic Generalization of On-Line Learning and an Application to Boosting — Freund &amp; Schapire, 1997">Freund &amp; Schapire, 1997 ↗</a></div>
-      <div class="card-sm"><span class="mono red">stacking</span><p style="margin-top:6px;font-size:0.95rem;">A meta-judge selects and blends the best outputs.</p><a class="cite" href="https://doi.org/10.1016/S0893-6080(05)80023-1" target="_blank" rel="noopener" title="Stacked Generalization — Wolpert, 1992">Wolpert, 1992 ↗</a></div>
+    <div class="card card-red" style="margin-top:20px;padding:16px 24px;text-align:center;">
+      <div style="font-size:1.24rem;color:var(--ink);line-height:1.5;">The same shift is coming to coding agents. The winning unit isn't the best single agent — it's the <span class="red">best <em>managed</em> agent team</span>.</div>
     </div>
+    <p class="mono" style="margin-top:10px;font-size:0.72rem;color:var(--text-faint);text-align:center;">ML precedent: bagging (Breiman ’96) · boosting (Freund &amp; Schapire ’97) · stacking (Wolpert ’92)</p>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 3 — The New Pattern / Core Insight
-══════════════════════════════════════════════════════════════ -->
-<div class="slide" style="gap:24px;">
-  <div style="width:100%;max-width:1040px;">
-    <div class="section-tag">The new pattern</div>
-    <h2>The same shift is coming<br>to <span class="red">coding agents</span>.</h2>
-    <p class="lede" style="max-width:820px;">Instead of one agent doing everything, teams will run specialized agents on the same task — and select the best result. The roles are already familiar from how humans ship software.</p>
-
-    <div class="g3" style="margin-top:22px;">
-      <div class="role"><span class="ra">architect</span><span class="rn">Architect</span><span class="rd">frames the design before any code</span></div>
-      <div class="role"><span class="ra">implementer</span><span class="rn">Implementer</span><span class="rd">writes the change end to end</span></div>
-      <div class="role"><span class="ra">reviewer</span><span class="rn">Reviewer</span><span class="rd">reads the candidate critically</span></div>
-      <div class="role"><span class="ra">skeptic</span><span class="rn">Security skeptic</span><span class="rd">tries to break it on purpose</span></div>
-      <div class="role"><span class="ra">test-fixer</span><span class="rn">Test fixer</span><span class="rd">makes the suite green honestly</span></div>
-      <div class="role"><span class="ra">migration</span><span class="rn">Migration expert</span><span class="rd">handles the wide mechanical sweep</span></div>
-    </div>
-
-    <div class="card card-red" style="margin-top:22px;padding:18px 24px;text-align:center;">
-      <div style="font-size:1.32rem;color:var(--ink);line-height:1.5;font-weight:500;">The winning unit is not <span class="dim">"the best single agent."</span><br>It is the <span class="red">best <em>managed</em> agent team.</span></div>
-    </div>
-  </div>
-</div>
-
-<!-- ══════════════════════════════════════════════════════════════
-     SLIDE 4 — Why single-agent workflows are fragile
-══════════════════════════════════════════════════════════════ -->
-<div class="slide" style="gap:24px;">
-  <div style="width:100%;max-width:900px;">
-    <div class="section-tag">The fragility of one</div>
-    <h2>One agent is a<br><span class="red">single point of failure</span>.</h2>
-    <p class="lede">Routing a whole task through a single model concentrates every risk into one opaque run.</p>
-
-    <div class="qlist" style="margin-top:22px;">
-      <div class="qrow"><span class="q">One model can <span class="red">miss edge cases</span> no one thought to prompt for.</span><span class="gx">blind spot</span></div>
-      <div class="qrow"><span class="q">One prompt can <span class="red">bias the whole run</span> in a single direction.</span><span class="gx">bias</span></div>
-      <div class="qrow"><span class="q">One vendor / model creates <span class="red">supply-chain &amp; availability risk</span>.</span><span class="gx">lock-in</span></div>
-      <div class="qrow"><span class="q">One agent's mistake can <span class="red">become the whole PR</span>.</span><span class="gx">no check</span></div>
-      <div class="qrow"><span class="q">One opaque run is <span class="red">hard to audit</span> after the fact.</span><span class="gx">no trail</span></div>
-    </div>
-  </div>
-</div>
-
-<!-- ══════════════════════════════════════════════════════════════
-     SLIDE 5 — THE PROBLEM: naive agent teams break immediately
+     SLIDE 3 — The problem (fragile one + naive-team pileup)
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:22px;">
   <div style="width:100%;max-width:1020px;">
-    <div class="section-tag">The core problem</div>
-    <h2>But naive agent teams<br>break <span class="red">immediately</span>.</h2>
-    <p class="lede" style="max-width:820px;">Spawn five agents on one repo with no coordination layer and you do not get an ensemble — you get a pileup.</p>
+    <div class="section-tag">The problem</div>
+    <h2>One agent is fragile.<br>Naive teams are a <span class="red">pileup</span>.</h2>
+    <p class="lede" style="max-width:840px;">Route a task through one model and every risk concentrates in one opaque run. Spawn five agents on one repo with no coordination layer and you don't get an ensemble — you get collisions.</p>
 
     <div class="fm" style="margin-top:18px;">
       <div class="fm-row head"><div class="fm-cell">Failure mode</div><div class="fm-cell">What happens</div></div>
-      <div class="fm-row"><div class="fm-cell">Environment conflict</div><div class="fm-cell">Agents overwrite each other's files, ports, caches, credentials, and branches.</div></div>
-      <div class="fm-row"><div class="fm-cell">Context contamination</div><div class="fm-cell">Agents see each other's output before making an independent attempt — diversity collapses.</div></div>
-      <div class="fm-row"><div class="fm-cell">Token explosion</div><div class="fm-cell">Every agent re-reads the whole repo and drags raw logs into context.</div></div>
-      <div class="fm-row"><div class="fm-cell">Review overload</div><div class="fm-cell">Humans can't inspect every prompt, command, retry, and failure across N agents.</div></div>
-      <div class="fm-row"><div class="fm-cell">Unsafe autonomy</div><div class="fm-cell">Agents can run destructive commands without enough containment.</div></div>
-      <div class="fm-row"><div class="fm-cell">No fair winner</div><div class="fm-cell">You get many patches but no neutral evidence for which one to merge.</div></div>
+      <div class="fm-row"><div class="fm-cell">Environment conflict</div><div class="fm-cell">Agents overwrite each other's files, ports, caches, and branches.</div></div>
+      <div class="fm-row"><div class="fm-cell">Context contamination</div><div class="fm-cell">Agents see each other's output before attempting independently — diversity collapses.</div></div>
+      <div class="fm-row"><div class="fm-cell">Review overload</div><div class="fm-cell">Humans can't inspect every prompt, command, and retry across N agents.</div></div>
+      <div class="fm-row"><div class="fm-cell">No fair winner</div><div class="fm-cell">Many patches, but no neutral evidence for which one to merge.</div></div>
     </div>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 6 — Proof this is already painful
+     SLIDE 4 — Already painful (honest, measured)
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:24px;">
   <div style="width:100%;max-width:980px;">
     <div class="section-tag">Already painful</div>
-    <h2>This isn't hypothetical —<br>the pain is <span class="red">already here</span>.</h2>
-    <p class="lede" style="max-width:820px;">Three signals show the market is already hitting the walls a coordination layer is meant to remove.</p>
+    <h2>The pain is <span class="red">already here</span>.</h2>
+    <p class="lede" style="max-width:820px;">Cost and autonomy risk are real today — and an unmanaged agent team multiplies both.</p>
 
     <div class="g3" style="margin-top:24px;align-items:stretch;">
       <div class="metric" style="align-items:flex-start;text-align:left;gap:10px;">
-        <span class="pill red">reported incident</span>
-        <span class="mv" style="font-size:2.2rem;line-height:1.05;">DB<br>wiped</span>
-        <span class="ml">AI coding agents have deleted production data and ignored stop instructions — vivid, widely-reported incidents in 2025.</span>
+        <span class="pill red">reported · 2025</span>
+        <span class="mv" style="font-size:2.0rem;line-height:1.05;">prod data<br>wiped</span>
+        <span class="ml">AI coding agents have deleted production databases and ignored stop instructions — widely reported in 2025.</span>
       </div>
       <div class="metric" style="align-items:flex-start;text-align:left;gap:10px;">
-        <span class="pill yellow">budget pressure</span>
-        <span class="mv" style="font-size:2.2rem;line-height:1.05;">hard<br>ceilings</span>
-        <span class="ml">Token spend is now an operational budget line; companies are setting ceilings after large, surprising AI bills.</span>
+        <span class="pill yellow">budget line</span>
+        <span class="mv" style="font-size:2.0rem;line-height:1.05;">token<br>ceilings</span>
+        <span class="ml">Agent token spend is now a tracked operational cost; teams set hard ceilings after surprising bills.</span>
       </div>
       <div class="metric" style="align-items:flex-start;text-align:left;gap:10px;">
-        <span class="pill cyan">study</span>
-        <span class="mv" style="font-size:2.6rem;">30×</span>
-        <span class="ml">Agentic coding runs of the <em>same</em> task varied up to ~30× in token use — and more tokens didn't mean more accuracy.</span>
+        <span class="pill green">measured · h5i</span>
+        <span class="mv" style="font-size:2.6rem;">95%</span>
+        <span class="ml">Up to 95% less token waste in our own runs — raw tool logs kept out of context, recoverable on demand.</span>
       </div>
     </div>
 
-    <p class="kicker" style="margin-top:20px;text-align:center;">Destructive autonomy, runaway cost, and unpredictable runs are exactly what an unmanaged agent team multiplies.</p>
+    <p class="kicker" style="margin-top:20px;text-align:center;">Runaway cost and destructive autonomy are exactly what a coordination layer is built to contain.</p>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 7 — The Product
+     SLIDE 5 — The Product
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:22px;">
   <div style="width:100%;max-width:1040px;">
@@ -822,13 +776,13 @@
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 8 — h5i team (the centerpiece) — phase model
+     SLIDE 6 — h5i team (the centerpiece) — phase model
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:22px;">
   <div style="width:100%;max-width:1080px;">
     <div class="section-tag">The centerpiece</div>
     <h2><code style="font-size:0.82em;">h5i team</code> turns many attempts<br>into <span class="red">one verified verdict</span>.</h2>
-    <p class="lede" style="max-width:840px;">A thin orchestration layer over <code>h5i env</code>: it owns only coordination — roster, phases, sealed submissions, and the verdict. State is an append-only event log in one ref per run. <span class="cyan">Not a group chat. Not a daemon.</span></p>
+    <p class="lede" style="max-width:840px;">A thin Git-native protocol: roster, sealed submissions, review, neutral verifier, verdict. <span class="cyan">Not a group chat. Not a daemon.</span></p>
 
     <div class="pipe" style="margin-top:22px;">
       <div class="pipe-step"><span class="pn">01 · create</span><span class="pt">Roster</span><span class="pd">N envs, each a persona: runtime · model · role</span></div>
@@ -848,7 +802,7 @@
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 9 — The workflow / control room
+     SLIDE 7 — The workflow / control room
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:20px;">
   <div style="width:100%;max-width:1080px;">
@@ -879,24 +833,17 @@
         <div class="dot dot-r"></div><div class="dot dot-y"></div><div class="dot dot-g"></div>
         <span class="terminal-path">~/my-project · h5i team: fix-auth</span>
       </div>
-      <div class="terminal-body"><pre><span class="t-prompt">$</span> <span class="t-cmd">h5i env create claude-arch --profile architect</span>  <span class="t-cmt"># persona baked from .h5i/env.toml</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i env create codex-impl --profile implementer</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team create fix-auth --base HEAD</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team add-env fix-auth env/claude-arch/fix-auth --runtime claude</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team add-env fix-auth env/codex/codex-impl     --runtime codex</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team status fix-auth</span>  <span class="t-cmt"># note the generated agent ids</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team dispatch fix-auth --prompt-file task.md</span>  <span class="t-cmt"># one broadcast → all agents</span>
-  <span class="t-out">…each agent works sealed in its own box…</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team freeze fix-auth</span>                          <span class="t-cmt"># seals independent attempts</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team verify fix-auth --agent &lt;agent-id&gt; -- cargo test</span>  <span class="t-ai"># neutral, sandboxed</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team finalize fix-auth</span>   <span class="t-pass">→ verdict: claude-impl (gates pass, smallest diff)</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team apply fix-auth</span>      <span class="t-out">replays the winning patch · gated</span></pre></div>
+      <div class="terminal-body"><pre><span class="t-prompt">$</span> <span class="t-cmd">h5i team create fix-auth --base HEAD</span>            <span class="t-cmt"># roster of persona envs</span>
+<span class="t-prompt">$</span> <span class="t-cmd">h5i team dispatch fix-auth --prompt-file task.md</span> <span class="t-cmt"># one broadcast → all agents</span>
+<span class="t-prompt">$</span> <span class="t-cmd">h5i team freeze fix-auth</span>                        <span class="t-cmt"># seals independent attempts</span>
+<span class="t-prompt">$</span> <span class="t-cmd">h5i team verify fix-auth -- cargo test</span>          <span class="t-ai"># neutral, sandboxed replay</span>
+<span class="t-prompt">$</span> <span class="t-cmd">h5i team apply fix-auth</span>   <span class="t-pass">→ verdict: claude-impl (gates pass, smallest diff)</span></pre></div>
     </div>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 10 — The neutral verifier
+     SLIDE 8 — The neutral verifier
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:22px;">
   <div style="width:100%;max-width:1040px;">
@@ -924,27 +871,7 @@
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 11 — Every failure mode, closed
-══════════════════════════════════════════════════════════════ -->
-<div class="slide" style="gap:22px;">
-  <div style="width:100%;max-width:1020px;">
-    <div class="section-tag">The fix</div>
-    <h2>Every naive-team failure,<br><span class="red">closed by design</span>.</h2>
-
-    <div class="fm" style="margin-top:18px;">
-      <div class="fm-row head"><div class="fm-cell">Failure mode</div><div class="fm-cell">How h5i closes it</div></div>
-      <div class="fm-row solved"><div class="fm-cell">Environment conflict</div><div class="fm-cell">Isolated <span class="cmd">h5i env</span> worktree + sandbox per agent — no shared files, ports, or branches.</div></div>
-      <div class="fm-row solved"><div class="fm-cell">Context contamination</div><div class="fm-cell">Independence-first phases — no peer's work is visible until <span class="cmd">team freeze</span>.</div></div>
-      <div class="fm-row solved"><div class="fm-cell">Token explosion</div><div class="fm-cell"><span class="cmd">h5i capture</span> keeps raw logs out of context — up to 95% less waste.</div></div>
-      <div class="fm-row solved"><div class="fm-cell">Review overload</div><div class="fm-cell">Sealed candidates + compare board + one explainable verdict — not N transcripts.</div></div>
-      <div class="fm-row solved"><div class="fm-cell">Unsafe autonomy</div><div class="fm-cell">Fail-closed policy tiers; destructive commands blocked and recorded.</div></div>
-      <div class="fm-row solved"><div class="fm-cell">No fair winner</div><div class="fm-cell"><span class="cmd">team verify</span> — a neutral, sandboxed judge selects on evidence.</div></div>
-    </div>
-  </div>
-</div>
-
-<!-- ══════════════════════════════════════════════════════════════
-     SLIDE 12 — Why h5i wins (positioning)
+     SLIDE 9 — Why h5i wins (positioning)
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:24px;">
   <div style="width:100%;max-width:980px;">
@@ -962,21 +889,20 @@
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 13 — Why Git-native matters
+     SLIDE 10 — Why Git-native matters
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:22px;">
   <div style="width:100%;max-width:960px;">
     <div class="section-tag">Why Git-native</div>
-    <h2>Evidence travels with the <span class="red">branch</span>.</h2>
-    <p class="lede" style="max-width:820px;">The whole team run — roster, sealed candidates, reviews, verifier results, verdict — lives in repo-owned <code>refs/h5i/*</code> and ships with <code>h5i share push</code>. No new system of record.</p>
+    <h2>Repo-owned evidence travels<br>with the <span class="red">branch</span>.</h2>
+    <p class="lede" style="max-width:820px;">The whole team run lives in <code>refs/h5i/*</code> and ships with <code>git</code>. No SaaS, no new system of record.</p>
 
     <div class="refstack" style="margin-top:20px;">
-      <div class="ref-layer"><span class="ref-name">refs/h5i/team</span><span class="ref-desc">append-only run log: roster, sealed submissions, reviews, verifier verdict</span></div>
+      <div class="ref-layer"><span class="ref-name">refs/h5i/team</span><span class="ref-desc">roster, sealed submissions, reviews, verdict</span></div>
       <div class="ref-layer"><span class="ref-name">refs/h5i/env</span><span class="ref-desc">per-agent sandbox policy &amp; blocked-access evidence</span></div>
-      <div class="ref-layer"><span class="ref-name">refs/h5i/notes</span><span class="ref-desc">provenance per commit — prompt, model, persona, tests, risk</span></div>
-      <div class="ref-layer"><span class="ref-name">refs/h5i/msg + context</span><span class="ref-desc">cross-agent messages and the branchable reasoning DAG</span></div>
-      <div class="ref-join">h5i sidecar · carried by <code>h5i share push / pull</code></div>
-      <div class="ref-git"><span class="ref-name">your Git repo</span><span class="ref-desc">commits, branches, any remote, unchanged. No SaaS, no new VCS, no lock-in.</span></div>
+      <div class="ref-layer"><span class="ref-name">refs/h5i/notes + msg + context</span><span class="ref-desc">provenance, cross-agent messages, reasoning DAG</span></div>
+      <div class="ref-join">carried by <code>h5i share push / pull</code></div>
+      <div class="ref-git"><span class="ref-name">your Git repo</span><span class="ref-desc">commits, branches, any remote — unchanged. No lock-in.</span></div>
     </div>
 
     <div class="g4" style="margin-top:16px;">
@@ -989,27 +915,47 @@
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 14 — Vision / narrative arc
+     SLIDE 11 — Traction
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:24px;">
-  <div style="width:100%;max-width:960px;">
-    <div class="section-tag">The vision</div>
-    <h2>Every AI change ships with its<br><span class="red">team, evidence, and verdict</span>.</h2>
-    <p class="lede" style="max-width:820px;">A reviewer should open a change and see not just the diff, but the agent team that produced it, the workspace evidence, the review graph, and the verdict that selected it.</p>
+  <div style="width:100%;max-width:1000px;">
+    <div class="section-tag">Traction</div>
+    <h2>Agent-heavy developers are<br>already <span class="red">pulling</span> this.</h2>
+    <p class="lede" style="max-width:820px;">Open source, ~3 months old, and fully dogfooded — built by an h5i agent team coordinating on the same refs the product ships.</p>
 
-    <div class="ladder" style="margin-top:22px;">
-      <div class="rung"><span class="rk">Ensembles</span><span class="rv">made <strong style="color:var(--text);">ML</strong> more robust.</span></div>
-      <div class="rung"><span class="rk">Agent teams</span><span class="rv">can make <strong style="color:var(--text);">software work</strong> more robust.</span></div>
-      <div class="rung"><span class="rk">But unmanaged</span><span class="rv">they create conflicts, cost explosions, and audit gaps.</span></div>
-      <div class="rung h5i"><span class="rk">h5i</span><span class="rv">is the infrastructure layer that makes agent teams <strong style="color:var(--ink);">manageable</strong>.</span></div>
+    <div class="g4" style="margin-top:24px;">
+      <div class="metric"><span class="mv">424</span><span class="ml">GitHub stars</span></div>
+      <div class="metric"><span class="mv">24</span><span class="ml">forks</span></div>
+      <div class="metric"><span class="mv">293</span><span class="ml">cross-agent messages</span></div>
+      <div class="metric"><span class="mv">95%</span><span class="ml">less token waste (measured)</span></div>
     </div>
 
-    <p style="margin-top:18px;font-size:0.98rem;color:var(--text-dim);"><span class="green">Dogfooded here:</span> h5i is built by an h5i agent team — these very slides were coordinated through the same refs the product exposes.</p>
+    <p class="kicker" style="margin-top:20px;text-align:center;">179 commits in ~3 months · 0 external services — the entire development record lives in <code>refs/h5i/*</code>.</p>
   </div>
 </div>
 
 <!-- ══════════════════════════════════════════════════════════════
-     SLIDE 15 — Closing / CTA
+     SLIDE 12 — Market / buyer
+══════════════════════════════════════════════════════════════ -->
+<div class="slide" style="gap:24px;">
+  <div style="width:100%;max-width:1000px;">
+    <div class="section-tag">Who buys</div>
+    <h2>The teams that feel this<br><span class="red">pain first</span>.</h2>
+    <p class="lede" style="max-width:820px;">As agents become production labor, four buyers need an auditable convergence layer — and they already live in Git.</p>
+
+    <div class="g4" style="margin-top:24px;">
+      <div class="feat-card"><span class="feat-cmd">Platform / DevEx</span><p class="feat-desc" style="margin-top:6px;">Wants many agents to ship safely — without adopting a new SaaS or VCS.</p></div>
+      <div class="feat-card"><span class="feat-cmd">Security</span><p class="feat-desc" style="margin-top:6px;">Needs sandboxed autonomy and a record of every blocked access.</p></div>
+      <div class="feat-card"><span class="feat-cmd">AI governance</span><p class="feat-desc" style="margin-top:6px;">Must prove which prompt, model, and verdict produced each change.</p></div>
+      <div class="feat-card"><span class="feat-cmd">Agent-heavy eng</span><p class="feat-desc" style="margin-top:6px;">Already running ensembles and drowning in unverifiable patches.</p></div>
+    </div>
+
+    <p class="kicker" style="margin-top:20px;text-align:center;">Wedge: open-source workspace layer today → enterprise governance layer next.</p>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════
+     SLIDE 13 — Closing / CTA
 ══════════════════════════════════════════════════════════════ -->
 <div class="slide" style="gap:24px;">
   <div class="hero-glow"></div>
@@ -1017,7 +963,7 @@
     <div class="hero-badge">Infrastructure for AI agent teams</div>
     <h1 style="font-size:clamp(2.3rem,4.8vw,4.2rem);"><span style="white-space:nowrap;">Run many coding agents.</span><br><span class="shine-text" style="white-space:nowrap;">Merge one auditable result</span></h1>
     <p class="mono" style="margin:14px auto 0;font-size:1rem;color:var(--text-dim);letter-spacing:0.01em;">Orchestrators launch agents. <span class="red">h5i manages convergence.</span></p>
-    <p class="lede" style="margin:16px auto 0;text-align:center;">An isolated workspace per agent, sealed independent attempts, a neutral verifier, and one auditable verdict — versioned in your repo. No SaaS required. No lock-in. Works offline.</p>
+    <p class="lede" style="margin:16px auto 0;text-align:center;max-width:720px;"><span class="green">Open source today. Enterprise governance layer next.</span> An isolated workspace per agent, sealed attempts, a neutral verifier, one auditable verdict — in your repo.</p>
 
     <div class="cta-install" style="margin-top:30px;">
       <span class="pmt">$</span> curl -fsSL https://raw.githubusercontent.com/h5i-dev/h5i/main/install.sh | sh

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -2870,7 +2870,84 @@ pub fn reconcile_git_vs_ctx(workdir: &Path) -> Result<ReconciliationReport, H5iE
     Ok(report)
 }
 
-pub fn print_status(workdir: &Path) -> Result<(), H5iError> {
+/// True when the context is pinned to a branch other than the current git
+/// branch — i.e. new traces/milestones would silently land on the pinned branch
+/// instead of the one matching `git`. Powers the warnings in [`print_goal`] and
+/// [`print_status`]. Returns `false` when not pinned or when the pin happens to
+/// match the git branch.
+pub fn is_pin_misrouting(workdir: &Path) -> bool {
+    is_pinned(workdir) && current_branch(workdir) != current_git_branch(workdir)
+}
+
+/// Print just the current goal and pin status — a deliberately cheap, low-token
+/// view (a few short lines) meant to be run at the start of a task, *before*
+/// `context init --goal`. It lets an agent read the existing goal and catch a
+/// *stale pin* that is silently routing new context to a non-current branch
+/// (the failure mode that kept a stale goal in place across many tasks).
+pub fn print_goal(workdir: &Path) -> Result<(), H5iError> {
+    use console::style;
+
+    ctx_git_repo(workdir)?;
+    if !is_initialized(workdir) {
+        println!(
+            "{} context not initialized — run {} to set a goal.",
+            style("ℹ").blue(),
+            style("h5i recall context init --goal \"<goal>\"").bold(),
+        );
+        return Ok(());
+    }
+
+    let git_branch = current_git_branch(workdir);
+    let git_goal = git_branch_goal(workdir, &git_branch).unwrap_or_default();
+    let ctx_branch = current_branch(workdir);
+
+    if git_goal.trim().is_empty() {
+        println!(
+            "{} no goal set for git branch {} — run {}",
+            style("ℹ").blue(),
+            style(&git_branch).cyan().bold(),
+            style("h5i recall context init --goal \"<goal>\"").bold(),
+        );
+    } else {
+        println!("{} {}", style("Goal:").dim(), style(git_goal.trim()).cyan());
+        println!(
+            "  {} {}  ·  {} {}",
+            style("git branch:").dim(),
+            style(&git_branch).cyan(),
+            style("context branch:").dim(),
+            style(&ctx_branch).magenta(),
+        );
+    }
+
+    // The silent footgun: a pin to a non-current git branch.
+    if is_pinned(workdir) {
+        if ctx_branch != git_branch {
+            println!(
+                "{} context is {} to {} but git branch is {} — new traces are landing on the pinned branch, not {}.",
+                style("⚠").yellow().bold(),
+                style("PINNED").yellow().bold(),
+                style(&ctx_branch).magenta().bold(),
+                style(&git_branch).cyan().bold(),
+                style(&git_branch).cyan(),
+            );
+            println!(
+                "  Run {} to resume tracking the git branch.",
+                style("h5i recall context unpin").bold(),
+            );
+        } else {
+            println!(
+                "  {} context is pinned to {} (auto-follow off; {} to resume)",
+                style("·").dim(),
+                style(&ctx_branch).magenta(),
+                style("h5i recall context unpin").bold(),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn print_status(workdir: &Path, limit: usize) -> Result<(), H5iError> {
     use console::style;
 
     // A repo we cannot open (e.g. EACCES under a sandbox that doesn't grant
@@ -2930,6 +3007,27 @@ pub fn print_status(workdir: &Path) -> Result<(), H5iError> {
         if log_lines == 1 { "" } else { "s" },
     );
 
+    // Pin visibility: a context pinned to a non-current git branch silently
+    // misroutes new traces/milestones to the pinned branch. Surface it loudly.
+    if is_pinned(workdir) {
+        if branch != git_branch {
+            println!(
+                "  {} context {} to {} but git branch is {} — new traces land on the pinned branch; run {} to track git.",
+                style("⚠").yellow().bold(),
+                style("PINNED").yellow().bold(),
+                style(&branch).magenta().bold(),
+                style(&git_branch).cyan().bold(),
+                style("h5i recall context unpin").bold(),
+            );
+        } else {
+            println!(
+                "  {} context pinned (auto-follow off; {} to resume)",
+                style("·").dim(),
+                style("h5i recall context unpin").bold(),
+            );
+        }
+    }
+
     // Separate regular branches from scoped sub-contexts.
     let (scope_branches, regular_branches): (Vec<&String>, Vec<&String>) = branches
         .iter()
@@ -2971,6 +3069,29 @@ pub fn print_status(workdir: &Path) -> Result<(), H5iError> {
             style(stable).cyan(),
             style(dynamic).yellow(),
         );
+    }
+
+    // Recent-trace tail — `--limit N` (0 = none). Keeps `status` a *recent*
+    // activity view without the full dump that `context show --trace` gives.
+    if limit > 0 {
+        let recent: Vec<&str> = trace_text
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            .collect();
+        if !recent.is_empty() {
+            let shown = limit.min(recent.len());
+            println!();
+            println!(
+                "  {} (last {} of {})",
+                style("Recent trace:").dim(),
+                style(shown).cyan(),
+                style(recent.len()).dim(),
+            );
+            for line in &recent[recent.len() - shown..] {
+                println!("    {}", style(line).dim());
+            }
+        }
     }
 
     // Reconciliation against git branches.
@@ -4129,7 +4250,7 @@ mod tests {
         let git_dir = dir.path().join(".git");
         let orig = std::fs::metadata(&git_dir).unwrap().permissions();
         std::fs::set_permissions(&git_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
-        let res = print_status(dir.path());
+        let res = print_status(dir.path(), 0);
         // Restore before asserting so tempdir cleanup works on every path.
         std::fs::set_permissions(&git_dir, orig).unwrap();
         assert!(res.is_err(), "unreadable .git must surface as an error");
@@ -5493,6 +5614,36 @@ mod tests {
             current_branch(dir.path()),
             "some-other-branch",
             "after unpin, ctx should re-shadow the current git branch"
+        );
+    }
+
+    #[test]
+    fn is_pin_misrouting_flags_stale_pin() {
+        let dir = tempdir().unwrap();
+        git_init(dir.path());
+        init(dir.path(), "goal").unwrap();
+
+        // Not pinned, ctx tracks git → no misrouting.
+        assert!(!is_pin_misrouting(dir.path()), "fresh workspace is not misrouting");
+
+        // Pin to a spike, then move the git branch sideways: the pin now points
+        // at a branch other than the current git branch → misrouting.
+        gcc_branch(dir.path(), "pinned-spike", "explore").unwrap();
+        {
+            let repo = Repository::open(dir.path()).unwrap();
+            repo.set_head("refs/heads/some-other-branch").unwrap();
+        }
+        assert!(
+            is_pin_misrouting(dir.path()),
+            "pinned to 'pinned-spike' while git is on 'some-other-branch' should misroute"
+        );
+
+        // Unpin resumes auto-follow → no longer misrouting.
+        unpin(dir.path()).unwrap();
+        let _ = prepare_context_write(dir.path());
+        assert!(
+            !is_pin_misrouting(dir.path()),
+            "after unpin the pin warning must clear"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1611,8 +1611,20 @@ enum ContextCommands {
         ephemeral: bool,
     },
 
-    /// Show the current reasoning workspace state (branch, commit count, trace size)
-    Status,
+    /// Show the current reasoning workspace state (branch, counts, pin status)
+    /// plus a short tail of recent trace entries
+    Status {
+        /// Number of recent trace entries to show (0 = none). Unlike
+        /// `context show --trace`, this stays a *recent* view, not the full log.
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+    },
+
+    /// Print just the current goal + pin status — a cheap, low-token check to run
+    /// at the start of a task (before `context init --goal`). Warns when context
+    /// is pinned to a branch other than the current git branch (a stale pin that
+    /// silently misroutes new traces), and suggests `context unpin`.
+    Goal,
 
     /// Print a system prompt for injecting h5i context commands into an agent session
     Prompt,
@@ -2678,11 +2690,20 @@ Apply these automatically, without being asked.
 
 ### Context workspace
 
-**At the start of every non-trivial task:**
+**At the start of every non-trivial task**, check the current goal and pin
+status (cheap — just a goal line), then (re)set the goal:
 ```bash
-# If no workspace exists yet, initialize one:
+h5i recall context goal        # prints the goal + warns if context is PINNED to a stale branch
 h5i recall context init --goal "<one-line summary of what you are about to do>"
 ```
+Run `init` **even if a workspace already exists** — it is idempotent: it updates
+the goal in place and keeps the existing context branch and milestones. A session
+often resumes with a *stale* goal left over from a previous task (the SessionStart
+hook will show it); always re-point the goal at what you are about to do now,
+rather than skipping `init` because a workspace exists. If `context goal` reports
+the context is **pinned** to a branch other than your current git branch, your
+traces are landing on the wrong branch — run `h5i recall context unpin` to resume
+tracking the git branch.
 
 **You do not need to call `h5i recall context trace` yourself.** h5i's hooks derive
 the trace automatically:
@@ -2846,11 +2867,17 @@ Codex should use `h5i recall context` as shared cross-session memory and `h5i ca
 
 ### Workflow
 
-**At the start of a non-trivial task:**
+**At the start of a non-trivial task**, check the current goal/pin, then (re)set it:
 ```bash
-# If no workspace exists yet, initialize it once:
+h5i recall context goal        # prints the goal + warns if context is PINNED to a stale branch
 h5i recall context init --goal "<one-line task summary>"
 ```
+Run `init` **even if a workspace already exists** — it is idempotent and just
+updates the goal in place (keeping the context branch and milestones). A session
+often resumes with a *stale* goal from a previous task; always re-point it at
+what you are doing now instead of skipping `init` because a workspace exists. If
+`context goal` reports the context is **pinned** to a branch other than the
+current git branch, run `h5i recall context unpin` to resume branch tracking.
 
 **While working:**
 ```bash
@@ -10714,8 +10741,8 @@ fn main() -> anyhow::Result<()> {
                     );
                 }
 
-                ContextCommands::Status => {
-                    ctx::print_status(workdir)?;
+                ContextCommands::Status { limit } => {
+                    ctx::print_status(workdir, limit)?;
                     // Feature 5: append proactive review surface if git repo + notes exist.
                     if let Ok(repo) = H5iRepository::open(workdir) {
                         if let Ok(pts) = repo.suggest_review_points(3, 0.4) {
@@ -10744,6 +10771,10 @@ fn main() -> anyhow::Result<()> {
                             }
                         }
                     }
+                }
+
+                ContextCommands::Goal => {
+                    ctx::print_goal(workdir)?;
                 }
 
                 ContextCommands::Prompt => {


### PR DESCRIPTION
Merge ensemble+shift into 'Why now', fragility+naive-teams into 'Problem' (4-row table), reframe 'Already painful' around measured 95% token win, trim team/workflow/git-native text, cut redundant 'failure closed' slide, replace Vision with a Traction slide (live numbers) and add a Market/buyer slide. 15 -> 13 slides.