### PR TITLE
team dispatch: read task prompt from stdin by default

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2826,7 +2826,7 @@ inboxes and never locks the round.
 | `h5i team finalize <team> [--json]` | Apply the finalization rule over **verifier** evidence → a verdict event. Hard gates (tests pass, applies cleanly) first; `smallest diff` only breaks ties among gate-passers. Records method + the verifier command + losers' reasons. No gate-passer → `no_verdict` (never applies a loser). |
 | `h5i team apply <team> [--winner <submission-id>] [--force] [--json]` | Replay the winning submission's recorded patch (`base..commit`) into the current branch and commit; records source + target commit oids; on conflict records an event, never mutates the artifact. Gated on the verdict's `can_auto_apply` unless `--force`. |
 | `h5i team worker --once \| --watch [--interval N] [--id ID] [--lease-ttl S] [--json]` | Optional automation: one lease-and-finalize pass (`--once`) or an opt-in in-process loop (`--watch`). **Finalize-only — never auto-applies.** Leases are idempotent + TTL'd; for production prefer an external scheduler driving `--once`. |
-| `h5i team dispatch <team> --prompt-file F [--json]` | Send the task to **every roster agent in one command** over [`h5i msg`](#h5i-msg) (an `ASK` per persona, tagged with the team + round) — no per-env pasting. It **notifies, it does not launch**: each agent must be running in its env to pick the task out of its inbox. Receipt/progress count only when the agent replies ACK/DONE threaded to the dispatch. |
+| `h5i team dispatch <team> [--prompt-file F] [--json]` | Send the task to **every roster agent in one command** (prompt read from **stdin** by default — `h5i team dispatch <team> < TASK.md`; `--prompt-file` reads it from a named file instead) over [`h5i msg`](#h5i-msg) (an `ASK` per persona, tagged with the team + round) — no per-env pasting. It **notifies, it does not launch**: each agent must be running in its env to pick the task out of its inbox. Receipt/progress count only when the agent replies ACK/DONE threaded to the dispatch. |
 | `h5i team grant-review <team> --reviewer A --target B [--artifacts diff,summary,tests] [--json]` | Open a permissioned review: grant reviewer A scoped access to target B's round artifacts (never raw logs or persona bodies by default) + send a `REVIEW_REQUEST`. |
 | `h5i team review submit <team> --reviewer A --target B --file F [--json]` | Record a review body for a target candidate. |
 | `h5i team discuss <team> --from S --to A,B --file F [--artifacts ids] [--json]` | Send a logged, influence-tracked discussion message (post-freeze only). |
@@ -2851,7 +2851,8 @@ the host-visible log and embeds the task text directly in each boxed agent's
 startup prompt.
 
 ```bash
-h5i team dispatch fix-auth --prompt-file task.md   # one host-side broadcast → all agents
+h5i team dispatch fix-auth < task.md               # one host-side broadcast → all agents (prompt from stdin)
+h5i team dispatch fix-auth --prompt-file task.md   # equivalent: read the prompt from a named file
 # bring each agent up in its box; the launcher normally embeds the task text
 h5i env shell env/claude-architect/fix-auth        # in-box H5I_AGENT=claude-architect
 h5i env shell env/codex/fix-auth                   # in-box H5I_AGENT=codex

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ h5i team status  qsort-demo                                 # note the generated
 Dispatch one task to every agent:
 
 ```bash
-echo "Implement Quick Sort from scratch in Python." > TASK.md
-h5i team dispatch qsort-demo --prompt-file TASK.md
+echo "Implement Quick Sort from scratch in Python." | h5i team dispatch qsort-demo
 ```
 
 Launch every agent in its own sandboxed environment. Each agent automatically starts working on the dispatched task:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1030,7 +1030,7 @@
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team add-env fix-auth env/claude-arch/fix-auth --runtime claude</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team add-env fix-auth env/codex/codex-impl --runtime codex</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team status fix-auth</span>   <span class="t-cmt"># note the generated agent ids</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team dispatch fix-auth --prompt-file task.md</span>
+<span class="t-prompt">$</span> <span class="t-cmd">h5i team dispatch fix-auth &lt; task.md</span>
   <span class="t-out">…each agent works sealed in its own box…</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team freeze fix-auth</span>   <span class="t-cmt"># seals attempts</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team verify fix-auth --agent &lt;agent-id&gt; -- cargo test</span>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3425,7 +3425,7 @@ inboxes and never locks the round.</p>
 <td>Optional automation: one lease-and-finalize pass (<code>--once</code>) or an opt-in in-process loop (<code>--watch</code>). <strong>Finalize-only — never auto-applies.</strong> Leases are idempotent + TTL'd; for production prefer an external scheduler driving <code>--once</code>.</td>
 </tr>
 <tr>
-<td><code>h5i team dispatch &lt;team&gt; --prompt-file F [--json]</code></td>
+<td><code>h5i team dispatch &lt;team&gt; [--prompt-file F] [--json]</code> (prompt from stdin by default)</td>
 <td>Send the task to <strong>every roster agent in one command</strong> over <a href="#h5i-msg"><code>h5i msg</code></a> (an <code>ASK</code> per persona, tagged with the team + round) — no per-env pasting. It <strong>notifies, it does not launch</strong>: each agent must be running in its env to pick the task out of its inbox. Receipt/progress count only when the agent replies ACK/DONE threaded to the dispatch.</td>
 </tr>
 <tr>
@@ -3458,7 +3458,8 @@ host-owned coordination state, not writable from sealed boxes. Use
 <code>scripts/team-launch.sh --task</code> for normal interactive runs; it dispatches for
 the host-visible log and embeds the task text directly in each boxed agent's
 startup prompt.</p>
-<pre><code class="language-bash">h5i team dispatch fix-auth --prompt-file task.md   # one host-side broadcast → all agents
+<pre><code class="language-bash">h5i team dispatch fix-auth &lt; task.md               # one host-side broadcast → all agents (prompt from stdin)
+h5i team dispatch fix-auth --prompt-file task.md   # equivalent: read the prompt from a named file
 # bring each agent up in its box; the launcher normally embeds the task text
 h5i env shell env/claude-architect/fix-auth        # in-box H5I_AGENT=claude-architect
 h5i env shell env/codex/fix-auth                   # in-box H5I_AGENT=codex

--- a/docs/pitch/index.html
+++ b/docs/pitch/index.html
@@ -834,7 +834,7 @@
         <span class="terminal-path">~/my-project · h5i team: fix-auth</span>
       </div>
       <div class="terminal-body"><pre><span class="t-prompt">$</span> <span class="t-cmd">h5i team create fix-auth --base HEAD</span>            <span class="t-cmt"># roster of persona envs</span>
-<span class="t-prompt">$</span> <span class="t-cmd">h5i team dispatch fix-auth --prompt-file task.md</span> <span class="t-cmt"># one broadcast → all agents</span>
+<span class="t-prompt">$</span> <span class="t-cmd">h5i team dispatch fix-auth &lt; task.md</span> <span class="t-cmt"># one broadcast → all agents</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team freeze fix-auth</span>                        <span class="t-cmt"># seals independent attempts</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team verify fix-auth -- cargo test</span>          <span class="t-ai"># neutral, sandboxed replay</span>
 <span class="t-prompt">$</span> <span class="t-cmd">h5i team apply fix-auth</span>   <span class="t-pass">→ verdict: claude-impl (gates pass, smallest diff)</span></pre></div>

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -691,9 +691,13 @@ Finalize-only \(em never auto-applies. Leases are idempotent + TTL'd; for
 production prefer an external scheduler driving
 .BR \-\-once .
 .TP
-.BI "dispatch " "TEAM " "\-\-prompt-file F"
+.BI "dispatch " "TEAM " "[\-\-prompt-file F]"
 Send the task to every roster agent at once over
 .BR "h5i msg" " (no per-env pasting)."
+The task prompt is read from standard input by default
+.RB ( "h5i team dispatch TEAM < TASK.md" );
+.B \-\-prompt-file
+reads it from a named file instead.
 Notifies, does not launch: the shared message log and cursors are host-owned
 coordination state. For normal interactive runs use
 .B scripts/team-launch.sh --task

--- a/src/main.rs
+++ b/src/main.rs
@@ -2154,12 +2154,16 @@ enum TeamCommands {
         json: bool,
     },
     /// Dispatch a prompt to every team agent through h5i msg
+    ///
+    /// The task prompt is read from stdin by default
+    /// (`h5i team dispatch qsort-demo < TASK.md`); pass `--prompt-file` to read
+    /// it from a named file instead.
     Dispatch {
         /// Team id (defaults to the current team — see `team use`)
         team: Option<String>,
-        /// Prompt text file
+        /// Read the task prompt from this file instead of stdin
         #[arg(long = "prompt-file")]
-        prompt_file: std::path::PathBuf,
+        prompt_file: Option<std::path::PathBuf>,
         /// Emit JSON
         #[arg(long)]
         json: bool,
@@ -9841,12 +9845,27 @@ fn main() -> anyhow::Result<()> {
                 }
                 TeamCommands::Dispatch { team, prompt_file, json } => {
                     let team = h5i_core::team::resolve_run(&h5i_root, team)?;
-                    let prompt = std::fs::read_to_string(&prompt_file).map_err(|e| {
-                        anyhow::anyhow!(
-                            "failed to read prompt file {}: {e}",
-                            prompt_file.display()
-                        )
-                    })?;
+                    let prompt = match prompt_file {
+                        Some(path) => std::fs::read_to_string(&path).map_err(|e| {
+                            anyhow::anyhow!("failed to read prompt file {}: {e}", path.display())
+                        })?,
+                        None => {
+                            use std::io::{IsTerminal, Read};
+                            if std::io::stdin().is_terminal() {
+                                anyhow::bail!(
+                                    "no task prompt given — pipe one in (e.g. `h5i team dispatch {team} < TASK.md`) or pass --prompt-file <path>"
+                                );
+                            }
+                            let mut s = String::new();
+                            std::io::stdin().read_to_string(&mut s).map_err(|e| {
+                                anyhow::anyhow!("failed to read prompt from stdin: {e}")
+                            })?;
+                            s
+                        }
+                    };
+                    if prompt.trim().is_empty() {
+                        anyhow::bail!("task prompt is empty");
+                    }
                     let messages =
                         h5i_core::team::dispatch(git, &h5i_root, &team, &prompt, &actor)?;
                     if json {


### PR DESCRIPTION
Make --prompt-file optional. The dispatch task prompt is now read from stdin by default (h5i team dispatch <team> < TASK.md), so users no longer need a TASK.md file on disk; --prompt-file stays for back-compat. Guard against a TTY (clear error instead of a silent hang when nothing is piped) and reject an empty/whitespace-only prompt (also closes the old 0-byte --prompt-file hole). Update MANUAL.md, man page, README, and docs/*.html.