### PR TITLE
prompt-score: segment pasted artifacts from authored prose; evidence …

### DIFF
--- a/src/pr.rs
+++ b/src/pr.rs
@@ -984,7 +984,7 @@ fn render_prompt_maturity_section(ps: &crate::prompt_score::BranchPromptScore) -
     // Collapsible per-signal breakdown. The order matches the weight ranking so
     // the signals that move the score most are read first.
     let b = &ps.breakdown;
-    let rows: [(&str, f64); 7] = [
+    let rows: [(&str, f64); 8] = [
         ("Specificity", b.specificity),
         ("Control / acceptance", b.control),
         ("Context grounding", b.context),
@@ -992,6 +992,7 @@ fn render_prompt_maturity_section(ps: &crate::prompt_score::BranchPromptScore) -
         ("Lexical diversity", b.diversity),
         ("Clarity (readability band)", b.clarity),
         ("Length adequacy", b.adequacy),
+        ("Evidence attached (bonus)", b.evidence),
     ];
     s.push_str("<details><summary>📊 heuristic breakdown</summary>\n\n");
     s.push_str("| Dimension | Signal |\n|---|---|\n");

--- a/src/pr.rs
+++ b/src/pr.rs
@@ -984,10 +984,12 @@ fn render_prompt_maturity_section(ps: &crate::prompt_score::BranchPromptScore) -
     // Collapsible per-signal breakdown. The order matches the weight ranking so
     // the signals that move the score most are read first.
     let b = &ps.breakdown;
-    let rows: [(&str, f64); 8] = [
-        ("Specificity", b.specificity),
-        ("Control / acceptance", b.control),
-        ("Context grounding", b.context),
+    let rows: [(&str, f64); 10] = [
+        ("Objective (core)", b.objective),
+        ("Grounding (core)", b.grounding),
+        ("Direction / acceptance (core)", b.direction),
+        ("Context", b.context),
+        ("Examples", b.examples),
         ("Structure", b.structure),
         ("Lexical diversity", b.diversity),
         ("Clarity (readability band)", b.clarity),
@@ -2476,17 +2478,21 @@ fn render_per_commit_section(
         let _ = writeln!(s, "- **prompt** — _{}_", escape_md(&truncate(&ai.prompt, 280)));
         if !ai.prompt.trim().is_empty() {
             let pscore = crate::prompt_score::score_prompt(&ai.prompt);
-            let mut line = format!(
-                "  - {} **prompt maturity** {}/100 _{}_",
-                pscore.level.emoji(),
-                pscore.score.round() as i64,
-                pscore.level.label(),
-            );
-            if !pscore.flags.is_empty() {
-                let flags: Vec<&str> = pscore.flags.iter().map(|f| f.label()).collect();
-                let _ = write!(line, " — {}", flags.join(", "));
+            if let Some(reason) = pscore.unscored {
+                let _ = writeln!(s, "  - **prompt maturity** _unscored ({})_", reason);
+            } else {
+                let mut line = format!(
+                    "  - {} **prompt maturity** {}/100 _{}_",
+                    pscore.level.emoji(),
+                    pscore.score.round() as i64,
+                    pscore.level.label(),
+                );
+                if !pscore.flags.is_empty() {
+                    let flags: Vec<&str> = pscore.flags.iter().map(|f| f.label()).collect();
+                    let _ = write!(line, " — {}", flags.join(", "));
+                }
+                let _ = writeln!(s, "{}", line);
             }
-            let _ = writeln!(s, "{}", line);
         }
         let mut line = format!("- **model** `{}` · **agent** `{}`", ai.model_name, ai.agent_id);
         if let Some(u) = ai.usage.as_ref() {
@@ -3312,7 +3318,8 @@ mod tests {
         assert!(out.contains("/100"));
         assert!(out.contains("prompts scored"));
         assert!(out.contains("heuristic breakdown"));
-        assert!(out.contains("Specificity"));
+        assert!(out.contains("Objective (core)"));
+        assert!(out.contains("Direction / acceptance (core)"));
         assert!(out.contains("Flesch"));
         // Honesty disclaimer must be present so the number isn't read as a rating.
         assert!(out.contains("not a developer rating"), "{out}");

--- a/src/prompt_score.rs
+++ b/src/prompt_score.rs
@@ -43,6 +43,41 @@
 //! *balance gates* — a keyword-stuffed but context-free prompt is capped at 69
 //! so it can never read as "advanced".
 //!
+//! # Artifact segmentation (v2) — craft ≠ paste volume
+//!
+//! Real prompts routinely *contain machine output*: error logs, stack traces,
+//! compiler diagnostics, test-runner output, diffs. That text was **pasted, not
+//! written** — yet to v1 it looked like craft: paths and numbers farmed
+//! `specificity`, `test`/`line`/`file` tokens farmed verification and
+//! grounding, and sheer length lifted the adequacy curve and hard length caps.
+//! Measured on a real cargo-test failure paste, `"fix this failing test"` went
+//! 18 → 32 just by attaching the log — while a *well-crafted* prompt **dropped**
+//! 53 → 35 when the same log was attached (the paste drowned its diversity and
+//! tripped the repetition penalty). Wrong in both directions.
+//!
+//! v2 therefore splits the prompt line-wise into **authored prose** and
+//! **pasted artifact** ([`segment_artifacts`]: stack-frame / diagnostic /
+//! test-runner / log-level / timestamp / diff-marker patterns seed blocks;
+//! machine-ish neighbours — stopword-free, symbol-dense, deeply indented, or
+//! code-token-majority lines — join by contagion; fenced ``` blocks are
+//! artifact by construction). Every craft signal, the length caps, and the
+//! branch length-weighting are computed on the **authored text only**. The
+//! artifact instead feeds one new, deliberately *saturating* signal:
+//! `evidence` — attaching machine output is good grounding practice, so it
+//! earns a small fixed bonus (up to [`EVIDENCE_BONUS_MAX`] points, more when
+//! the prose explicitly frames the paste), but it can never scale with paste
+//! volume and never dilutes the authored signals.
+//!
+//! The segmentation features follow the natural-language-vs-machine-text
+//! literature: NLoN (Mäntylä et al., MSR 2018, arXiv 1803.07292) reaches
+//! AUC ≈ 0.97 line-level from exactly these cheap signals (stopword density,
+//! special-character ratio, digit ratio, indentation); infoZilla and the
+//! bug-report de-noising line (arXiv 2110.01336) show stack traces / diffs /
+//! logs are regex-friendly with precision > 0.9. The evidence-not-length move
+//! mirrors the standard length-bias countermeasure in text-quality metrics
+//! (Length-Controlled AlpacaEval, arXiv 2404.04475): credit *per unit of
+//! authored signal*, never total volume.
+//!
 //! # Scope vs. prompt-eval frameworks
 //!
 //! This is deliberately *not* an LLM-eval. Frameworks like PromptBench
@@ -87,6 +122,14 @@ pub const WEIGHTS: Weights = Weights {
     adequacy: 0.06,
 };
 
+/// Maximum bonus points the `evidence` signal can add to the composite.
+/// Attaching machine output (a log, trace, diff, or fenced block) is good
+/// grounding practice, so it earns a small fixed credit — deliberately a
+/// *bonus outside the weighted sum* so its absence never penalises the many
+/// prompts that have no artifact to attach, and deliberately saturating so it
+/// can never scale with paste volume.
+pub const EVIDENCE_BONUS_MAX: f64 = 5.0;
+
 /// Weighting of the seven sub-signals. See [`WEIGHTS`].
 #[derive(Debug, Clone, Copy)]
 pub struct Weights {
@@ -125,6 +168,11 @@ pub struct PromptScoreBreakdown {
     pub diversity: f64,
     pub clarity: f64,
     pub adequacy: f64,
+    /// Evidence signal (`0.0..=1.0`): pasted machine output / fenced blocks
+    /// attached (0.7) and explicitly framed by the authored prose (up to 1.0).
+    /// A *bonus* signal — not part of the weighted sum; it adds up to
+    /// [`EVIDENCE_BONUS_MAX`] points on top and its absence costs nothing.
+    pub evidence: f64,
     /// Raw Flesch Reading Ease (≈0–100, higher = easier). Display-only.
     pub flesch_reading_ease: f64,
     /// Raw Flesch-Kincaid Grade Level (US school grade). Display-only.
@@ -143,6 +191,7 @@ impl PromptScoreBreakdown {
             diversity: 0.0,
             clarity: 0.0,
             adequacy: 0.0,
+            evidence: 0.0,
             flesch_reading_ease: 0.0,
             fk_grade: 0.0,
             gunning_fog: 0.0,
@@ -210,6 +259,9 @@ pub enum Flag {
     WeakVerification,
     Repetitive,
     HardToScan,
+    /// The prompt is dominated by pasted machine output (log / trace / diff)
+    /// with only a thin authored ask around it.
+    MostlyPaste,
 }
 
 impl Flag {
@@ -221,6 +273,7 @@ impl Flag {
             Flag::WeakVerification => "no acceptance criteria",
             Flag::Repetitive => "repetitive",
             Flag::HardToScan => "hard to scan",
+            Flag::MostlyPaste => "mostly pasted output",
         }
     }
 }
@@ -232,7 +285,8 @@ pub struct PromptScore {
     pub score: f64,
     pub level: MaturityLevel,
     pub breakdown: PromptScoreBreakdown,
-    /// Prose word count (code-masked).
+    /// *Authored* prose word count — pasted artifact lines and code spans are
+    /// excluded, so a giant log paste doesn't read as a long prompt.
     pub words: usize,
     /// Up to two diagnostic flags, weakest dimension first.
     pub flags: Vec<Flag>,
@@ -285,12 +339,22 @@ impl BranchPromptScore {
 pub fn score_prompt(prompt: &str) -> PromptScore {
     let f = Features::extract(prompt);
     if f.words == 0 {
+        // No authored prose at all. A pure artifact paste still shows its
+        // evidence signal (and earns the bonus alone), but there is no craft
+        // to score.
+        let mut breakdown = PromptScoreBreakdown::zero();
+        breakdown.evidence = f.evidence_signal();
+        let score = (EVIDENCE_BONUS_MAX * breakdown.evidence).clamp(0.0, 100.0);
+        let mut flags = vec![Flag::TooShort];
+        if f.artifact_lines > 0 {
+            flags.push(Flag::MostlyPaste);
+        }
         return PromptScore {
-            score: 0.0,
-            level: MaturityLevel::Nascent,
-            breakdown: PromptScoreBreakdown::zero(),
+            score,
+            level: MaturityLevel::from_score(score),
+            breakdown,
             words: 0,
-            flags: vec![Flag::TooShort],
+            flags,
         };
     }
 
@@ -325,6 +389,12 @@ pub fn score_prompt(prompt: &str) -> PromptScore {
         // a 1200+ word unstructured wall is a dump, not a mature prompt
         score = score.min(75.0);
     }
+
+    // (4) Evidence bonus — attached machine output is grounding, not craft:
+    //     a small fixed credit on top, saturating (never scales with paste
+    //     volume) and applied *after* the caps so a lazy one-liner around a
+    //     log wall stays capped as the one-liner it is.
+    score += EVIDENCE_BONUS_MAX * breakdown.evidence;
 
     let score = score.clamp(0.0, 100.0);
 
@@ -384,6 +454,7 @@ where
         diversity: wmean_b(&|b| b.diversity),
         clarity: wmean_b(&|b| b.clarity),
         adequacy: wmean_b(&|b| b.adequacy),
+        evidence: wmean_b(&|b| b.evidence),
         flesch_reading_ease: wmean_b(&|b| b.flesch_reading_ease),
         fk_grade: wmean_b(&|b| b.fk_grade),
         gunning_fog: wmean_b(&|b| b.gunning_fog),
@@ -420,8 +491,11 @@ where
 // ── Feature extraction ───────────────────────────────────────────────────────
 
 /// Everything we measure off one prompt. Built once in [`Features::extract`].
+/// All fields describe the **authored** portion of the prompt — pasted
+/// machine-artifact lines are split off first by [`segment_artifacts`] and
+/// only feed `artifact_lines` / the evidence signal.
 struct Features {
-    /// Prose word count (code spans masked out before counting).
+    /// Authored prose word count (artifact lines and code spans excluded).
     words: usize,
     /// Prose tokens (lowercased), code spans removed — for diversity/readability.
     prose_tokens: Vec<String>,
@@ -451,10 +525,24 @@ struct Features {
     code_fences: usize,
     // ── anti-gaming ──
     repetition_factor: f64,
+    // ── artifact / evidence inputs ──
+    /// Lines classified as pasted machine output (logs, traces, diffs, fenced
+    /// block interiors).
+    artifact_lines: usize,
+    /// Non-blank lines that remained authored.
+    authored_lines: usize,
+    /// Deictic references from the authored prose to the paste ("the error
+    /// below", "this log", …).
+    evidence_refs: usize,
 }
 
 impl Features {
     fn extract(text: &str) -> Self {
+        // Split pasted machine artifacts (logs, stack traces, diffs, fenced
+        // blocks) from the authored prose first — everything below measures
+        // only what the engineer actually *wrote*.
+        let seg = segment_artifacts(text);
+        let text: &str = &seg.authored;
         // Mask code/paths/URLs so prose metrics aren't corrupted, but keep the
         // raw text for code-ref counting and lexicon matching.
         let masked = mask_code(text);
@@ -501,6 +589,9 @@ impl Features {
             edge_cases: lexicon_hits(&lower, &lower_counts, &word_set, EDGE_CASES),
             safety: lexicon_hits(&lower, &lower_counts, &word_set, SAFETY),
             scope: lexicon_hits(&lower, &lower_counts, &word_set, SCOPE),
+            evidence_refs: lexicon_hits(&lower, &lower_counts, &word_set, EVIDENCE_REFS),
+            artifact_lines: seg.artifact_lines,
+            authored_lines: seg.authored_lines,
             repetition_factor: repetition_factor(&prose_tokens),
             bullets,
             numbered,
@@ -567,6 +658,9 @@ impl Features {
         // ── Adequacy — length sweet spot (additive, gentle) ─────────────────
         let adequacy = length_adequacy(self.words);
 
+        // ── Evidence — attached artifact, saturating ────────────────────────
+        let evidence = self.evidence_signal();
+
         PromptScoreBreakdown {
             specificity,
             control,
@@ -575,10 +669,22 @@ impl Features {
             diversity,
             clarity,
             adequacy,
+            evidence,
             flesch_reading_ease,
             fk_grade,
             gunning_fog,
         }
+    }
+
+    /// Evidence signal in `0.0..=1.0`. Binary-ish and saturating by design:
+    /// *having* an artifact attached is worth 0.7; explicitly framing it from
+    /// the prose ("the error below", "this log") tops it up to 1.0. Volume is
+    /// deliberately not a factor — see the module docs on paste-gaming.
+    fn evidence_signal(&self) -> f64 {
+        if self.artifact_lines == 0 {
+            return 0.0;
+        }
+        0.7 + 0.3 * cap_ratio(self.evidence_refs, 2)
     }
 
     /// Up to two diagnostic flags, weakest qualifying dimension first.
@@ -586,6 +692,15 @@ impl Features {
         let mut out = Vec::new();
         if self.words < 15 {
             out.push(Flag::TooShort);
+        }
+        // A wall of pasted output around a thin ask: enough artifact lines to
+        // dominate (≥5 and ≥3× the authored lines) with under 40 authored
+        // words. Diagnostic: "write the ask, don't just paste".
+        if self.artifact_lines >= 5
+            && self.words < 40
+            && self.artifact_lines >= 3 * self.authored_lines.max(1)
+        {
+            out.push(Flag::MostlyPaste);
         }
         // Candidate (signal, flag) pairs, lowest signal surfaced first.
         let mut cands: Vec<(f64, Flag)> = vec![
@@ -679,6 +794,308 @@ const SCOPE: &[&str] = &[
     "only", "scope", "do not change", "don't change", "no unrelated", "out of scope",
     "in scope", "leave", "untouched", "just",
 ];
+
+/// Deictic references from the authored prose to an attached artifact — the
+/// difference between *framing* a paste ("the trace below shows…") and just
+/// dumping it. Tops up the evidence signal; matched on authored text only.
+const EVIDENCE_REFS: &[&str] = &[
+    "below", "above", "following", "attached", "pasted", "paste", "this error",
+    "the error", "this log", "the log", "this output", "the output", "the trace",
+    "the backtrace", "the stack trace", "this diff", "the diff", "stderr",
+    "stdout", "error message", "test output", "the failure", "this failure",
+];
+
+// ── Artifact segmentation ────────────────────────────────────────────────────
+//
+// Line-level split of a prompt into authored prose and pasted machine output,
+// following the NL-vs-machine-text literature (NLoN, infoZilla — see module
+// docs): high-precision *strong* patterns (stack frames, compiler diagnostics,
+// test-runner lines, log levels, timestamps, diff markers) seed artifact
+// blocks; cheap *weak* machine-ish signals (stopword-free, symbol-dense,
+// deeply indented, code-token-majority lines) join a block only by contagion
+// with an adjacent artifact line, so an isolated technical sentence in prose
+// stays authored. Fenced ``` interiors are artifact by construction (the
+// fence markers themselves stay authored so structure credit survives).
+// Fails toward *authored*: a missed artifact line costs a little noise, an
+// eaten prose line costs real signal.
+
+/// Result of [`segment_artifacts`].
+struct Segmented {
+    /// The authored lines, rejoined with `\n`.
+    authored: String,
+    /// Lines classified as pasted machine output.
+    artifact_lines: usize,
+    /// Non-blank lines that stayed authored.
+    authored_lines: usize,
+}
+
+/// Split `text` into authored prose and pasted machine artifacts.
+fn segment_artifacts(text: &str) -> Segmented {
+    let lines: Vec<&str> = text.lines().collect();
+    let n = lines.len();
+    let mut strength = vec![0u8; n];
+    let mut fence_marker = vec![false; n];
+    let mut in_fence = false;
+    for (i, l) in lines.iter().enumerate() {
+        if l.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            fence_marker[i] = true; // marker stays authored (structure credit)
+            continue;
+        }
+        strength[i] = if in_fence { 2 } else { line_artifact_strength(l) };
+    }
+
+    // Strong lines are artifact; weak lines join by contagion with a
+    // neighbouring artifact line (forward then backward pass, so runs grow
+    // from strong seeds in both directions).
+    let mut artifact: Vec<bool> = strength.iter().map(|&s| s >= 2).collect();
+    for i in 0..n {
+        if strength[i] == 1 && i > 0 && artifact[i - 1] {
+            artifact[i] = true;
+        }
+    }
+    for i in (0..n).rev() {
+        if strength[i] == 1 && i + 1 < n && artifact[i + 1] {
+            artifact[i] = true;
+        }
+    }
+
+    let mut authored = String::with_capacity(text.len());
+    let mut artifact_lines = 0usize;
+    let mut authored_lines = 0usize;
+    for (i, l) in lines.iter().enumerate() {
+        if artifact[i] && !fence_marker[i] {
+            artifact_lines += 1;
+            continue;
+        }
+        if !authored.is_empty() {
+            authored.push('\n');
+        }
+        authored.push_str(l);
+        if !l.trim().is_empty() && !fence_marker[i] {
+            authored_lines += 1;
+        }
+    }
+    Segmented { authored, artifact_lines, authored_lines }
+}
+
+/// Classify one line: `2` = unmistakable machine output (seeds an artifact
+/// block on its own), `1` = machine-ish (artifact only next to one), `0` =
+/// authored.
+fn line_artifact_strength(line: &str) -> u8 {
+    let t = line.trim();
+    if t.is_empty() {
+        return 0;
+    }
+    let lower = t.to_ascii_lowercase();
+
+    // ── Strong: high-precision machine-output patterns ──────────────────────
+    // Stack frames: "at src/…" / "at pkg.Class.method(File.java:123)" /
+    // 'File "x.py", line N' / numbered Rust/gdb frames.
+    if lower.starts_with("at ") && (t.contains('/') || t.contains("::") || t.contains('(')) {
+        return 2;
+    }
+    if t.starts_with("File \"") || is_frame_line(t) {
+        return 2;
+    }
+    // Panics / tracebacks / exception headlines.
+    if lower.contains("panicked at")
+        || lower.contains("stack backtrace")
+        || lower.contains("rust_backtrace")
+        || lower.starts_with("traceback (")
+        || lower.starts_with("caused by:")
+        || lower.starts_with("exception in thread")
+        || is_exception_headline(t)
+    {
+        return 2;
+    }
+    // Compiler / tool diagnostics.
+    if lower.starts_with("error:")
+        || lower.starts_with("error[")
+        || lower.starts_with("warning:")
+        || lower.starts_with("fatal:")
+        || t.starts_with("-->")
+        || t.contains("npm ERR!")
+    {
+        return 2;
+    }
+    if lower.contains("expected") && lower.contains("found") && t.contains('`') {
+        return 2; // rustc "expected `X`, found `Y`"
+    }
+    if lower.starts_with("assertion") && lower.contains("fail") {
+        return 2; // "assertion `left == right` failed" / "assertion failed: …"
+    }
+    if lower.starts_with("left:") || lower.starts_with("right:") {
+        return 2; // rustc assert_eq! operand dump
+    }
+    // Test-runner output.
+    if lower.starts_with("test ")
+        && (lower.ends_with("... ok")
+            || lower.contains("... failed")
+            || lower.contains("... ignored"))
+    {
+        return 2;
+    }
+    if (lower.starts_with("running ") && (lower.ends_with(" tests") || lower.ends_with(" test")))
+        || t == "failures:"
+        || t.starts_with("----")
+        || t.starts_with("====")
+    {
+        return 2;
+    }
+    // Log lines: leading timestamp or log-level token.
+    if starts_with_timestamp(t) || starts_with_log_level(t) {
+        return 2;
+    }
+    // Unified diff markers.
+    if t.starts_with("@@") || t.starts_with("+++ ") || t.starts_with("--- ")
+        || t.starts_with("diff --git")
+    {
+        return 2;
+    }
+
+    // ── Weak: machine-ish (NLoN-style cheap features) ───────────────────────
+    // Deep indentation (continuation lines of dumps / assertion diffs).
+    if line.starts_with("      ") || line.starts_with('\t') {
+        return 1;
+    }
+    // Diff content lines: +/- glued to content ("- item" bullets keep a space).
+    if t.len() > 1
+        && (t.starts_with('+') || t.starts_with('-'))
+        && !t[1..].starts_with(' ')
+        && !t.starts_with("--")
+    {
+        return 1;
+    }
+    // Terminal capture ("$ cargo test").
+    if t.starts_with("$ ") {
+        return 1;
+    }
+    // Very long unwrapped line — machine text doesn't wrap.
+    if t.len() > 180 {
+        return 1;
+    }
+    // Stopword-free multi-token line: authored English virtually always
+    // carries a function word; key:value dumps and identifier soup don't.
+    let toks: Vec<&str> = t.split_whitespace().collect();
+    if toks.len() >= 5 && !line_has_stopword(&lower) {
+        return 1;
+    }
+    // Majority of tokens look like code (paths, idents, calls).
+    if toks.len() >= 3 {
+        let codey = toks.iter().filter(|k| token_is_code(k)).count();
+        if codey * 10 >= toks.len() * 6 {
+            return 1;
+        }
+    }
+    // Symbol-dense line (braces, colons, equals — dump shrapnel).
+    if t.len() >= 12 && symbol_density(t) > 0.22 {
+        return 1;
+    }
+    0
+}
+
+/// Tiny function-word list for the natural-language-or-not signal (NLoN's
+/// strongest single feature). A ≥5-token line with *zero* of these is almost
+/// never authored English.
+const LINE_STOPWORDS: &[&str] = &[
+    "the", "a", "an", "and", "or", "but", "if", "then", "else", "for", "to",
+    "of", "in", "on", "at", "is", "are", "was", "were", "be", "been", "it",
+    "this", "that", "these", "those", "with", "as", "by", "from", "so", "we",
+    "you", "i", "not", "no", "do", "does", "did", "don't", "should", "must",
+    "can", "could", "will", "would", "when", "what", "how", "why", "which",
+    "there", "their", "our", "your", "my", "me", "us", "them", "they", "he",
+    "she", "his", "her", "its", "also", "than", "into", "over", "under",
+    "after", "before", "while", "where", "all", "any", "some", "please",
+];
+
+/// Does the (lowercased) line contain at least one English function word?
+fn line_has_stopword(lower: &str) -> bool {
+    lower.split_whitespace().any(|tok| {
+        let w: String = tok.chars().filter(|c| c.is_ascii_alphabetic() || *c == '\'').collect();
+        LINE_STOPWORDS.contains(&w.as_str())
+    })
+}
+
+/// Ratio of machine-punctuation characters (braces, colons, equals, …) to
+/// line length. Prose punctuation and backticks are excluded so a normal
+/// technical sentence stays low.
+fn symbol_density(t: &str) -> f64 {
+    let total = t.chars().count().max(1);
+    let sym = t
+        .chars()
+        .filter(|c| {
+            !c.is_alphanumeric()
+                && !c.is_whitespace()
+                && !matches!(c, '.' | ',' | '!' | '?' | '\'' | '"' | '-' | '`')
+        })
+        .count();
+    sym as f64 / total as f64
+}
+
+/// Numbered stack frame: "  3: core::ops::…", "0: rust_begin_unwind",
+/// "#2 0x00007f8e…".
+fn is_frame_line(t: &str) -> bool {
+    if let Some(rest) = t.strip_prefix('#') {
+        let digits = rest.chars().take_while(|c| c.is_ascii_digit()).count();
+        return digits > 0 && rest[digits..].trim_start().starts_with("0x");
+    }
+    let digits = t.chars().take_while(|c| c.is_ascii_digit()).count();
+    if digits == 0 {
+        return false;
+    }
+    if let Some(r) = t[digits..].strip_prefix(": ") {
+        return r.contains("::")
+            || r.contains('/')
+            || r.starts_with("0x")
+            || r.split_whitespace().next().map(is_code_like).unwrap_or(false);
+    }
+    false
+}
+
+/// Leading ISO date (`2026-07-03…`) or clock time (`07:12:33…`), optionally
+/// bracketed — the log-shipper heuristic for "this is a log line".
+fn starts_with_timestamp(t: &str) -> bool {
+    let s = t.trim_start_matches('[');
+    let c: Vec<char> = s.chars().take(10).collect();
+    if c.len() >= 10
+        && c[..4].iter().all(|c| c.is_ascii_digit())
+        && c[4] == '-'
+        && c[5..7].iter().all(|c| c.is_ascii_digit())
+        && c[7] == '-'
+        && c[8..10].iter().all(|c| c.is_ascii_digit())
+    {
+        return true;
+    }
+    c.len() >= 8
+        && c[0].is_ascii_digit()
+        && c[1].is_ascii_digit()
+        && c[2] == ':'
+        && c[3].is_ascii_digit()
+        && c[4].is_ascii_digit()
+        && c[5] == ':'
+        && c[6].is_ascii_digit()
+        && c[7].is_ascii_digit()
+}
+
+/// First token is an all-caps log-level keyword (optionally bracketed).
+fn starts_with_log_level(t: &str) -> bool {
+    let first = t.split_whitespace().next().unwrap_or("");
+    let w = first.trim_matches(|c: char| matches!(c, '[' | ']' | '(' | ')' | ':'));
+    matches!(
+        w,
+        "INFO" | "WARN" | "WARNING" | "ERROR" | "DEBUG" | "TRACE" | "FATAL" | "PANIC"
+            | "FAIL" | "PASS" // jest/tap runner result lines
+    )
+}
+
+/// One of the first tokens is an exception headline ("TypeError:",
+/// "java.lang.NullPointerException: …").
+fn is_exception_headline(t: &str) -> bool {
+    t.split_whitespace()
+        .take(3)
+        .any(|tok| tok.ends_with("Exception:") || tok.ends_with("Error:") || (tok.ends_with("Exception") && tok.contains('.')))
+}
 
 // ── Tokenisation & counting primitives ───────────────────────────────────────
 
@@ -844,6 +1261,9 @@ fn is_code_like(t: &str) -> bool {
     }
     if t.contains('/') && t.len() > 2 {
         return true; // path
+    }
+    if t.contains("::") {
+        return true; // Rust/C++ qualified path
     }
     if let Some(idx) = t.find('(') {
         if idx > 0 && t[..idx].chars().all(|c| c.is_alphanumeric() || c == '_') {
@@ -1609,6 +2029,130 @@ mod tests {
         let s2 = score_branch(vec![x, p], 2);
         assert!((s1.score - s2.score).abs() < 1e-9);
         assert_eq!(s1.level, s2.level);
+    }
+
+    // ── Artifact segmentation & evidence ─────────────────────────────────────
+
+    #[test]
+    fn segments_rust_panic_from_prose() {
+        let text = "Fix the parser bug shown below.\n\
+                    running 3 tests\n\
+                    test parser::tests::nested ... FAILED\n\
+                    thread 'parser::tests::nested' panicked at src/parser.rs:214:9:\n\
+                    assertion `left == right` failed\n\
+                    \u{20}\u{20}left: 3\n\
+                    \u{20}\u{20}right: 2\n\
+                    stack backtrace:\n\
+                    \u{20}\u{20} 0: rust_begin_unwind\n\
+                    \u{20}\u{20}           at /rustc/07dca48/library/std/src/panicking.rs:652:5\n\
+                    Keep the public signature unchanged.";
+        let seg = segment_artifacts(text);
+        assert!(seg.authored.contains("Fix the parser bug"));
+        assert!(seg.authored.contains("Keep the public signature"));
+        assert!(!seg.authored.contains("panicked"), "authored: {}", seg.authored);
+        assert!(!seg.authored.contains("rust_begin_unwind"));
+        assert!(!seg.authored.contains("FAILED"));
+        assert!(seg.artifact_lines >= 8);
+        assert_eq!(seg.authored_lines, 2);
+    }
+
+    #[test]
+    fn segments_python_traceback_java_frames_and_diffs() {
+        let py = segment_artifacts(
+            "The import fails, trace below.\n\
+             Traceback (most recent call last):\n\
+             \u{20}\u{20}File \"app.py\", line 3, in main\n\
+             TypeError: run() missing 1 required argument: 'x'\n\
+             Make main() pass a default.",
+        );
+        assert!(!py.authored.contains("Traceback"));
+        assert!(!py.authored.contains("TypeError"));
+        assert!(py.authored.contains("Make main() pass a default."));
+
+        let java = segment_artifacts(
+            "NPE on startup:\n\
+             Exception in thread \"main\" java.lang.NullPointerException\n\
+             \tat com.foo.Bar.baz(Bar.java:42)\n\
+             Guard the config lookup.",
+        );
+        assert!(!java.authored.contains("NullPointerException"));
+        assert!(!java.authored.contains("com.foo.Bar.baz"));
+        assert!(java.authored.contains("Guard the config lookup."));
+
+        let diff = segment_artifacts(
+            "Apply this diff and add a test:\n\
+             --- a/src/foo.rs\n\
+             +++ b/src/foo.rs\n\
+             @@ -1,3 +1,4 @@\n\
+             +use std::fmt;\n\
+             \u{20}fn main() {}\n",
+        );
+        assert!(!diff.authored.contains("@@"));
+        assert!(!diff.authored.contains("+use"));
+        assert!(diff.authored.contains("Apply this diff"));
+        assert!(diff.artifact_lines >= 5);
+    }
+
+    #[test]
+    fn structured_prose_is_not_misread_as_artifact() {
+        // Bullets, numbered steps, backticked idents, paths — all authored.
+        let seg = segment_artifacts(
+            "Harden `Invoice::finalize()` in src/billing.rs in three steps:\n\
+             - Reject a zero-quantity item by returning `Err(BillingError::EmptyLine)`.\n\
+             1. Round each subtotal to two decimals.\n\
+             2. Sanitize the note to drop control characters.\n\
+             Keep the signature stable and edit only billing.rs.",
+        );
+        assert_eq!(seg.artifact_lines, 0, "authored: {}", seg.authored);
+        assert_eq!(seg.authored_lines, 5);
+    }
+
+    #[test]
+    fn fenced_interior_is_artifact_but_fence_structure_survives() {
+        let text = "Reproduce with this snippet:\n```\nspam0 = 1\nspam1 = 2\nspam2 = 3\n```\nThen fix the overflow in `sum()`.";
+        let seg = segment_artifacts(text);
+        assert!(!seg.authored.contains("spam1"));
+        assert!(seg.authored.contains("```"), "fence markers must stay for structure");
+        assert_eq!(seg.artifact_lines, 3);
+        // End-to-end: the code_fences structure signal still counts the block.
+        let f = Features::extract(text);
+        assert_eq!(f.code_fences, 1);
+        assert!(f.artifact_lines == 3);
+    }
+
+    #[test]
+    fn evidence_bonus_is_additive_and_framing_tops_it_up() {
+        let ask = "Fix the flaky retry in src/net.rs and add a regression test.";
+        let plain = score_prompt(ask);
+        assert_eq!(plain.breakdown.evidence, 0.0);
+
+        // Same ask + a pasted diagnostic → identical craft signals, evidence 0.7,
+        // score up by exactly the bonus.
+        let with_log = score_prompt(&format!("{ask}\nerror[E0308]: mismatched types"));
+        assert!((with_log.breakdown.evidence - 0.7).abs() < 1e-9);
+        assert!((with_log.score - plain.score - EVIDENCE_BONUS_MAX * 0.7).abs() < 1e-6);
+        assert_eq!(with_log.words, plain.words, "paste must not count as words");
+
+        // Framing the paste ("the error below") tops evidence up to 1.0.
+        let framed = score_prompt(&format!(
+            "{ask} The error below shows the failing case.\nerror[E0308]: mismatched types"
+        ));
+        assert!((framed.breakdown.evidence - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mostly_paste_flag_fires_on_thin_ask_around_log_wall() {
+        let mut p = String::from("fix this\n");
+        for i in 0..12 {
+            p.push_str(&format!("error[E0308]: mismatched types --> src/a.rs:{i}:5\n"));
+        }
+        let s = score_prompt(&p);
+        assert!(s.flags.contains(&Flag::MostlyPaste), "flags: {:?}", s.flags);
+        // Artifact-only paste: no craft, evidence bonus only, both flags.
+        let only = score_prompt("error[E0308]: mismatched types --> src/a.rs:1:5");
+        assert_eq!(only.words, 0);
+        assert!(only.score <= EVIDENCE_BONUS_MAX);
+        assert!(only.flags.contains(&Flag::TooShort) && only.flags.contains(&Flag::MostlyPaste));
     }
 
     #[test]

--- a/src/prompt_score.rs
+++ b/src/prompt_score.rs
@@ -610,6 +610,7 @@ struct Features {
     quoted: usize,
     numbers: usize,
     action_verbs: usize,
+    imprecise_verbs: usize,
     weak_words: usize,
     grounding_refs: usize,
     // ── objective inputs ──
@@ -709,6 +710,7 @@ impl Features {
                 .filter(|w| w.chars().any(|c| c.is_ascii_digit()))
                 .count(),
             action_verbs: lexicon_hits(&lower, &lower_counts, &word_set, ACTION_VERBS),
+            imprecise_verbs: lexicon_hits(&lower, &lower_counts, &word_set, IMPRECISE_VERBS),
             weak_words: lexicon_hits(&lower, &lower_counts, &word_set, WEAK_WORDS),
             grounding_refs: lexicon_hits(&lower, &lower_counts, &word_set, GROUNDING_REFS),
             imperative_open: opens_with_imperative(text),
@@ -761,6 +763,10 @@ impl Features {
         // bonus, not a requirement. Dragged down by vagueness; a prompt of pure
         // prohibitions (no action verb) scores ~0 here, which the multiplicative
         // core then turns into a real cap.
+        // Imprecise-verb penalty (Paska's "not precise verb" smell): a prompt
+        // whose actionable content is dominated by verbs like "handle" /
+        // "process" / "support" names no real action.
+        let imprecise = (per100(self.imprecise_verbs) / 6.0).clamp(0.0, 1.0);
         let objective = {
             let base = if self.action_verbs == 0 {
                 0.0
@@ -768,7 +774,7 @@ impl Features {
                 0.6 + 0.2 * f64::from(self.action_verbs >= 2)
                     + 0.2 * f64::from(self.imperative_open)
             };
-            (base - 0.5 * vagueness).clamp(0.0, 1.0)
+            (base - 0.5 * vagueness - 0.4 * imprecise).clamp(0.0, 1.0)
         };
 
         // ── Core slot: grounding — concrete references ──────────────────────
@@ -938,12 +944,25 @@ impl Features {
 const ACTION_VERBS: &[&str] = &[
     "implement", "fix", "refactor", "add", "remove", "delete", "update", "design",
     "build", "create", "write", "migrate", "debug", "optimize", "rename", "extract",
-    "replace", "wire", "integrate", "parse", "render", "validate", "handle", "edit",
-    "ensure", "support", "improve", "convert", "move", "split", "guard", "harden",
+    "replace", "wire", "integrate", "parse", "render", "validate", "edit",
+    "convert", "move", "split", "guard", "harden",
     "sanitize", "reject", "return", "cache", "expose", "document", "cover", "port",
     "upgrade", "patch", "register", "normalize", "serialize", "deserialize", "strip",
     "compute", "check", "enforce", "apply", "disable", "enable", "configure",
     "extend", "adjust", "drop", "wrap", "cap", "emit", "escape", "trim", "raise",
+];
+
+/// Verbs that *look* actionable but name no precise action — Paska's
+/// "not precise verb" smell (Veizaga et al., arXiv 2305.07097). A prompt whose
+/// only "action" is one of these ("handle the errors", "process the data",
+/// "support pagination") is not a clear objective, so their density is a
+/// *negative* signal on `objective` — never counted as an [`ACTION_VERBS`] hit.
+// NB: "do" and "make" are deliberately excluded — they fire on "do not change"
+// and "make sure" (a constraint and an acceptance phrase), not on an imprecise
+// action. We keep only verbs that are almost always imprecise *actions*.
+const IMPRECISE_VERBS: &[&str] = &[
+    "handle", "support", "process", "manage", "deal", "perform", "consider",
+    "accomplish", "propose", "ensure", "improve", "address",
 ];
 
 /// NALABS / Femmer "requirements smells" — vague, subjective, or non-actionable
@@ -2049,6 +2068,27 @@ mod tests {
              3. Add a test in tests/config_test.rs covering the default value",
         );
         assert!(s.breakdown.structure > 0.5, "structure {}", s.breakdown.structure);
+    }
+
+    #[test]
+    fn imprecise_verbs_do_not_earn_objective_credit() {
+        // Paska's "not precise verb" smell: "handle"/"process"/"support" look
+        // actionable but name no action — they must not score like a real verb.
+        let precise = score_prompt(
+            "Add pagination to `list_items()` in src/api.rs, capping the page size at 100.",
+        );
+        let imprecise = score_prompt(
+            "Handle the errors and process the data and support pagination properly.",
+        );
+        assert!(
+            precise.breakdown.objective > imprecise.breakdown.objective + 0.3,
+            "precise {} vs imprecise {}",
+            precise.breakdown.objective,
+            imprecise.breakdown.objective
+        );
+        // The imprecise-only ask reads as objectiveless and scores low.
+        assert!(imprecise.breakdown.objective < 0.2, "obj {}", imprecise.breakdown.objective);
+        assert!(imprecise.score < 30.0, "imprecise-verb prompt scored {}", imprecise.score);
     }
 
     #[test]

--- a/src/prompt_score.rs
+++ b/src/prompt_score.rs
@@ -23,25 +23,34 @@
 //!   the text so file paths and `func()` tokens don't corrupt the syllable
 //!   counter.
 //!
-//! # The composite (locked with the `codex` agent over i5h)
+//! # The composite (v2 — slot rubric + multiplicative core)
 //!
-//! Seven sub-signals, each normalised to `0.0..=1.0`, combined by a fixed
-//! weighted sum (see [`WEIGHTS`], which sums to 1.0):
+//! Every signal is normalised to `0.0..=1.0`. Three **core slots** are
+//! *necessary* and combine **multiplicatively** (each floored at [`CORE_MIN`]);
+//! the rest are **enrichment** that lifts an already-solid core additively (see
+//! [`ENRICHMENT`], which sums to 1.0). See the "Aggregation model (v2)" section
+//! below for the full formula and the rationale for replacing v1's flat
+//! weighted sum + balance-gate caps.
 //!
-//! | Signal          | Weight | Captures                                          |
-//! |-----------------|-------:|---------------------------------------------------|
-//! | `specificity`   | 24%    | concreteness (code refs, idents) − vague words    |
-//! | `control`       | 24%    | constraints, output shape, acceptance/verification|
-//! | `context`       | 18%    | background, goal/why, current state, grounding    |
-//! | `structure`     | 10%    | decomposition — bullets, steps, multi-sentence    |
-//! | `diversity`     | 10%    | lexical richness (adaptive MATTR), non-repetitive |
-//! | `clarity`       |  8%    | readability in a target band (trapezoid)          |
-//! | `adequacy`      |  6%    | length in a sweet spot (not one word, not a wall) |
+//! | Slot          | Role        | Captures                                        |
+//! |---------------|-------------|-------------------------------------------------|
+//! | `objective`   | core (×)    | a positive, actionable goal − vague words       |
+//! | `grounding`   | core (×)    | concrete refs: paths, `func()`, idents, numbers |
+//! | `direction`   | core (×)    | acceptance · constraints · pre/post/IO/exception|
+//! | `context`     | enrichment  | background, goal/why, current state             |
+//! | `examples`    | enrichment  | examples, doctests, input→output illustrations  |
+//! | `structure`   | enrichment  | decomposition — bullets, steps, headings        |
+//! | `diversity`   | enrichment  | lexical richness (adaptive MATTR)               |
+//! | `clarity`     | enrichment  | readability in a target band (trapezoid)        |
+//! | `adequacy`    | enrichment  | authored length in a sweet spot                 |
 //!
-//! On top of the weighted sum sit **anti-gaming guards** (locked with codex):
-//! per-category keyword caps, a repetition penalty, hard length caps, and
-//! *balance gates* — a keyword-stuffed but context-free prompt is capped at 69
-//! so it can never read as "advanced".
+//! On top sit **anti-gaming guards**: per-category keyword caps, a repetition
+//! penalty, a vagueness penalty (folded into the core), a single short-prompt
+//! floor, and a saturating **evidence** bonus for attached machine output. The
+//! multiplicative core means a prompt empty on any necessary axis is *capped*
+//! with no special-case gate — a keyword-stuffed but ungrounded prompt can never
+//! read as "advanced". Prompts the heuristics can't assess (no authored request,
+//! non-English) are **abstained** on rather than mis-scored.
 //!
 //! # Artifact segmentation (v2) — craft ≠ paste volume
 //!
@@ -94,83 +103,148 @@
 
 use std::collections::{HashMap, HashSet};
 
-// ── Weights ──────────────────────────────────────────────────────────────────
+// ── Aggregation model (v2) ─────────────────────────────────────────────────────
+//
+// v1 was a flat weighted sum of seven sub-signals plus a stack of special-case
+// caps (the 69/79 "balance gates", the tactical exemption, tiered length caps).
+// v2 replaces both with a **slot rubric + multiplicative core** — the shape the
+// bug-report-quality (CTQRS) and code-gen prompt-guideline literature
+// (Midolo et al., arXiv 2601.13118) both converge on:
+//
+//   * Three **core slots** are *necessary* and combine **multiplicatively**, so
+//     a prompt cannot look mature on one axis while empty on another (this is
+//     what the balance gates hand-coded). Each slot is floored at [`CORE_MIN`]
+//     so a genuine weakness *caps* the score gracefully instead of zeroing it:
+//       - `objective`  — is there a positive, actionable goal? (not just "don't…")
+//       - `grounding`  — concrete references: paths, `func()`, idents, numbers
+//       - `direction`  — did they bound the agent: acceptance criteria,
+//                        constraints, and the pre/post/IO/exception contract
+//   * Five **enrichment signals** (context, examples, structure, diversity,
+//     clarity, adequacy) form an *additive lift* above a floor of
+//     [`ENRICHMENT_BASE`]: they can only raise a prompt that already has a solid
+//     core, never rescue one that doesn't.
+//   * A **repetition** multiplier and a **vagueness** penalty (folded into
+//     `objective`) defeat keyword-farming; an **evidence** bonus (outside the
+//     composite, saturating) credits attached machine output — see the
+//     artifact-segmentation docs above.
+//
+// The tactical exemption falls out for free: `context` is enrichment, not core,
+// so a concrete + bounded ask with no "why" keeps its core and simply forgoes
+// the context lift — no special case needed.
+//
+// TODO(empirical-calibration, v2): the slot weights, [`CORE_MIN`], and
+// [`ENRICHMENT_BASE`] are still *normative* (hand-tuned; the enrichment/direction
+// weights seeded from the guideline-prevalence rates in arXiv 2601.13118 — I/O
+// format 44%, post-conditions 23%, requirements 19%, …). They are an explainable
+// proxy, not a validated model. `PromptScoreBreakdown` exposes every slot per
+// prompt, so a future PR can join them against h5i's per-commit outcome signals
+// (test pass/fail, review-flag score, churn, later reverts) and *learn* the
+// weights while keeping the features explainable. Do NOT regress from a tiny
+// biased sample — that needs a corpus and confound controls.
 
-// TODO(empirical-calibration, v2): these weights — and the gate thresholds in
-// `score_prompt` — are *normative* (hand-tuned, locked with codex). They are an
-// explainable proxy, not a validated model. The `PromptScoreBreakdown` features
-// are already exposed per prompt, so a future PR can join them against h5i's
-// existing per-commit outcome signals — test pass/fail (`metadata::TestMetrics`),
-// review-flag score (`ReviewPoint`), diff churn, and later reverts — over a real
-// commit corpus and *learn* / validate these weights while keeping the features
-// explainable. Do NOT regress from a tiny biased sample: that needs a corpus and
-// confound controls (a senior writes good prompts AND good code). No durable
-// schema change belongs here — feature persistence is its own design.
+/// Per-factor floor for the three core slots. A core slot at 0 still contributes
+/// `CORE_MIN` to the geometric-mean core, so a single missing axis caps the
+/// score rather than annihilating it (an all-empty core equals `CORE_MIN`).
+pub const CORE_MIN: f64 = 0.18;
 
-/// Relative weights of the seven sub-signals. Sums to 1.0 (asserted in tests).
-/// Specificity and control dominate (they are what a manager actually wants to
-/// see — "the engineer was concrete and bounded the agent"); the
-/// readability-derived `clarity` band is the smallest voice because it is the
-/// signal most likely to mislead on technical text.
-pub const WEIGHTS: Weights = Weights {
-    specificity: 0.24,
-    control: 0.24,
-    context: 0.18,
-    structure: 0.10,
-    diversity: 0.10,
-    clarity: 0.08,
-    adequacy: 0.06,
-};
+/// Floor of the enrichment lift: a prompt with a perfect core but zero
+/// enrichment still keeps this fraction of its core-driven score. Enrichment
+/// fills the remaining `1 - ENRICHMENT_BASE`.
+pub const ENRICHMENT_BASE: f64 = 0.63;
+
+/// Prompts under this many *authored* words can't fully specify a coding task;
+/// their score is capped at [`SHORT_PROMPT_CAP`]. Replaces v1's tiered word caps
+/// with a single gentle floor so crisp 8–15 word tactical asks can still breathe.
+const SHORT_PROMPT_WORDS: usize = 6;
+const SHORT_PROMPT_CAP: f64 = 35.0;
+
+/// Branch-roll-up shrinkage: the neutral prior a small sample is pulled toward,
+/// and its strength in prompt-equivalents. At `n` scored prompts the branch
+/// score is `(STRENGTH·PRIOR + n·mean) / (STRENGTH + n)` — so 1 prompt is pulled
+/// strongly toward the prior, ~10 prompts barely at all.
+pub const BRANCH_PRIOR_MEAN: f64 = 50.0;
+pub const BRANCH_PRIOR_STRENGTH: f64 = 2.5;
 
 /// Maximum bonus points the `evidence` signal can add to the composite.
 /// Attaching machine output (a log, trace, diff, or fenced block) is good
 /// grounding practice, so it earns a small fixed credit — deliberately a
-/// *bonus outside the weighted sum* so its absence never penalises the many
-/// prompts that have no artifact to attach, and deliberately saturating so it
-/// can never scale with paste volume.
+/// *bonus outside the composite* so its absence never penalises the many prompts
+/// that have no artifact to attach, and deliberately saturating so it can never
+/// scale with paste volume.
 pub const EVIDENCE_BONUS_MAX: f64 = 5.0;
 
-/// Weighting of the seven sub-signals. See [`WEIGHTS`].
+/// Relative weights of the six enrichment signals (the additive lift above the
+/// multiplicative core). Sums to 1.0 (asserted in tests). Seeded from the
+/// guideline-prevalence rates in arXiv 2601.13118 where they map (I/O format and
+/// examples are the most impactful enrichers observed there).
+pub const ENRICHMENT: EnrichmentWeights = EnrichmentWeights {
+    context: 0.30,
+    examples: 0.20,
+    structure: 0.20,
+    diversity: 0.12,
+    clarity: 0.10,
+    adequacy: 0.08,
+};
+
+/// Weighting of the six enrichment signals. See [`ENRICHMENT`].
 #[derive(Debug, Clone, Copy)]
-pub struct Weights {
-    pub specificity: f64,
-    pub control: f64,
+pub struct EnrichmentWeights {
     pub context: f64,
+    pub examples: f64,
     pub structure: f64,
     pub diversity: f64,
     pub clarity: f64,
     pub adequacy: f64,
 }
 
-impl Weights {
+impl EnrichmentWeights {
+    /// The additive enrichment lift in `0.0..=1.0` for one breakdown.
+    fn lift(&self, b: &PromptScoreBreakdown) -> f64 {
+        (self.context * b.context
+            + self.examples * b.examples
+            + self.structure * b.structure
+            + self.diversity * b.diversity
+            + self.clarity * b.clarity
+            + self.adequacy * b.adequacy)
+            .clamp(0.0, 1.0)
+    }
+
     #[cfg(test)]
     fn sum(&self) -> f64 {
-        self.specificity
-            + self.control
-            + self.context
-            + self.structure
-            + self.diversity
-            + self.clarity
-            + self.adequacy
+        self.context + self.examples + self.structure + self.diversity + self.clarity + self.adequacy
     }
 }
 
 // ── Public result types ──────────────────────────────────────────────────────
 
-/// The seven normalised sub-signals (`0.0..=1.0`) plus the raw readability
-/// numbers, retained for transparent display.
+/// The normalised sub-signals (`0.0..=1.0`) plus the raw readability numbers,
+/// retained for transparent display. The first three are the multiplicative
+/// **core slots**; the next six are the additive **enrichment** signals;
+/// `evidence` is a saturating bonus outside the composite.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PromptScoreBreakdown {
-    pub specificity: f64,
-    pub control: f64,
+    /// Core: a positive, actionable goal is stated (not merely prohibitions).
+    pub objective: f64,
+    /// Core: concrete references — paths, `func()`, identifiers, numbers.
+    pub grounding: f64,
+    /// Core: the agent is bounded — acceptance criteria, constraints, and the
+    /// pre/post-condition · I/O-format · exception contract.
+    pub direction: f64,
+    /// Enrichment: background / why / current state.
     pub context: f64,
+    /// Enrichment: examples, doctests, input→output illustrations.
+    pub examples: f64,
+    /// Enrichment: decomposition — bullets, numbered steps, headings.
     pub structure: f64,
+    /// Enrichment: lexical richness (adaptive MATTR).
     pub diversity: f64,
+    /// Enrichment: readability in a target band (trapezoid).
     pub clarity: f64,
+    /// Enrichment: authored length in a sweet spot.
     pub adequacy: f64,
     /// Evidence signal (`0.0..=1.0`): pasted machine output / fenced blocks
     /// attached (0.7) and explicitly framed by the authored prose (up to 1.0).
-    /// A *bonus* signal — not part of the weighted sum; it adds up to
+    /// A *bonus* signal — not part of the composite; it adds up to
     /// [`EVIDENCE_BONUS_MAX`] points on top and its absence costs nothing.
     pub evidence: f64,
     /// Raw Flesch Reading Ease (≈0–100, higher = easier). Display-only.
@@ -184,9 +258,11 @@ pub struct PromptScoreBreakdown {
 impl PromptScoreBreakdown {
     fn zero() -> Self {
         PromptScoreBreakdown {
-            specificity: 0.0,
-            control: 0.0,
+            objective: 0.0,
+            grounding: 0.0,
+            direction: 0.0,
             context: 0.0,
+            examples: 0.0,
             structure: 0.0,
             diversity: 0.0,
             clarity: 0.0,
@@ -196,6 +272,16 @@ impl PromptScoreBreakdown {
             fk_grade: 0.0,
             gunning_fog: 0.0,
         }
+    }
+
+    /// The multiplicative core in `[CORE_MIN, 1]`: the **geometric mean** of the
+    /// three core slots, each floored at [`CORE_MIN`]. Geometric (not raw
+    /// product) so three healthy-but-imperfect slots don't over-compound to a
+    /// tiny number, while a single weak slot still drags the whole core down and
+    /// a missing one floors it at `CORE_MIN`.
+    fn core(&self) -> f64 {
+        let floor = |x: f64| CORE_MIN + (1.0 - CORE_MIN) * x.clamp(0.0, 1.0);
+        (floor(self.objective) * floor(self.grounding) * floor(self.direction)).cbrt()
     }
 }
 
@@ -262,6 +348,9 @@ pub enum Flag {
     /// The prompt is dominated by pasted machine output (log / trace / diff)
     /// with only a thin authored ask around it.
     MostlyPaste,
+    /// Constraints / prohibitions but no positive, actionable goal — "don't do
+    /// X" with no "do Y". (arXiv 2601.13118 / OpenAI: say what to do.)
+    NoObjective,
 }
 
 impl Flag {
@@ -274,6 +363,7 @@ impl Flag {
             Flag::Repetitive => "repetitive",
             Flag::HardToScan => "hard to scan",
             Flag::MostlyPaste => "mostly pasted output",
+            Flag::NoObjective => "no clear objective",
         }
     }
 }
@@ -281,7 +371,9 @@ impl Flag {
 /// Score for a single prompt.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PromptScore {
-    /// Composite maturity score, `0.0..=100.0` (after guards & caps).
+    /// Composite maturity score, `0.0..=100.0`. `0.0` when [`unscored`] is set.
+    ///
+    /// [`unscored`]: PromptScore::unscored
     pub score: f64,
     pub level: MaturityLevel,
     pub breakdown: PromptScoreBreakdown,
@@ -290,6 +382,18 @@ pub struct PromptScore {
     pub words: usize,
     /// Up to two diagnostic flags, weakest dimension first.
     pub flags: Vec<Flag>,
+    /// When `Some(reason)`, the prompt was **not assessable** as prompt craft
+    /// (no authored request, or non-English / unsupported text) and the score is
+    /// a placeholder `0.0` that callers should render as "unscored", not as a
+    /// bad score. Abstaining beats confidently mis-scoring text the heuristics
+    /// don't cover.
+    pub unscored: Option<&'static str>,
+}
+
+impl PromptScore {
+    pub fn is_unscored(&self) -> bool {
+        self.unscored.is_some()
+    }
 }
 
 /// Branch-level roll-up across every AI-commit prompt.
@@ -338,62 +442,44 @@ impl BranchPromptScore {
 /// Score a single prompt string.
 pub fn score_prompt(prompt: &str) -> PromptScore {
     let f = Features::extract(prompt);
-    if f.words == 0 {
-        // No authored prose at all. A pure artifact paste still shows its
-        // evidence signal (and earns the bonus alone), but there is no craft
-        // to score.
-        let mut breakdown = PromptScoreBreakdown::zero();
-        breakdown.evidence = f.evidence_signal();
-        let score = (EVIDENCE_BONUS_MAX * breakdown.evidence).clamp(0.0, 100.0);
-        let mut flags = vec![Flag::TooShort];
-        if f.artifact_lines > 0 {
-            flags.push(Flag::MostlyPaste);
-        }
+
+    // ── Abstention: refuse to score what the heuristics don't cover ──────────
+    // Better an honest "unscored (reason)" than a confident wrong number.
+    if let Some(reason) = f.unscored_reason() {
         return PromptScore {
-            score,
-            level: MaturityLevel::from_score(score),
-            breakdown,
-            words: 0,
-            flags,
+            score: 0.0,
+            level: MaturityLevel::Nascent,
+            breakdown: PromptScoreBreakdown::zero(),
+            words: f.words,
+            flags: Vec::new(),
+            unscored: Some(reason),
         };
     }
 
     let breakdown = f.breakdown();
 
-    // Weighted sum → 0..100.
-    let w = &WEIGHTS;
-    let mut score = 100.0
-        * (breakdown.specificity * w.specificity
-            + breakdown.control * w.control
-            + breakdown.context * w.context
-            + breakdown.structure * w.structure
-            + breakdown.diversity * w.diversity
-            + breakdown.clarity * w.clarity
-            + breakdown.adequacy * w.adequacy);
+    // ── Multiplicative core × additive enrichment lift ──────────────────────
+    // core ∈ [CORE_MIN^3, 1]; lift ∈ [ENRICHMENT_BASE, 1]. A weak core slot caps
+    // the whole score (no balance gate needed); enrichment only lifts an already
+    // solid core.
+    let core = breakdown.core();
+    let lift = ENRICHMENT_BASE + (1.0 - ENRICHMENT_BASE) * ENRICHMENT.lift(&breakdown);
+    let mut score = 100.0 * core * lift;
 
-    // ── Anti-gaming guards ──────────────────────────────────────────────────
-    // (1) Repetition penalty: a prompt that farms keywords by repeating phrases
-    //     ("must test format must test format") is multiplied down.
+    // (1) Repetition penalty — phrase-farming ("must test format must test
+    //     format") is multiplied down.
     score *= f.repetition_factor;
 
-    // (2) Balance gates — you cannot look mature on one axis alone.
-    score = apply_balance_gates(score, &breakdown);
-
-    // (3) Hard length caps — short prompts can't score high no matter how many
-    //     keywords they pack.
-    if f.words < 8 {
-        score = score.min(20.0);
-    } else if f.words < 15 {
-        score = score.min(45.0);
-    } else if f.words > 1200 && breakdown.structure < 0.6 {
-        // a 1200+ word unstructured wall is a dump, not a mature prompt
-        score = score.min(75.0);
+    // (2) Short-prompt floor — under a handful of authored words you can't fully
+    //     specify a coding task, however many keywords are packed in.
+    if f.words < SHORT_PROMPT_WORDS {
+        score = score.min(SHORT_PROMPT_CAP);
     }
 
-    // (4) Evidence bonus — attached machine output is grounding, not craft:
-    //     a small fixed credit on top, saturating (never scales with paste
-    //     volume) and applied *after* the caps so a lazy one-liner around a
-    //     log wall stays capped as the one-liner it is.
+    // (3) Evidence bonus — attached machine output is grounding, not craft: a
+    //     small fixed credit on top, saturating (never scales with paste
+    //     volume) and applied last so a lazy one-liner around a log wall can't
+    //     ride the paste into a higher band.
     score += EVIDENCE_BONUS_MAX * breakdown.evidence;
 
     let score = score.clamp(0.0, 100.0);
@@ -404,6 +490,7 @@ pub fn score_prompt(prompt: &str) -> PromptScore {
         words: f.words,
         breakdown,
         score,
+        unscored: None,
     }
 }
 
@@ -417,7 +504,14 @@ pub fn score_prompt(prompt: &str) -> PromptScore {
 /// (weight `= clamp(words, 20, 250)`), so a single rambling prompt can't
 /// dominate and a disciplined engineer is rewarded for every crisp ask. Prompts
 /// are **never concatenated** — concatenation lets many weak prompts look mature
-/// by pooling vocabulary and structure.
+/// by pooling vocabulary and structure. **Unscored** prompts (no authored
+/// request, non-English) are dropped from the mean but still count against
+/// coverage.
+///
+/// The mean is then **shrunk toward a neutral prior** ([`BRANCH_PRIOR_MEAN`],
+/// pseudo-count [`BRANCH_PRIOR_STRENGTH`]) so a branch with only one or two
+/// prompts can't be crowned or condemned on a tiny sample: three great prompts
+/// pull most of the way to their mean, one great prompt only part way.
 pub fn score_branch<I, S>(prompts: I, ai_commits: usize) -> BranchPromptScore
 where
     I: IntoIterator<Item = S>,
@@ -427,6 +521,7 @@ where
         .into_iter()
         .filter(|p| !p.as_ref().trim().is_empty())
         .map(|p| score_prompt(p.as_ref()))
+        .filter(|s| !s.is_unscored())
         .collect();
 
     if scored.is_empty() {
@@ -447,9 +542,11 @@ where
     };
 
     let breakdown = PromptScoreBreakdown {
-        specificity: wmean_b(&|b| b.specificity),
-        control: wmean_b(&|b| b.control),
+        objective: wmean_b(&|b| b.objective),
+        grounding: wmean_b(&|b| b.grounding),
+        direction: wmean_b(&|b| b.direction),
         context: wmean_b(&|b| b.context),
+        examples: wmean_b(&|b| b.examples),
         structure: wmean_b(&|b| b.structure),
         diversity: wmean_b(&|b| b.diversity),
         clarity: wmean_b(&|b| b.clarity),
@@ -459,7 +556,13 @@ where
         fk_grade: wmean_b(&|b| b.fk_grade),
         gunning_fog: wmean_b(&|b| b.gunning_fog),
     };
-    let score = wmean(&|s| s.score);
+    // Empirical-Bayes shrinkage toward a neutral prior: with `n` scored prompts,
+    // pull the length-weighted mean toward BRANCH_PRIOR_MEAN with weight
+    // BRANCH_PRIOR_STRENGTH (in prompt-equivalents). Stabilises small samples.
+    let raw = wmean(&|s| s.score);
+    let n = scored.len() as f64;
+    let score = (BRANCH_PRIOR_STRENGTH * BRANCH_PRIOR_MEAN + n * raw)
+        / (BRANCH_PRIOR_STRENGTH + n);
 
     // Coverage / confidence.
     let denom = ai_commits.max(scored.len());
@@ -502,22 +605,36 @@ struct Features {
     sentences: usize,
     syllables: usize,
     polysyllables: usize,
-    // ── concreteness inputs ──
+    // ── concreteness / grounding inputs ──
     code_refs: usize,
     quoted: usize,
     numbers: usize,
     action_verbs: usize,
     weak_words: usize,
+    grounding_refs: usize,
+    // ── objective inputs ──
+    /// Imperative opener ("Add …", "Fix …") — a positive directive up front.
+    imperative_open: bool,
     // ── context inputs ──
     context_markers: usize,
-    grounding_refs: usize,
-    // ── control inputs ──
-    constraints: usize,
+    // ── direction inputs ──
+    strong_constraints: usize,
+    soft_constraints: usize,
+    negative_directives: usize,
     output_shape: usize,
     verification: usize,
+    /// A named, runnable acceptance check ("done when `cargo test` passes").
+    executable_acceptance: bool,
+    preconditions: usize,
+    postconditions: usize,
+    exceptions: usize,
     edge_cases: usize,
     safety: usize,
     scope: usize,
+    ambiguous_cond: usize,
+    // ── examples inputs ──
+    example_markers: usize,
+    arrows: usize,
     // ── structure inputs ──
     bullets: usize,
     numbered: usize,
@@ -525,6 +642,9 @@ struct Features {
     code_fences: usize,
     // ── anti-gaming ──
     repetition_factor: f64,
+    /// Fraction of authored prose tokens that are English function words — the
+    /// natural-language discriminator (NLoN). Drives non-English abstention.
+    stopword_ratio: f64,
     // ── artifact / evidence inputs ──
     /// Lines classified as pasted machine output (logs, traces, diffs, fenced
     /// block interiors).
@@ -572,6 +692,15 @@ impl Features {
         // (not code-masked spans) score.
         let lower_counts = word_counts(&lower);
 
+        // Fraction of prose tokens that are English function words (NLoN's
+        // strongest NL discriminator) — near-zero on non-English / code-soup text.
+        let stopword_ratio = if prose_tokens.is_empty() {
+            0.0
+        } else {
+            prose_tokens.iter().filter(|w| LINE_STOPWORDS.contains(&w.as_str())).count() as f64
+                / prose_tokens.len() as f64
+        };
+
         Features {
             code_refs: count_code_refs(text),
             quoted: text.matches('`').count() / 2 + text.matches('"').count() / 2,
@@ -581,18 +710,29 @@ impl Features {
                 .count(),
             action_verbs: lexicon_hits(&lower, &lower_counts, &word_set, ACTION_VERBS),
             weak_words: lexicon_hits(&lower, &lower_counts, &word_set, WEAK_WORDS),
-            context_markers: lexicon_hits(&lower, &lower_counts, &word_set, CONTEXT_MARKERS),
             grounding_refs: lexicon_hits(&lower, &lower_counts, &word_set, GROUNDING_REFS),
-            constraints: lexicon_hits(&lower, &lower_counts, &word_set, CONSTRAINTS),
+            imperative_open: opens_with_imperative(text),
+            context_markers: lexicon_hits(&lower, &lower_counts, &word_set, CONTEXT_MARKERS),
+            strong_constraints: lexicon_hits(&lower, &lower_counts, &word_set, STRONG_CONSTRAINTS),
+            soft_constraints: lexicon_hits(&lower, &lower_counts, &word_set, SOFT_CONSTRAINTS),
+            negative_directives: lexicon_hits(&lower, &lower_counts, &word_set, NEGATIVE_DIRECTIVES),
             output_shape: lexicon_hits(&lower, &lower_counts, &word_set, OUTPUT_SHAPE),
             verification: lexicon_hits(&lower, &lower_counts, &word_set, VERIFICATION),
+            executable_acceptance: lower_matches_any(&lower, RUNNERS),
+            preconditions: lexicon_hits(&lower, &lower_counts, &word_set, PRECONDITIONS),
+            postconditions: lexicon_hits(&lower, &lower_counts, &word_set, POSTCONDITIONS),
+            exceptions: lexicon_hits(&lower, &lower_counts, &word_set, EXCEPTIONS),
             edge_cases: lexicon_hits(&lower, &lower_counts, &word_set, EDGE_CASES),
             safety: lexicon_hits(&lower, &lower_counts, &word_set, SAFETY),
             scope: lexicon_hits(&lower, &lower_counts, &word_set, SCOPE),
+            ambiguous_cond: lexicon_hits(&lower, &lower_counts, &word_set, AMBIGUOUS_COND),
+            example_markers: lexicon_hits(&lower, &lower_counts, &word_set, EXAMPLE_MARKERS),
+            arrows: count_arrows(text),
             evidence_refs: lexicon_hits(&lower, &lower_counts, &word_set, EVIDENCE_REFS),
             artifact_lines: seg.artifact_lines,
             authored_lines: seg.authored_lines,
             repetition_factor: repetition_factor(&prose_tokens),
+            stopword_ratio,
             bullets,
             numbered,
             headings,
@@ -609,30 +749,66 @@ impl Features {
         let n = self.words.max(1) as f64;
         let per100 = |count: usize| (count as f64) / n * 100.0;
 
-        // ── Specificity = concreteness − vagueness ──────────────────────────
-        // Concreteness from capped category contributions (no single category
-        // can farm the whole signal).
-        let concreteness = 0.40 * cap_ratio(self.code_refs, 4)
-            + 0.22 * cap_ratio(self.action_verbs, 3)
-            + 0.20 * cap_ratio(self.quoted, 3)
-            + 0.18 * cap_ratio(self.numbers, 4);
         // Vagueness penalty from the NALABS/Femmer requirements-smell lexicon:
-        // density of weak words (per 100 words) drags the signal down.
+        // density of weak words (per 100 words) is a negative signal shared by
+        // objective and grounding.
         let vagueness = (per100(self.weak_words) / 8.0).clamp(0.0, 1.0);
-        let specificity = (concreteness - 0.5 * vagueness).clamp(0.0, 1.0);
 
-        // ── Context grounding ───────────────────────────────────────────────
-        let context = (0.60 * cap_ratio(self.context_markers, 4)
-            + 0.40 * cap_ratio(self.grounding_refs, 3))
+        // ── Core slot: objective — is there a positive, actionable goal? ─────
+        // A single clear action verb earns most of the credit; a second verb or
+        // an imperative opener tops it up. Leading with the problem statement
+        // ("The parser miscounts…") must NOT be penalised, so the opener is a
+        // bonus, not a requirement. Dragged down by vagueness; a prompt of pure
+        // prohibitions (no action verb) scores ~0 here, which the multiplicative
+        // core then turns into a real cap.
+        let objective = {
+            let base = if self.action_verbs == 0 {
+                0.0
+            } else {
+                0.6 + 0.2 * f64::from(self.action_verbs >= 2)
+                    + 0.2 * f64::from(self.imperative_open)
+            };
+            (base - 0.5 * vagueness).clamp(0.0, 1.0)
+        };
+
+        // ── Core slot: grounding — concrete references ──────────────────────
+        // Paths, `func()`, idents, quoted spans, numbers, and grounding nouns.
+        let grounding = (0.42 * cap_ratio(self.code_refs, 3)
+            + 0.18 * cap_ratio(self.quoted, 2)
+            + 0.12 * cap_ratio(self.numbers, 3)
+            + 0.28 * cap_ratio(self.grounding_refs, 2)
+            - 0.4 * vagueness)
+            .clamp(0.0, 1.0);
+
+        // ── Core slot: direction — did they bound the agent? ────────────────
+        // Acceptance (a runnable check beats a bare "ensure"), constraints
+        // (must-class weighted over should-class), and the behavioral contract
+        // (I/O format · post- · pre-conditions · exceptions — weights seeded
+        // from arXiv 2601.13118 prevalence). "Otherwise"-style ambiguous
+        // conditionals dock a little.
+        let acceptance = (0.6 * cap_ratio(self.verification, 3)
+            + 0.4 * f64::from(self.executable_acceptance))
         .clamp(0.0, 1.0);
+        let constraint_sig = (0.7 * cap_ratio(self.strong_constraints, 3)
+            + 0.3 * cap_ratio(self.soft_constraints, 2)
+            + 0.15 * cap_ratio(self.scope, 2))
+        .clamp(0.0, 1.0);
+        let contract = (0.36 * cap_ratio(self.output_shape, 3)
+            + 0.24 * cap_ratio(self.postconditions, 2)
+            + 0.20 * cap_ratio(self.preconditions, 2)
+            + 0.20 * cap_ratio(self.exceptions + self.edge_cases + self.safety, 2))
+        .clamp(0.0, 1.0);
+        let ambiguity = (0.15 * cap_ratio(self.ambiguous_cond, 2)).clamp(0.0, 1.0);
+        let direction = (0.42 * acceptance + 0.34 * constraint_sig + 0.24 * contract
+            - ambiguity)
+            .clamp(0.0, 1.0);
 
-        // ── Control / specification ─ reward breadth of categories hit ───────
-        let control = (0.26 * cap_ratio(self.constraints, 4)
-            + 0.22 * cap_ratio(self.verification, 3)
-            + 0.20 * cap_ratio(self.output_shape, 3)
-            + 0.14 * cap_ratio(self.edge_cases, 2)
-            + 0.10 * cap_ratio(self.scope, 2)
-            + 0.08 * cap_ratio(self.safety, 2))
+        // ── Enrichment: context grounding (background / why) ────────────────
+        let context = cap_ratio(self.context_markers, 4).clamp(0.0, 1.0);
+
+        // ── Enrichment: examples / illustrations ────────────────────────────
+        let examples = (0.6 * cap_ratio(self.example_markers, 2)
+            + 0.4 * cap_ratio(self.arrows, 2))
         .clamp(0.0, 1.0);
 
         // ── Structure / decomposition ───────────────────────────────────────
@@ -662,9 +838,11 @@ impl Features {
         let evidence = self.evidence_signal();
 
         PromptScoreBreakdown {
-            specificity,
-            control,
+            objective,
+            grounding,
+            direction,
             context,
+            examples,
             structure,
             diversity,
             clarity,
@@ -687,6 +865,23 @@ impl Features {
         0.7 + 0.3 * cap_ratio(self.evidence_refs, 2)
     }
 
+    /// Reason to **abstain** from scoring, or `None` if the prompt is assessable.
+    /// Narrow by design — very short *English* asks stay scored (and score low
+    /// with advice); we only refuse text the heuristics genuinely don't cover.
+    fn unscored_reason(&self) -> Option<&'static str> {
+        if self.words == 0 {
+            // Pure paste, punctuation, or empty — no authored request to assess.
+            return Some("no authored request");
+        }
+        // Substantial text with almost no English function words is not English
+        // (or is code-soup that survived masking): the lexicon/readability
+        // signals are meaningless on it, so abstain rather than mis-score.
+        if self.words >= 8 && self.stopword_ratio < 0.05 {
+            return Some("non-English or unsupported text");
+        }
+        None
+    }
+
     /// Up to two diagnostic flags, weakest qualifying dimension first.
     fn flags(&self, b: &PromptScoreBreakdown) -> Vec<Flag> {
         let mut out = Vec::new();
@@ -702,11 +897,17 @@ impl Features {
         {
             out.push(Flag::MostlyPaste);
         }
-        // Candidate (signal, flag) pairs, lowest signal surfaced first.
+        // Prohibitions with no positive goal: constraints present but objective
+        // essentially absent. Surfaced ahead of the generic weak-signal flags.
+        if b.objective < 0.2 && self.negative_directives >= 1 && out.len() < 2 {
+            out.push(Flag::NoObjective);
+        }
+        // Candidate (signal, flag) pairs, lowest signal surfaced first. The core
+        // slots map to the actionable flags; grounding+objective share "vague".
         let mut cands: Vec<(f64, Flag)> = vec![
-            (b.specificity, Flag::Vague),
+            (b.objective.max(b.grounding), Flag::Vague),
             (b.context, Flag::WeakContext),
-            (b.control, Flag::WeakVerification),
+            (b.direction, Flag::WeakVerification),
         ];
         if self.repetition_factor < 0.9 {
             cands.push((b.diversity.min(self.repetition_factor), Flag::Repetitive));
@@ -719,7 +920,7 @@ impl Features {
             if out.len() >= 2 {
                 break;
             }
-            if sig < 0.35 {
+            if sig < 0.35 && !out.contains(&fl) {
                 out.push(fl);
             }
         }
@@ -737,7 +938,12 @@ impl Features {
 const ACTION_VERBS: &[&str] = &[
     "implement", "fix", "refactor", "add", "remove", "delete", "update", "design",
     "build", "create", "write", "migrate", "debug", "optimize", "rename", "extract",
-    "replace", "wire", "integrate", "parse", "render", "validate", "handle",
+    "replace", "wire", "integrate", "parse", "render", "validate", "handle", "edit",
+    "ensure", "support", "improve", "convert", "move", "split", "guard", "harden",
+    "sanitize", "reject", "return", "cache", "expose", "document", "cover", "port",
+    "upgrade", "patch", "register", "normalize", "serialize", "deserialize", "strip",
+    "compute", "check", "enforce", "apply", "disable", "enable", "configure",
+    "extend", "adjust", "drop", "wrap", "cap", "emit", "escape", "trim", "raise",
 ];
 
 /// NALABS / Femmer "requirements smells" — vague, subjective, or non-actionable
@@ -763,10 +969,59 @@ const GROUNDING_REFS: &[&str] = &[
     "manager",
 ];
 
-const CONSTRAINTS: &[&str] = &[
-    "must", "should", "only", "without", "avoid", "never", "always", "do not",
-    "don't", "dont", "at least", "at most", "no more than", "limit", "require",
-    "offline", "keep", "preserve", "backward", "compatible", "minimal",
+/// Strong (imperative) constraints — "must"-class. Weighted above the soft
+/// class in `direction` (arXiv 2601.13118 / OpenAI: prefer assertive language).
+const STRONG_CONSTRAINTS: &[&str] = &[
+    "must", "only", "without", "avoid", "never", "always", "do not", "don't",
+    "dont", "at least", "at most", "no more than", "limit", "require", "required",
+    "offline", "backward", "compatible", "minimal",
+];
+
+/// Soft constraints — "should"-class, hedged. Real but weaker bounding.
+const SOFT_CONSTRAINTS: &[&str] = &[
+    "should", "prefer", "preferably", "try to", "ideally", "keep", "preserve",
+];
+
+/// Negative directives — the "don't do X" prohibitions. Used to detect
+/// prohibitions-without-objective (the `NoObjective` flag).
+const NEGATIVE_DIRECTIVES: &[&str] =
+    &["without", "avoid", "never", "do not", "don't", "dont", "no unrelated", "don't change"];
+
+/// Pre-conditions — assumptions that must hold on the input before execution.
+const PRECONDITIONS: &[&str] = &[
+    "precondition", "assume", "assumes", "assuming", "given that", "input is",
+    "when the input", "must be non-empty", "expects", "requires that", "invariant",
+];
+
+/// Post-conditions — guarantees on the output/result after execution.
+const POSTCONDITIONS: &[&str] = &[
+    "postcondition", "should return", "must return", "returns", "result is",
+    "guarantee", "guarantees", "ensures that", "resulting", "so that the result",
+    "the output should",
+];
+
+/// Exception / error-handling behaviour the agent must specify.
+const EXCEPTIONS: &[&str] = &[
+    "raise", "throw", "throws", "exception", "panic", "error case", "on error",
+    "fail with", "return an error", "handle the error", "err(", "result<",
+];
+
+/// Ambiguous conditionals — the "otherwise"-style smell (arXiv 2601.13118):
+/// a branch that refers to an unstated second condition.
+const AMBIGUOUS_COND: &[&str] = &["otherwise", "or else", "if not", "as appropriate"];
+
+/// Example / illustration markers.
+const EXAMPLE_MARKERS: &[&str] = &[
+    "for example", "e.g.", "example:", "examples:", "for instance", "such as",
+    "sample", "doctest", "input:", "output:", "expected output", "given input",
+];
+
+/// Runnable acceptance checks — a named command the agent can execute to know
+/// it is done. A far stronger acceptance signal than the word "ensure".
+const RUNNERS: &[&str] = &[
+    "cargo test", "cargo build", "cargo clippy", "npm test", "npm run", "yarn ",
+    "pytest", "go test", "make ", "./", "mvn ", "gradle", "done when", "done-when",
+    "acceptance criteria", "ci passes", "the test passes", "tests pass",
 ];
 
 const OUTPUT_SHAPE: &[&str] = &[
@@ -804,6 +1059,40 @@ const EVIDENCE_REFS: &[&str] = &[
     "the backtrace", "the stack trace", "this diff", "the diff", "stderr",
     "stdout", "error message", "test output", "the failure", "this failure",
 ];
+
+// ── Slot detector helpers ────────────────────────────────────────────────────
+
+/// True if any entry (a phrase or word, matched as a substring) is present in
+/// the lowercased text. For multi-token acceptance/runner phrases.
+fn lower_matches_any(lower: &str, lex: &[&str]) -> bool {
+    lex.iter().any(|e| lower.contains(e))
+}
+
+/// Does the prompt (or one of its first bulleted/numbered lines) open with an
+/// imperative action verb? A positive directive up front — "Add …", "Fix …",
+/// "Refactor …" — is the clearest signal of a stated objective.
+fn opens_with_imperative(text: &str) -> bool {
+    for raw in text.lines().take(6) {
+        let l = raw.trim_start();
+        // Strip a leading bullet / number marker so "1. Add the struct" counts.
+        let l = l
+            .trim_start_matches(|c: char| {
+                matches!(c, '-' | '*' | '•' | '+' | '#' | '.' | ')' | '(')
+                    || c.is_ascii_digit()
+                    || c.is_whitespace()
+            });
+        let first = l.split(|c: char| !c.is_ascii_alphabetic()).next().unwrap_or("");
+        if !first.is_empty() && ACTION_VERBS.contains(&first.to_ascii_lowercase().as_str()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Count input→output arrows (`->`, `=>`, `⇒`) — a compact example/spec form.
+fn count_arrows(text: &str) -> usize {
+    text.matches("->").count() + text.matches("=>").count() + text.matches('⇒').count()
+}
 
 // ── Artifact segmentation ────────────────────────────────────────────────────
 //
@@ -1548,34 +1837,6 @@ fn clarity_band(fk_grade: f64, flesch: f64, words: usize) -> f64 {
     ((grade_fit + flesch_fit) / 2.0).clamp(0.0, 1.0)
 }
 
-/// Balance gates (v1.1, locked with the codex agent over i5h). You cannot look
-/// mature on one axis alone, but the policy distinguishes the two specification
-/// axes:
-///
-/// * `control` — *did the engineer bound the agent?* — is a **hard gate**: a
-///   prompt that sets no constraints / acceptance criteria is capped below
-///   "advanced" regardless of how concrete it is.
-/// * `context` — *did they explain why?* — is **soft**: a prompt that is already
-///   both specific (`>=0.6`) and bounded (`control>=0.5`) is a legitimate
-///   *tactical* ask ("run `cargo test`, fix the clippy warning in `src/foo.rs`")
-///   and must not be dragged into mediocrity merely for omitting background —
-///   the agent often already holds the repo / h5i context. Weak context still
-///   surfaces as a flag; it just no longer hard-caps a crisp tactical prompt.
-///
-/// A low specificity additionally caps at 79 (you can't be "exemplary" while
-/// vague).
-fn apply_balance_gates(score: f64, b: &PromptScoreBreakdown) -> f64 {
-    let tactical = b.specificity >= 0.6 && b.control >= 0.5;
-    let mut s = score;
-    if b.control < 0.35 || (b.context < 0.35 && !tactical) {
-        s = s.min(69.0);
-    }
-    if b.specificity < 0.45 {
-        s = s.min(79.0);
-    }
-    s
-}
-
 /// Trapezoid membership: 0 outside `[min,max]`, 1 on the `[ideal_min,ideal_max]`
 /// plateau, linear on the shoulders.
 fn trapezoid(v: f64, min: f64, ideal_min: f64, ideal_max: f64, max: f64) -> f64 {
@@ -1595,8 +1856,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn weights_sum_to_one() {
-        assert!((WEIGHTS.sum() - 1.0).abs() < 1e-9, "weights sum = {}", WEIGHTS.sum());
+    #[ignore]
+    fn diag_calibration() {
+        let cases = [
+            ("vague-make", "make it better"),
+            ("vague-fix", "fix the bug please"),
+            ("tactical", "Edit `foo()` in src/a.rs and `bar()` in src/b.rs. Must return JSON. Add tests and run `cargo test`. Do not change signatures. Only touch those two files."),
+            ("rich", "Refactor `parse_range()` in src/util.rs so it handles the off-by-one when the upper bound is inclusive. Add a unit test for the empty-range case and make sure the existing tests still pass. Do not change the public signature."),
+            ("loaded", "The nested-list parser miscounts children. Fix `parse_nested()` in src/parser.rs so a trailing separator does not produce a phantom child. Add a regression test covering the trailing-separator case and keep the public signature unchanged. Done when `cargo test parser::` passes."),
+            ("stuffed", "must must should ensure test test verify return format handle error case must test format must test format edge case must verify only"),
+            ("prohib", "Do not change the public signature. Never touch src/legacy.rs. Avoid adding new dependencies. Don't reformat unrelated code."),
+        ];
+        for (name, p) in cases {
+            let s = score_prompt(p);
+            let b = &s.breakdown;
+            println!(
+                "{name:10} score={:5.1} {:11} obj={:.2} grd={:.2} dir={:.2} ctx={:.2} ex={:.2} core={:.2}",
+                s.score, s.level.label(), b.objective, b.grounding, b.direction, b.context, b.examples, b.core()
+            );
+        }
+    }
+
+    #[test]
+    fn enrichment_weights_sum_to_one() {
+        assert!(
+            (ENRICHMENT.sum() - 1.0).abs() < 1e-9,
+            "enrichment weights sum = {}",
+            ENRICHMENT.sum()
+        );
     }
 
     #[test]
@@ -1643,63 +1930,77 @@ mod tests {
             rich.score,
             vague.score
         );
-        assert!(rich.breakdown.specificity > 0.4);
-        assert!(rich.breakdown.control > 0.3);
+        assert!(rich.breakdown.objective > 0.4);
+        assert!(rich.breakdown.grounding > 0.4);
+        assert!(rich.breakdown.direction > 0.3);
         assert!(rich.level >= MaturityLevel::Proficient);
     }
 
-    /// Build a breakdown with the three gate-relevant axes set and everything
-    /// else neutral — lets the gate policy be tested in isolation.
-    fn bd(specificity: f64, control: f64, context: f64) -> PromptScoreBreakdown {
+    /// Build a breakdown with the three multiplicative core slots set and
+    /// everything else neutral — lets the core policy be tested in isolation.
+    fn bd_core(objective: f64, grounding: f64, direction: f64) -> PromptScoreBreakdown {
         PromptScoreBreakdown {
-            specificity,
-            control,
-            context,
+            objective,
+            grounding,
+            direction,
             ..PromptScoreBreakdown::zero()
         }
     }
 
     #[test]
-    fn gate_control_is_a_hard_cap() {
-        // No constraints/acceptance → capped at 69 no matter how concrete.
-        assert_eq!(apply_balance_gates(90.0, &bd(0.9, 0.2, 0.9)), 69.0);
+    fn core_is_multiplicative_with_floor() {
+        // Geometric mean of three floored factors, ranging [CORE_MIN, 1]. A full
+        // core → 1.0; an all-empty one → CORE_MIN.
+        assert!((bd_core(1.0, 1.0, 1.0).core() - 1.0).abs() < 1e-9);
+        let empty = bd_core(0.0, 0.0, 0.0).core();
+        assert!((empty - CORE_MIN).abs() < 1e-9, "empty core {}", empty);
+        // A single weak slot caps the core below the two-strong-slots case.
+        assert!(bd_core(1.0, 1.0, 0.1).core() < bd_core(1.0, 1.0, 0.9).core());
     }
 
     #[test]
-    fn gate_weak_context_caps_a_non_tactical_prompt() {
-        // Thin on both context and specificity → capped.
-        assert_eq!(apply_balance_gates(85.0, &bd(0.5, 0.6, 0.1)), 69.0);
-    }
-
-    #[test]
-    fn gate_exempts_specific_and_bounded_tactical_prompt() {
-        // v1.1: specific (>=.6) AND bounded (control>=.5) with weak context is a
-        // legitimate tactical ask — NOT capped for missing "why".
-        assert_eq!(apply_balance_gates(85.0, &bd(0.7, 0.6, 0.1)), 85.0);
-        // …but if control slips below .5 it's no longer tactical → capped again.
-        assert_eq!(apply_balance_gates(85.0, &bd(0.7, 0.45, 0.1)), 69.0);
-    }
-
-    #[test]
-    fn gate_low_specificity_caps_at_79() {
-        assert_eq!(apply_balance_gates(95.0, &bd(0.4, 0.9, 0.9)), 79.0);
-    }
-
-    #[test]
-    fn tactical_prompt_keeps_weak_context_flag() {
-        // The exemption must not hide the diagnostic — a concrete, bounded,
-        // context-free prompt should still *flag* weak context even though it's
-        // no longer hard-capped.
+    fn missing_core_slot_caps_the_score() {
+        // No direction (unbounded) → score capped well under "advanced" no
+        // matter how concrete — this replaces the old hard control gate.
         let s = score_prompt(
-            "Harden `Invoice::finalize()` in src/billing.rs in three steps:\n\
-             - Reject a zero-quantity item by returning `Err(BillingError::EmptyLine)`.\n\
-             - Round each subtotal to two decimals, then sanitize the note to drop \
-               control characters.\n\
-             - Add focused checks: an empty item, a rounding boundary, and a \
-               happy-path total; assert the exact cents. Keep the signature stable \
-               and edit only billing.rs.",
+            "Refactor `parse_range()` in src/util.rs and rename the helper in \
+             src/helpers.rs to match the new module path.",
         );
-        assert!(s.breakdown.specificity >= 0.6 && s.breakdown.control >= 0.5);
+        assert!(s.breakdown.direction < 0.35, "direction {}", s.breakdown.direction);
+        assert!(s.score < 75.0, "unbounded prompt reached advanced: {}", s.score);
+    }
+
+    #[test]
+    fn tactical_prompt_survives_missing_context() {
+        // Concrete + bounded but no "why": context is *enrichment*, not core,
+        // so the multiplicative core keeps this a proficient tactical ask — the
+        // old tactical-exemption behaviour, now with no special case.
+        let s = score_prompt(
+            "Edit `foo()` in src/a.rs and `bar()` in src/b.rs. Must return JSON. \
+             Add tests and run `cargo test`. Do not change signatures. Only touch \
+             those two files.",
+        );
+        assert!(s.breakdown.context < 0.35, "should read as context-free");
+        assert!(
+            s.breakdown.objective >= 0.5 && s.breakdown.direction >= 0.4,
+            "should be concrete+bounded (obj {:.2}, dir {:.2})",
+            s.breakdown.objective,
+            s.breakdown.direction,
+        );
+        assert!(s.level >= MaturityLevel::Proficient, "tactical prompt scored {}", s.score);
+    }
+
+    #[test]
+    fn prohibitions_without_objective_flag_and_cap() {
+        // All "don't", no "do": low objective drags the core, and the smell is
+        // surfaced as a flag.
+        let s = score_prompt(
+            "Do not change the public signature. Never touch src/legacy.rs. Avoid \
+             adding new dependencies. Don't reformat unrelated code.",
+        );
+        assert!(s.breakdown.objective < 0.2, "objective {}", s.breakdown.objective);
+        assert!(s.flags.contains(&Flag::NoObjective), "flags {:?}", s.flags);
+        assert!(s.score < 50.0, "prohibitions-only scored {}", s.score);
     }
 
     #[test]
@@ -1708,29 +2009,35 @@ mod tests {
             "must must should ensure test test verify return format handle error \
              case must test format must test format edge case must verify only",
         );
-        // balance gate (no context) + repetition penalty keep it out of advanced
+        // No grounding (no code refs) → core capped; repetition penalty compounds.
         assert!(spam.score <= 69.0, "stuffed prompt scored {}", spam.score);
+        assert!(spam.breakdown.grounding < 0.35, "grounding {}", spam.breakdown.grounding);
     }
 
     #[test]
-    fn tactical_context_free_prompt_is_exempt_from_context_gate() {
-        // v1.1 end-to-end: this prompt is concrete AND bounded (tactical) but
-        // states no "why". The context gate must NOT cap it — verify the real
-        // feature profile is *exempt* (a high base score survives the gate),
-        // which is the opposite of the pre-v1.1 behavior.
-        let s = score_prompt(
-            "Edit `foo()` in src/a.rs and `bar()` in src/b.rs. Must return JSON. \
-             Add tests. Do not change signatures. Only touch those two files.",
+    fn executable_acceptance_beats_bare_keyword() {
+        // A named runnable check is stronger direction than the word "ensure".
+        let runnable = score_prompt(
+            "Add a retry wrapper in `src/net.rs`. Done when `cargo test net::` passes.",
         );
-        assert!(s.breakdown.context < 0.35, "prompt should read as context-free");
+        let bare = score_prompt(
+            "Add a retry wrapper in `src/net.rs`. Ensure it works and is correct.",
+        );
         assert!(
-            s.breakdown.specificity >= 0.6 && s.breakdown.control >= 0.5,
-            "prompt should qualify as tactical (spec {:.2}, control {:.2})",
-            s.breakdown.specificity,
-            s.breakdown.control,
+            runnable.breakdown.direction > bare.breakdown.direction,
+            "runnable {} vs bare {}",
+            runnable.breakdown.direction,
+            bare.breakdown.direction
         );
-        // A high base score is NOT clamped to 69 for this tactical profile.
-        assert_eq!(apply_balance_gates(85.0, &s.breakdown), 85.0);
+    }
+
+    #[test]
+    fn examples_slot_detected() {
+        let with_ex = score_prompt(
+            "Add a `slugify()` helper in `src/util.rs`. For example, slugify(\"Hi There\") \
+             -> \"hi-there\" and slugify(\"a  b\") -> \"a-b\". Add tests.",
+        );
+        assert!(with_ex.breakdown.examples > 0.3, "examples {}", with_ex.breakdown.examples);
     }
 
     #[test]
@@ -1745,18 +2052,80 @@ mod tests {
     }
 
     #[test]
-    fn weak_words_lower_specificity() {
+    fn weak_words_lower_objective_and_grounding() {
         let crisp = score_prompt(
             "Add a `retry()` wrapper around the HTTP call in src/net.rs with a 3x cap.",
         );
         let weak = score_prompt(
             "Make the thing handle stuff appropriately and maybe make it better somehow.",
         );
-        assert!(crisp.breakdown.specificity > weak.breakdown.specificity);
+        assert!(crisp.breakdown.grounding > weak.breakdown.grounding);
+        assert!(crisp.breakdown.objective > weak.breakdown.objective);
     }
 
     #[test]
-    fn branch_aggregation_is_length_weighted_mean() {
+    fn abstains_on_no_authored_request() {
+        // A pasted error line with no authored ask around it → no authored
+        // words after segmentation → unscored, not a confident bad number.
+        let s = score_prompt("error[E0308]: mismatched types --> src/a.rs:1:5");
+        assert!(s.is_unscored(), "expected unscored, got {:?}", s.unscored);
+        assert_eq!(s.score, 0.0);
+        assert_eq!(s.unscored, Some("no authored request"));
+    }
+
+    #[test]
+    fn abstains_on_non_english() {
+        // Substantial text, essentially no English function words → abstain.
+        let s = score_prompt(
+            "実装してください パーサー モジュール テスト 関数 修正 変更 追加 引数 戻り値",
+        );
+        assert_eq!(s.unscored, Some("non-English or unsupported text"));
+    }
+
+    #[test]
+    fn english_short_prompt_is_scored_not_abstained() {
+        // Narrow abstention: a short *English* ask stays scored (low, with a
+        // flag), it is not refused.
+        let s = score_prompt("fix the bug please");
+        assert!(!s.is_unscored());
+        assert!(s.flags.contains(&Flag::TooShort));
+    }
+
+    #[test]
+    fn branch_shrinkage_pulls_small_samples_toward_prior() {
+        // One strong prompt should not crown a branch: it is pulled toward the
+        // neutral prior, so the branch score sits below the single-prompt score.
+        let strong = "Refactor `parse_range()` in src/util.rs to fix the inclusive \
+                      off-by-one. Add a regression test for the empty range and run \
+                      `cargo test`. Do not change the public signature.";
+        let one = score_prompt(strong).score;
+        let branch = score_branch(vec![strong], 1);
+        let expect = (BRANCH_PRIOR_STRENGTH * BRANCH_PRIOR_MEAN + 1.0 * one)
+            / (BRANCH_PRIOR_STRENGTH + 1.0);
+        assert!((branch.score - expect).abs() < 1e-6, "branch {} expect {}", branch.score, expect);
+        // Pulled toward the prior: closer to it than the single prompt was.
+        assert!(
+            (branch.score - BRANCH_PRIOR_MEAN).abs() < (one - BRANCH_PRIOR_MEAN).abs(),
+            "shrinkage should pull {} toward {} from {}",
+            branch.score,
+            BRANCH_PRIOR_MEAN,
+            one
+        );
+    }
+
+    #[test]
+    fn branch_drops_unscored_prompts() {
+        // A non-English prompt alongside a real one is excluded from the mean
+        // but still counts against coverage.
+        let real = "Add a test for `foo()` in src/foo.rs and run `cargo test`.";
+        let branch = score_branch(vec![real, "実装 テスト 関数 引数 戻り値 修正 変更 追加"], 2);
+        assert_eq!(branch.scored_prompts, 1);
+        assert_eq!(branch.ai_commits, 2);
+        assert!(branch.low_confidence);
+    }
+
+    #[test]
+    fn branch_aggregation_is_length_weighted_and_shrunk() {
         let a = "fix it"; // short, low
         let b = "Add a unit test for `foo()` in src/foo.rs and ensure it passes \
                  without changing the public signature, covering the empty input case.";
@@ -1764,11 +2133,19 @@ mod tests {
         assert_eq!(branch.scored_prompts, 2);
         assert_eq!(branch.ai_commits, 2);
         assert!((branch.coverage - 1.0).abs() < 1e-9);
-        // weighted toward the longer, better prompt
         let sa = score_prompt(a);
         let sb = score_prompt(b);
-        let plain_mean = (sa.score + sb.score) / 2.0;
-        assert!(branch.score > plain_mean, "length weighting should lift {} above {}", branch.score, plain_mean);
+        let wa = sa.words.clamp(20, 250) as f64;
+        let wb = sb.words.clamp(20, 250) as f64;
+        let lw = (sa.score * wa + sb.score * wb) / (wa + wb);
+        let plain = (sa.score + sb.score) / 2.0;
+        // Length weighting favors the longer, better prompt over a plain mean.
+        assert!(lw > plain, "length weighting should lift {} above {}", lw, plain);
+        // The branch score is that length-weighted mean, then shrunk toward the
+        // prior (n = 2 prompts).
+        let expect = (BRANCH_PRIOR_STRENGTH * BRANCH_PRIOR_MEAN + 2.0 * lw)
+            / (BRANCH_PRIOR_STRENGTH + 2.0);
+        assert!((branch.score - expect).abs() < 1e-6, "branch {} expect {}", branch.score, expect);
     }
 
     #[test]
@@ -1828,10 +2205,14 @@ mod tests {
 
     #[test]
     fn empty_and_flags() {
+        // Whitespace-only → no authored request → abstained.
         let e = score_prompt("   ");
         assert_eq!(e.score, 0.0);
-        assert_eq!(e.flags, vec![Flag::TooShort]);
+        assert!(e.is_unscored());
+        assert!(e.flags.is_empty());
+        // A real (if terse) English ask is scored, with a TooShort flag.
         let short = score_prompt("fix bug");
+        assert!(!short.is_unscored());
         assert!(short.flags.contains(&Flag::TooShort));
         assert!(short.flags.len() <= 2);
     }
@@ -2005,11 +2386,14 @@ mod tests {
         let branch = score_branch(prompts.clone(), prompts.len());
         let scored: Vec<PromptScore> = prompts.iter().map(|p| score_prompt(p)).collect();
         let wsum: f64 = scored.iter().map(|s| s.words.clamp(20, 250) as f64).sum();
-        let expect: f64 = scored
+        let lw: f64 = scored
             .iter()
             .map(|s| s.score * s.words.clamp(20, 250) as f64)
             .sum::<f64>()
             / wsum;
+        // Roll-up equals the length-weighted mean, then shrunk toward the prior.
+        let n = scored.len() as f64;
+        let expect = (BRANCH_PRIOR_STRENGTH * BRANCH_PRIOR_MEAN + n * lw) / (BRANCH_PRIOR_STRENGTH + n);
         assert!((branch.score - expect).abs() < 1e-9, "branch {} vs expect {}", branch.score, expect);
     }
 
@@ -2148,11 +2532,11 @@ mod tests {
         }
         let s = score_prompt(&p);
         assert!(s.flags.contains(&Flag::MostlyPaste), "flags: {:?}", s.flags);
-        // Artifact-only paste: no craft, evidence bonus only, both flags.
+        // Artifact-only paste: no authored request at all → abstained, not scored.
         let only = score_prompt("error[E0308]: mismatched types --> src/a.rs:1:5");
         assert_eq!(only.words, 0);
-        assert!(only.score <= EVIDENCE_BONUS_MAX);
-        assert!(only.flags.contains(&Flag::TooShort) && only.flags.contains(&Flag::MostlyPaste));
+        assert!(only.is_unscored());
+        assert_eq!(only.unscored, Some("no authored request"));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -2914,6 +2914,7 @@ fn suggested_upgrade(prompt: &str, flags: &[crate::prompt_score::Flag]) -> Optio
             Flag::WeakContext => adds.push("Scope: change only <file/module>; do not touch <out-of-scope area>."),
             Flag::Vague => adds.push("Acceptance criteria: <observable outcome that means done>."),
             Flag::TooShort => adds.push("State the goal, the files in scope, and how to verify the result."),
+            Flag::MostlyPaste => adds.push("Summarize what the pasted output shows and state the outcome you want from it."),
             _ => {}
         }
     }
@@ -2971,6 +2972,13 @@ async fn api_prompt_score(
             dim("Diversity", b.diversity, w.diversity),
             dim("Clarity", b.clarity, w.clarity),
             dim("Adequacy", b.adequacy, w.adequacy),
+            // Evidence is a bonus outside the weighted sum; its "weight" here
+            // only shapes the display so points/max match the real bonus.
+            dim(
+                "Evidence (bonus)",
+                b.evidence,
+                crate::prompt_score::EVIDENCE_BONUS_MAX / 100.0,
+            ),
         ];
         Ok(Some(PromptMaturity {
             prompt,

--- a/src/server.rs
+++ b/src/server.rs
@@ -2692,7 +2692,7 @@ async fn api_cockpit(
             .as_ref()
             .and_then(|r| r.ai_metadata.as_ref())
             .map(|ai| crate::prompt_score::score_prompt(&ai.prompt))
-            .filter(|s| s.words > 0);
+            .filter(|s| s.words > 0 && !s.is_unscored());
 
         let model = record.as_ref().and_then(|r| r.ai_metadata.as_ref()).map(|ai| ai.model_name.clone()).filter(|s| !s.is_empty());
         let prov = record.as_ref().and_then(|r| r.env_provenance.as_ref());
@@ -2890,11 +2890,16 @@ pub struct PromptMaturity {
     pub level: String,
     pub words: usize,
     pub flags: Vec<String>,
-    /// The seven weighted sub-signals behind `score` (composition before the
-    /// anti-gaming guards / length caps, which can lower the final number).
+    /// The core + enrichment sub-signals behind `score`. The three core slots
+    /// combine multiplicatively; enrichment lifts above the core. Empty when
+    /// `unscored` is set.
     pub dimensions: Vec<PromptDimension>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_upgrade: Option<String>,
+    /// When set, the prompt was not assessable (no authored request, or
+    /// non-English text); `score`/`dimensions` are placeholders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unscored: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -2915,6 +2920,7 @@ fn suggested_upgrade(prompt: &str, flags: &[crate::prompt_score::Flag]) -> Optio
             Flag::Vague => adds.push("Acceptance criteria: <observable outcome that means done>."),
             Flag::TooShort => adds.push("State the goal, the files in scope, and how to verify the result."),
             Flag::MostlyPaste => adds.push("Summarize what the pasted output shows and state the outcome you want from it."),
+            Flag::NoObjective => adds.push("Lead with the positive goal — what to build/change — not only what to avoid."),
             _ => {}
         }
     }
@@ -2955,25 +2961,44 @@ async fn api_prompt_score(
             return Ok(None);
         };
         let s = crate::prompt_score::score_prompt(&prompt);
+        if let Some(reason) = s.unscored {
+            // Abstained: report the reason, no score/dimensions to show.
+            return Ok(Some(PromptMaturity {
+                prompt,
+                score: 0.0,
+                level: "unscored".to_string(),
+                words: s.words,
+                flags: Vec::new(),
+                dimensions: Vec::new(),
+                suggested_upgrade: None,
+                unscored: Some(reason.to_string()),
+            }));
+        }
         let upgrade = suggested_upgrade(&prompt, &s.flags);
         let b = &s.breakdown;
-        let w = &crate::prompt_score::WEIGHTS;
+        let en = &crate::prompt_score::ENRICHMENT;
         let dim = |label: &str, signal: f64, weight: f64| PromptDimension {
             label: label.to_string(),
             signal: (signal * 100.0).clamp(0.0, 100.0),
             points: 100.0 * signal * weight,
             max_points: 100.0 * weight,
         };
+        // The three core slots combine multiplicatively, not by weight — their
+        // display `weight` is a nominal share (documented) so the meter reads
+        // sensibly; the enrichment slots use their real ENRICHMENT weights.
+        const CORE_DISPLAY_W: f64 = 0.20;
         let dimensions = vec![
-            dim("Specificity", b.specificity, w.specificity),
-            dim("Control", b.control, w.control),
-            dim("Context", b.context, w.context),
-            dim("Structure", b.structure, w.structure),
-            dim("Diversity", b.diversity, w.diversity),
-            dim("Clarity", b.clarity, w.clarity),
-            dim("Adequacy", b.adequacy, w.adequacy),
-            // Evidence is a bonus outside the weighted sum; its "weight" here
-            // only shapes the display so points/max match the real bonus.
+            dim("Objective (core)", b.objective, CORE_DISPLAY_W),
+            dim("Grounding (core)", b.grounding, CORE_DISPLAY_W),
+            dim("Direction (core)", b.direction, CORE_DISPLAY_W),
+            dim("Context", b.context, en.context),
+            dim("Examples", b.examples, en.examples),
+            dim("Structure", b.structure, en.structure),
+            dim("Diversity", b.diversity, en.diversity),
+            dim("Clarity", b.clarity, en.clarity),
+            dim("Adequacy", b.adequacy, en.adequacy),
+            // Evidence is a bonus outside the composite; its "weight" here only
+            // shapes the display so points/max match the real bonus.
             dim(
                 "Evidence (bonus)",
                 b.evidence,
@@ -2988,6 +3013,7 @@ async fn api_prompt_score(
             flags: s.flags.iter().map(|f| f.label().to_string()).collect(),
             dimensions,
             suggested_upgrade: upgrade,
+            unscored: None,
         }))
     })
     .await;

--- a/tests/prompt_score_gaming.rs
+++ b/tests/prompt_score_gaming.rs
@@ -139,9 +139,9 @@ fn diag_print_scores() {
         ("crafted+log", format!("The nested-list parser miscounts children. Fix `parse_nested()` in src/parser.rs so a trailing separator does not produce a phantom child. Add a regression test covering the trailing-separator case and keep the public signature unchanged. Done when `cargo test parser::` passes.\n\n{log}")),
     ] {
         let s = score_prompt(&p);
-        println!("{name:12} score={:6.2} level={:?} words={} spec={:.2} ctrl={:.2} ctx={:.2} struct={:.2} div={:.2} clar={:.2} adeq={:.2}",
-            s.score, s.level, s.words,
-            s.breakdown.specificity, s.breakdown.control, s.breakdown.context,
-            s.breakdown.structure, s.breakdown.diversity, s.breakdown.clarity, s.breakdown.adequacy);
+        println!("{name:12} score={:6.2} level={:?} words={} unscored={:?} obj={:.2} grd={:.2} dir={:.2} ctx={:.2} ex={:.2} evid={:.2}",
+            s.score, s.level, s.words, s.unscored,
+            s.breakdown.objective, s.breakdown.grounding, s.breakdown.direction,
+            s.breakdown.context, s.breakdown.examples, s.breakdown.evidence);
     }
 }

--- a/tests/prompt_score_gaming.rs
+++ b/tests/prompt_score_gaming.rs
@@ -1,0 +1,147 @@
+//! Anti-gaming regression tests for the prompt maturity score: pasted machine
+//! artifacts (error logs, stack traces, compiler output) must not read as
+//! prompt craft.
+
+use h5i_core::prompt_score::score_prompt;
+
+/// A realistic pasted artifact: cargo test failure output with a Rust panic
+/// backtrace. Nobody *wrote* this; it was copy-pasted.
+fn error_log() -> String {
+    let mut log = String::from(
+        "running 12 tests\n\
+         test parser::tests::parses_empty ... ok\n\
+         test parser::tests::parses_nested ... FAILED\n\
+         test parser::tests::round_trips ... ok\n\
+         \n\
+         failures:\n\
+         \n\
+         ---- parser::tests::parses_nested stdout ----\n\
+         thread 'parser::tests::parses_nested' panicked at src/parser.rs:214:9:\n\
+         assertion `left == right` failed\n\
+           left: Some(Node { kind: List, children: 3 })\n\
+           right: Some(Node { kind: List, children: 2 })\n\
+         note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\
+         stack backtrace:\n\
+            0: rust_begin_unwind\n\
+                      at /rustc/07dca48/library/std/src/panicking.rs:652:5\n\
+            1: core::panicking::panic_fmt\n\
+                      at /rustc/07dca48/library/core/src/panicking.rs:72:14\n\
+            2: h5i::parser::tests::parses_nested\n\
+                      at ./src/parser.rs:214:9\n\
+            3: core::ops::function::FnOnce::call_once\n\
+                      at /rustc/07dca48/library/core/src/ops/function.rs:250:5\n",
+    );
+    // Pad with more log-shaped lines the way a real paste often does — repeated
+    // assertion diffs and error lines from subsequent test cases.
+    for i in 0..40 {
+        log.push_str(&format!(
+            "test parser::tests::case_{i} ... FAILED\n\
+             error[E0308]: mismatched types --> src/parser.rs:{}:{}\n\
+             expected `Option<Node>`, found `Result<Node, ParseError>`\n\
+             assertion failed: expected 2 children but the list node returned {} at line {}\n",
+            200 + i,
+            5 + (i % 7),
+            i % 5,
+            100 + i,
+        ));
+    }
+    log
+}
+
+/// The observed failure mode: "fix this" + a wall of pasted log scores far
+/// above the bare ask, purely on the strength of machine-generated text.
+#[test]
+fn pasted_error_log_does_not_inflate_score() {
+    let bare = score_prompt("fix this failing test");
+    let with_log = score_prompt(&format!("fix this failing test\n\n{}", error_log()));
+
+    // Attaching evidence may legitimately help a little, but a pasted log must
+    // not move a lazy ask up a whole maturity band on its own.
+    assert!(
+        with_log.score <= bare.score + 10.0,
+        "pasted log inflated score: bare {} → with log {}",
+        bare.score,
+        with_log.score
+    );
+}
+
+/// A crisp, well-crafted prompt with NO log must outscore a lazy ask + huge log.
+#[test]
+fn crafted_prompt_beats_lazy_ask_with_log_wall() {
+    let crafted = score_prompt(
+        "The nested-list parser miscounts children. Fix `parse_nested()` in \
+         src/parser.rs so a trailing separator does not produce a phantom child. \
+         Add a regression test covering the trailing-separator case and keep the \
+         public signature unchanged. Done when `cargo test parser::` passes.",
+    );
+    let lazy_with_log = score_prompt(&format!("fix\n\n{}", error_log()));
+    assert!(
+        crafted.score > lazy_with_log.score + 15.0,
+        "crafted {} should clearly beat lazy+log {}",
+        crafted.score,
+        lazy_with_log.score
+    );
+}
+
+/// Doubling the pasted log must not raise the score: evidence credit saturates
+/// instead of scaling with paste volume.
+#[test]
+fn log_volume_has_diminishing_returns() {
+    let log = error_log();
+    let once = score_prompt(&format!("fix this failing test\n\n{}", log));
+    let thrice = score_prompt(&format!("fix this failing test\n\n{}{}{}", log, log, log));
+    assert!(
+        thrice.score <= once.score + 2.0,
+        "more log should not mean more maturity: 1x {} vs 3x {}",
+        once.score,
+        thrice.score
+    );
+}
+
+/// The other half of the v1 bug: attaching a log to a *good* prompt used to
+/// TANK the score (53 → 35) because the paste drowned diversity and tripped
+/// the repetition penalty. Evidence must never hurt.
+#[test]
+fn attaching_log_never_hurts_a_crafted_prompt() {
+    let crafted = "The nested-list parser miscounts children. Fix `parse_nested()` in \
+                   src/parser.rs so a trailing separator does not produce a phantom child. \
+                   Add a regression test covering the trailing-separator case and keep the \
+                   public signature unchanged. Done when `cargo test parser::` passes.";
+    let alone = score_prompt(crafted);
+    let with_log = score_prompt(&format!("{crafted}\n\n{}", error_log()));
+    assert!(
+        with_log.score >= alone.score,
+        "evidence must never hurt: alone {} vs with log {}",
+        alone.score,
+        with_log.score
+    );
+}
+
+/// A pure paste with no authored ask at all is not prompt craft.
+#[test]
+fn log_only_prompt_is_nascent() {
+    let s = score_prompt(&error_log());
+    assert!(s.score < 10.0, "log-only scored {}", s.score);
+    assert_eq!(s.words, 0, "machine output must not count as authored words");
+}
+
+#[test]
+#[ignore]
+fn diag_print_scores() {
+    let log = error_log();
+    for (name, p) in [
+        ("bare-vague", "fix this failing test".to_string()),
+        ("vague+log", format!("fix this failing test\n\n{log}")),
+        ("medium", "The nested parser test fails. Please fix the child counting bug in the parser module.".to_string()),
+        ("medium+log", format!("The nested parser test fails. Please fix the child counting bug in the parser module.\n\n{log}")),
+        ("log-only", log.clone()),
+        ("crafted", "The nested-list parser miscounts children. Fix `parse_nested()` in src/parser.rs so a trailing separator does not produce a phantom child. Add a regression test covering the trailing-separator case and keep the public signature unchanged. Done when `cargo test parser::` passes.".to_string()),
+        ("crafted+log", format!("The nested-list parser miscounts children. Fix `parse_nested()` in src/parser.rs so a trailing separator does not produce a phantom child. Add a regression test covering the trailing-separator case and keep the public signature unchanged. Done when `cargo test parser::` passes.\n\n{log}")),
+    ] {
+        let s = score_prompt(&p);
+        println!("{name:12} score={:6.2} level={:?} words={} spec={:.2} ctrl={:.2} ctx={:.2} struct={:.2} div={:.2} clar={:.2} adeq={:.2}",
+            s.score, s.level, s.words,
+            s.breakdown.specificity, s.breakdown.control, s.breakdown.context,
+            s.breakdown.structure, s.breakdown.diversity, s.breakdown.clarity, s.breakdown.adequacy);
+    }
+}


### PR DESCRIPTION
…bonus

A pasted error log inflated the maturity score (18 -> 32 for a lazy ask: paths/numbers farmed specificity, test/line/file tokens farmed control and grounding, length lifted adequacy and the hard caps) while the same log attached to a well-crafted prompt TANKED it (53 -> 35: the paste drowned diversity and tripped the repetition penalty). Wrong in both directions.

Split every prompt line-wise into authored prose vs pasted machine output (NLoN-style features: strong seeds for stack frames / compiler diagnostics / test-runner lines / log levels / timestamps / diff markers; stopword-free, symbol-dense, deeply-indented or code-majority lines join by contagion; fenced interiors are artifact by construction). All craft signals, length caps, and branch length-weighting now measure authored text only. Attached artifacts feed a new saturating evidence signal instead: +3.5 points for having one, +5 when the prose explicitly frames it - never scaling with paste volume, never diluting the authored signals. New 'mostly pasted output' flag diagnoses a thin ask around a log wall.