### PR TITLE
docs: fix first-definition to 'auditable workspace layer for AI codin…

### DIFF
--- a/docs/features/index.html
+++ b/docs/features/index.html
@@ -92,7 +92,7 @@
           {
             "@type": "Question",
             "name": "What is h5i?",
-            "acceptedAnswer": {"@type": "Answer", "text": "h5i (pronounced high-five) is an open-source Git sidecar that gives AI agents auditable workspaces. An auditable workspace is the place an agent does its work — a Git-backed worktree where every prompt, decision, command, log, policy, and handoff is recorded in your repo and provable after the fact. Git tracks the diff; h5i tracks the workspace behind it, in refs/h5i/*."}
+            "acceptedAnswer": {"@type": "Answer", "text": "h5i (pronounced high-five) is an open-source auditable workspace layer for AI coding agents. An auditable workspace is the place an agent does its work — a Git-backed worktree where every prompt, decision, command, log, policy, and handoff is recorded in your repo and provable after the fact. Git tracks the diff; h5i tracks the workspace behind it, stored as Git-native sidecar refs under refs/h5i/*."}
           },
           {
             "@type": "Question",

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -23,7 +23,7 @@
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="h5i Guides">
-  <meta name="twitter:description" content="Practical guides for AI-era version control with h5i, Claude Code, and Codex.">
+  <meta name="twitter:description" content="Practical guides for auditable AI coding workspaces with h5i, Claude Code, and Codex.">
   <meta name="twitter:image" content="https://h5i.dev/_static/screenshot_h5i_server.png">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -57,7 +57,7 @@
 
 <section class="index-hero">
   <div class="post-eyebrow">h5i Guides</div>
-  <h1>Practical guides for AI-era auditable workspace</h1>
+  <h1>Practical guides for auditable AI coding workspaces</h1>
   <p>
     Run many coding agents, merge one auditable result. Start with the end-to-end workflow, then dive into task-focused walkthroughs for using h5i with Claude Code and Codex: persistent memory and handoff, multi-agent coordination, AI code provenance, auditing AI-generated code, prompt-injection detection, and AI blame.
   </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>h5i: Infrastructure for AI Agent Teams (Claude Code &amp; Codex)</title>
-  <meta name="description" content="h5i is the Git-native workspace layer for AI agent teams. Run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result — versioned in refs/h5i/*, no SaaS.">
+  <title>h5i — Auditable Workspaces for AI Coding Agents (Claude Code &amp; Codex)</title>
+  <meta name="description" content="h5i is an auditable workspace layer for AI coding agents — Claude Code, Codex, and agent teams. Run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result — versioned in refs/h5i/*, no SaaS.">
   <meta name="keywords" content="ai agent teams, agent ensembles, multi-agent coding, auditable workspace, neutral verifier, sealed submissions, ai agent audit, agent provenance, confined agent sandbox, ai code governance, prompt injection detection, claude code, codex, git sidecar, h5i">
   <meta name="author" content="h5i-dev">
   <meta name="theme-color" content="#D21C1C">
@@ -21,8 +21,8 @@
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="h5i">
-  <meta property="og:title" content="h5i: Infrastructure for AI Agent Teams (Claude Code &amp; Codex)">
-  <meta property="og:description" content="Run many coding agents. Merge one auditable result. h5i is the Git-native workspace layer for AI agent teams: isolated workspaces, sealed independent attempts, a neutral verifier, and one auditable verdict — in refs/h5i/*, no SaaS.">
+  <meta property="og:title" content="h5i — Auditable Workspaces for AI Coding Agents (Claude Code &amp; Codex)">
+  <meta property="og:description" content="Run many coding agents. Merge one auditable result. h5i is an auditable workspace layer for AI coding agents: isolated workspaces, sealed independent attempts, a neutral verifier, and one auditable verdict — in refs/h5i/*, no SaaS.">
   <meta property="og:url" content="https://h5i.dev/">
   <meta property="og:image" content="https://h5i.dev/_static/screenshot_h5i_server.png">
   <meta property="og:image:width" content="2257">
@@ -31,8 +31,8 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="h5i: Infrastructure for AI Agent Teams (Claude Code &amp; Codex)">
-  <meta name="twitter:description" content="Run many coding agents. Merge one auditable result. The Git-native workspace layer for AI agent teams: isolated workspaces, sealed attempts, a neutral verifier — versioned beside your code, no SaaS.">
+  <meta name="twitter:title" content="h5i — Auditable Workspaces for AI Coding Agents (Claude Code &amp; Codex)">
+  <meta name="twitter:description" content="Run many coding agents. Merge one auditable result. An auditable workspace layer for AI coding agents: isolated workspaces, sealed attempts, a neutral verifier — versioned beside your code, no SaaS.">
   <meta name="twitter:image" content="https://h5i.dev/_static/screenshot_h5i_server.png">
   <meta name="twitter:image:alt" content="h5i web dashboard showing AI provenance, integrity scores, and test badges for each commit">
 
@@ -55,7 +55,7 @@
         "name": "h5i",
         "alternateName": "high-five",
         "url": "https://h5i.dev/",
-        "description": "The Git-native workspace layer for AI agent teams: run many coding agents, seal independent attempts, verify neutrally, and merge one auditable result.",
+        "description": "An auditable workspace layer for AI coding agents: run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result.",
         "publisher": {"@id": "https://h5i.dev/#org"},
         "inLanguage": "en"
       },
@@ -66,7 +66,7 @@
         "alternateName": "high-five",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Linux, macOS, Windows",
-        "description": "A Git sidecar that gives AI coding agents shared, version-controlled context with prompts, reasoning traces, memory snapshots, audit signals, shareable evidence, and a confined, auditable sandbox (tiered isolation + a network egress allowlist) to run agent work safely.",
+        "description": "An auditable workspace layer for AI coding agents. It runs Claude Code, Codex, and other agents in isolated, sandboxed Git workspaces (tiered isolation + a network egress allowlist) and records the prompts, commands, reasoning traces, logs, sandbox policy, reviews, and verifier results behind every change as Git-native sidecar refs under refs/h5i/* — no SaaS.",
         "url": "https://h5i.dev/",
         "downloadUrl": "https://github.com/h5i-dev/h5i",
         "softwareHelp": "/manual/",
@@ -93,7 +93,7 @@
           {
             "@type": "Question",
             "name": "What is h5i?",
-            "acceptedAnswer": {"@type": "Answer", "text": "h5i (pronounced high-five) is an open-source Git sidecar — the Git-native workspace layer for AI agent teams. Run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result. Git records what changed; h5i records the rest — the prompt, model, agent, reasoning, commands, audit signals, and verdict behind every change — versioned alongside your code in refs/h5i/*."}
+            "acceptedAnswer": {"@type": "Answer", "text": "h5i (pronounced high-five) is an open-source auditable workspace layer for AI coding agents. It runs Claude Code, Codex, and other agents in isolated Git workspaces and records the prompt, model, agent, reasoning, commands, logs, sandbox policy, reviews, and verifier results behind every change — then lets teams merge one evidence-backed result. Technically, h5i stores this evidence as Git-native sidecar refs under refs/h5i/*, so it travels with your repo with no hosted control plane."}
           },
           {
             "@type": "Question",
@@ -113,7 +113,7 @@
           {
             "@type": "Question",
             "name": "How is h5i different from plain Git?",
-            "acceptedAnswer": {"@type": "Answer", "text": "Git versions code. h5i adds five semantic dimensions on top: temporal (history), intentional (AI provenance), empirical (test metrics), and associative (cross-agent messaging). It stores this metadata in dedicated refs/h5i/* refs so it travels with the repo without touching your commit history."}
+            "acceptedAnswer": {"@type": "Answer", "text": "Git versions code. h5i adds four semantic dimensions on top: temporal (history), intentional (AI provenance), empirical (test metrics), and associative (cross-agent messaging). It stores this metadata in dedicated refs/h5i/* refs so it travels with the repo without touching your commit history."}
           },
           {
             "@type": "Question",
@@ -1167,7 +1167,7 @@
     <!-- <div class="hero-logo-wrap">
       <img src="/_static/logo.png" width="1280" height="640" alt="h5i logo" fetchpriority="high">
     </div> -->
-    <div class="hero-badge">INFRASTRUCTURE FOR AI AGENT TEAMS · SEALED ATTEMPTS · NEUTRAL VERIFIER</div>
+    <div class="hero-badge">AUDITABLE WORKSPACES FOR AI CODING AGENTS · SEALED ATTEMPTS · NEUTRAL VERIFIER</div>
     <h1 class="hero-title">
       <span class="shine-text"><span class="hl">Run Many Coding Agents.</span><br><span class="hl">Merge One Auditable Result</span></span>
     </h1>
@@ -1676,7 +1676,7 @@
       </details>
       <details class="faq-item">
         <summary>What is h5i?</summary>
-        <div class="faq-answer">h5i (pronounced <em>high-five</em>) is an open-source Git sidecar — the Git-native workspace layer for AI agent teams. Run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result. Git records <strong>what</strong> changed; h5i records the rest — the prompt, model, agent, reasoning, commands, logs, sandbox policy, audit signals, and verdict — versioned alongside your code in <code>refs/h5i/*</code>.</div>
+        <div class="faq-answer">h5i (pronounced <em>high-five</em>) is an open-source <strong>auditable workspace layer for AI coding agents</strong>. It runs Claude Code, Codex, and other agents in isolated Git workspaces and records the prompt, model, agent, reasoning, commands, logs, sandbox policy, reviews, and verifier results behind every change — then lets teams merge one evidence-backed result. Technically, h5i stores this evidence as Git-native sidecar refs under <code>refs/h5i/*</code>, so it travels with your repo with no hosted control plane.</div>
       </details>
       <details class="faq-item">
         <summary>Does h5i work with Claude Code and Codex?</summary>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,8 +1,21 @@
 # h5i
 
-> h5i ("high-five") is a Git-native sidecar that makes AI coding-agent work auditable. It records prompts, model/agent provenance, reasoning traces, test evidence, and cross-agent messages in `refs/h5i/*` (no SaaS), and sandboxes each agent in an isolated git worktree.
+> h5i ("high-five") is an open-source auditable workspace layer for AI coding agents. It runs Claude Code, Codex, and other coding agents in isolated Git workspaces, records the prompts, commands, logs, sandbox policy, reviews, and verifier results behind every change, then helps teams merge one evidence-backed result. Local-first, no SaaS.
 
-h5i extends version control with four dimensions: temporal (Git history), intentional (AI provenance), empirical (test metrics), and associative (cross-agent messaging). It integrates with Claude Code and Codex via lifecycle hooks and MCP, stores everything in your own repository, and shares h5i refs with `h5i share push` / `h5i share pull`. Apache-2.0, written in Rust.
+h5i solves the problems that show up once agents — not just humans — write the code: running many agents in parallel without collisions, sandboxing what each one can touch, proving where AI-generated code came from, and verifying which attempt to trust. Each agent works in its own isolated git worktree under a pinned policy; attempts are sealed independently and judged by a neutral, sandboxed verifier. It integrates with Claude Code and Codex via lifecycle hooks and MCP. Apache-2.0, written in Rust.
+
+## Core concepts
+- Auditable workspaces for AI coding agents
+- Sandboxed agent environments (tiered isolation + network egress allowlist)
+- Sealed independent attempts
+- Neutral verifier
+- Prompt-aware commits
+- AI code provenance
+- Git-native audit trail under `refs/h5i/*`
+- Local-first, no SaaS required
+
+## Technical model
+h5i stores agent evidence as Git-native sidecar refs under `refs/h5i/*` — prompts, model/agent provenance, reasoning traces, test metrics, reviews, verifier decisions, and cross-agent messages — so it lives alongside the repository with no hosted control plane, and travels with `h5i share push` / `h5i share pull`. It extends version control with four dimensions: temporal (Git history), intentional (AI provenance), empirical (test metrics), and associative (cross-agent messaging).
 
 ## Docs
 - [Features](https://h5i.dev/features/): What h5i gives Claude Code and Codex — sandboxed worktrees, prompt-aware commits, compressed tool logs, agent handoffs.

--- a/docs/pitch/index.html
+++ b/docs/pitch/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>h5i Pitch Deck: Infrastructure for AI Agent Teams</title>
-<meta name="description" content="h5i pitch deck: the Git-native workspace layer for AI agent teams. Run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result.">
+<title>h5i Pitch Deck: Auditable Workspaces for AI Coding Agents</title>
+<meta name="description" content="h5i pitch deck: an auditable workspace layer for AI coding agents. Run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result.">
 <meta name="keywords" content="h5i pitch, ai agent teams, agent ensembles, multi-agent coding, auditable workspaces, ai agents, agent sandbox, git sidecar, agent provenance, claude code, codex, neutral verifier, ai code review, agent governance">
 <meta name="author" content="h5i-dev">
 <meta name="theme-color" content="#D21C1C">
@@ -15,21 +15,21 @@
 <link rel="apple-touch-icon" href="/_static/logo.png">
 
 <script type="application/ld+json">
-{"@context": "https://schema.org", "@type": "PresentationDigitalDocument", "name": "h5i Pitch Deck", "headline": "h5i Pitch Deck: Infrastructure for AI Agent Teams", "description": "The Git-native workspace layer for AI agent teams: run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result.", "url": "https://h5i.dev/pitch/", "inLanguage": "en", "author": {"@type": "Organization", "name": "h5i-dev", "url": "https://github.com/h5i-dev/h5i"}, "publisher": {"@type": "Organization", "name": "h5i", "logo": {"@type": "ImageObject", "url": "https://h5i.dev/_static/logo.png"}}, "about": {"@type": "SoftwareApplication", "name": "h5i", "applicationCategory": "DeveloperApplication"}}
+{"@context": "https://schema.org", "@type": "PresentationDigitalDocument", "name": "h5i Pitch Deck", "headline": "h5i Pitch Deck: Auditable Workspaces for AI Coding Agents", "description": "An auditable workspace layer for AI coding agents: run many coding agents in isolated workspaces, seal independent attempts, verify neutrally, and merge one auditable result.", "url": "https://h5i.dev/pitch/", "inLanguage": "en", "author": {"@type": "Organization", "name": "h5i-dev", "url": "https://github.com/h5i-dev/h5i"}, "publisher": {"@type": "Organization", "name": "h5i", "logo": {"@type": "ImageObject", "url": "https://h5i.dev/_static/logo.png"}}, "about": {"@type": "SoftwareApplication", "name": "h5i", "applicationCategory": "DeveloperApplication"}}
 </script>
 
 <!-- Open Graph -->
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="h5i">
-<meta property="og:title" content="h5i Pitch Deck: Infrastructure for AI Agent Teams">
-<meta property="og:description" content="Run many coding agents. Merge one auditable result. h5i is the Git-native workspace layer for AI agent teams.">
+<meta property="og:title" content="h5i Pitch Deck: Auditable Workspaces for AI Coding Agents">
+<meta property="og:description" content="Run many coding agents. Merge one auditable result. h5i is an auditable workspace layer for AI coding agents.">
 <meta property="og:url" content="https://h5i.dev/pitch/">
 <meta property="og:image" content="https://h5i.dev/_static/screenshot_h5i_server.png">
 
 <!-- Twitter Card -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="h5i Pitch Deck: Infrastructure for AI Agent Teams">
-<meta name="twitter:description" content="Run many coding agents. Merge one auditable result. h5i is the Git-native workspace layer for AI agent teams.">
+<meta name="twitter:title" content="h5i Pitch Deck: Auditable Workspaces for AI Coding Agents">
+<meta name="twitter:description" content="Run many coding agents. Merge one auditable result. h5i is an auditable workspace layer for AI coding agents.">
 <meta name="twitter:image" content="https://h5i.dev/_static/screenshot_h5i_server.png">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -661,7 +661,7 @@
 <div class="slide active" style="gap:28px;">
   <div class="hero-glow"></div>
   <div style="width:100%;max-width:1000px;">
-    <div class="hero-badge">Infrastructure for AI agent teams</div>
+    <div class="hero-badge">Auditable workspaces for AI coding agents</div>
     <h1 style="font-size:clamp(2.6rem,5.4vw,4.8rem);">Run many coding agents.<br><span class="shine-text">Merge one auditable result</span></h1>
     <p class="lede" style="max-width:820px;margin-top:20px;font-size:1.28rem;">h5i gives each coding agent an <span class="cyan">isolated workspace</span>, seals independent attempts, and lets a <span class="cyan">neutral verifier</span> merge one auditable winner — in Git.</p>
 
@@ -960,7 +960,7 @@
 <div class="slide" style="gap:24px;">
   <div class="hero-glow"></div>
   <div style="width:100%;max-width:840px;text-align:center;display:flex;flex-direction:column;align-items:center;">
-    <div class="hero-badge">Infrastructure for AI agent teams</div>
+    <div class="hero-badge">Auditable workspaces for AI coding agents</div>
     <h1 style="font-size:clamp(2.3rem,4.8vw,4.2rem);"><span style="white-space:nowrap;">Run many coding agents.</span><br><span class="shine-text" style="white-space:nowrap;">Merge one auditable result</span></h1>
     <p class="mono" style="margin:14px auto 0;font-size:1rem;color:var(--text-dim);letter-spacing:0.01em;">Orchestrators launch agents. <span class="red">h5i manages convergence.</span></p>
     <p class="lede" style="margin:16px auto 0;text-align:center;max-width:720px;"><span class="green">Open source today. Enterprise governance layer next.</span> An isolated workspace per agent, sealed attempts, a neutral verifier, one auditable verdict — in your repo.</p>


### PR DESCRIPTION
…g agents'

Align the SEO/AEO lead definition across the site and demote 'Git sidecar' to a second-sentence technical detail (per SEO/AEO review):

- llms.txt: new lead def + Core concepts + Technical model sections
- homepage: title, OG/Twitter, meta, WebSite + SoftwareApplication schema, both 'What is h5i?' answers (visible + FAQPage JSON-LD), hero badge; fix 'five semantic dimensions' -> 'four'
- features: FAQ JSON-LD lead
- guides: H1 grammar + twitter description
- pitch: title/meta/JSON-LD/OG/Twitter + slide badges

Kept the punchy H1 and Claude Code/Codex in the title.