### PR TITLE
feat(cli): add prompt-maturity, version --json, and env capabilities …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ h5i env create <name> [--from REV] [--profile P] [--isolation workspace|process|
 h5i env run <name> -- <cmd>              # policy-enforced, capture-wrapped
 h5i env shell <name> [-- <cmd>]          # interactive confined session (agent-in-box)
 h5i env probe                            # host isolation capabilities (incl. rootless Podman)
+h5i env capabilities [--json]            # machine-readable enforcement report (tier, egress, limits)
 h5i env list | status <name> [--json] | log <name> | diff <name> [--stat]
 h5i env context <name> [--trace]        # show the env's reasoning/context branch
 h5i env rebase <name>                   # re-pin base onto the advanced parent

--- a/src/cli_routing.rs
+++ b/src/cli_routing.rs
@@ -92,7 +92,7 @@ pub fn nearest_verb(noun: &str, typo: &str) -> Option<&'static str> {
             "log", "blame", "context", "notes", "memory", "recap", "resume",
             "object", "objects", "search", "rm",
         ],
-        "audit" => &["review", "scan", "compliance", "policy", "vibe"],
+        "audit" => &["review", "scan", "compliance", "policy", "vibe", "maturity"],
         "share" => &[
             "push",
             "pull",
@@ -168,6 +168,7 @@ pub fn noun_alias(noun: &str, verb: &str) -> Option<&'static [&'static str]> {
         ("audit", "compliance") => &["compliance"],
         ("audit", "policy") => &["policy"],
         ("audit", "vibe") => &["vibe"],
+        ("audit", "maturity") => &["maturity"],
         ("audit", "notes") => &["notes", "review"],
 
         // ── share ───────────────────────────────────────────────────────
@@ -286,6 +287,11 @@ mod tests {
         assert_eq!(
             plan_noun_route(&argv(&["h5i", "recall", "rm", "feature/x", "--force"])),
             NounRoute::Rewritten(argv(&["h5i", "recall-rm", "feature/x", "--force"]))
+        );
+        // `audit maturity` routes to the hidden maturity command, flags preserved.
+        assert_eq!(
+            plan_noun_route(&argv(&["h5i", "audit", "maturity", "--json"])),
+            NounRoute::Rewritten(argv(&["h5i", "maturity", "--json"]))
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1046,6 +1046,30 @@ enum Commands {
         json: bool,
     },
 
+    /// Score prompt maturity for headless / CI grading — the same signal that
+    /// feeds `merge_confidence`, otherwise only reachable via `h5i serve`.
+    /// Default: roll up every AI-commit prompt on this branch (`base..HEAD`).
+    /// Pass `--text`/`--oid` to score one prompt instead.
+    #[command(hide = true)]
+    Maturity {
+        /// Score this literal prompt string instead of the branch's commits.
+        #[arg(long, conflicts_with = "oid")]
+        text: Option<String>,
+
+        /// Score the captured prompt of one commit (its git OID) instead of the
+        /// whole branch.
+        #[arg(long)]
+        oid: Option<String>,
+
+        /// Number of recent commits to scan in branch mode.
+        #[arg(short, long, default_value_t = 500)]
+        limit: usize,
+
+        /// Output raw JSON instead of the pretty report.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Manage governance policy for AI-assisted commits (.h5i/policy.toml)
     Policy {
         #[command(subcommand)]
@@ -1876,6 +1900,15 @@ enum EnvCommands {
     /// Probe what isolation this host can actually provide (Landlock, user
     /// namespaces, seccomp) and which claims are satisfiable.
     Probe,
+
+    /// Machine-readable host enforcement report: isolation tier, egress-enforced
+    /// yes/no, resource-limit support, and per-claim satisfiable/runnable — so a
+    /// product can adapt to the real host without scraping `env probe` text.
+    Capabilities {
+        /// Emit the structured report as JSON instead of the human view.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// List environments on this clone (the fleet view)
     List {
@@ -4768,6 +4801,12 @@ fn noun_table(noun: &str) -> (&'static str, &'static [NounVerb], &'static [&'sta
                     legacy: "h5i vibe",
                     example: "h5i audit vibe --limit 1000 --json",
                 },
+                NounVerb {
+                    verb: "maturity",
+                    summary: "Prompt-maturity score for the branch's AI commits (or a single --text/--oid prompt).",
+                    legacy: "h5i maturity",
+                    example: "h5i audit maturity --json",
+                },
             ],
             &[
                 "Use `h5i audit review` as a triage funnel before merging an AI-heavy branch.",
@@ -5022,9 +5061,48 @@ fn init_tracing() {
         .try_init();
 }
 
+/// Handle `h5i --version --json` (either flag order) before clap sees it —
+/// clap's built-in `--version` prints `h5i 0.2.6` and exits, so a machine
+/// consumer would otherwise have to parse that text. Only fires when *both*
+/// flags appear among the leading top-level options (scanning stops at the
+/// first positional/`--`, so `env run -- cmd --version --json` is untouched);
+/// plain `h5i --version` still falls through to clap.
+fn maybe_version_json(argv: &[String]) {
+    let mut wants_version = false;
+    let mut wants_json = false;
+    for tok in argv.iter().skip(1) {
+        if tok == "--" || !tok.starts_with('-') {
+            break;
+        }
+        match tok.as_str() {
+            "--version" | "-V" => wants_version = true,
+            "--json" => wants_json = true,
+            _ => {}
+        }
+    }
+    if !(wants_version && wants_json) {
+        return;
+    }
+    let mut features: Vec<&str> = Vec::new();
+    if cfg!(feature = "web") {
+        features.push("web");
+    }
+    let out = serde_json::json!({
+        "name": "h5i",
+        "version": env!("CARGO_PKG_VERSION"),
+        "features": features,
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&out).expect("version json is serializable")
+    );
+    std::process::exit(0);
+}
+
 fn main() -> anyhow::Result<()> {
     init_tracing();
     let argv: Vec<String> = std::env::args().collect();
+    maybe_version_json(&argv);
     // `rewrote` is true when we translated a `capture/recall/audit/share`
     // invocation — in that case the user did NOT type the legacy form, so we
     // must NOT emit the "this has moved" hint.
@@ -11022,6 +11100,61 @@ fn main() -> anyhow::Result<()> {
                     }
                 }
 
+                EnvCommands::Capabilities { json } => {
+                    let report = h5i_core::sandbox::capabilities_report();
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&report)?);
+                    } else {
+                        let yn = |b: bool| {
+                            if b {
+                                style("yes").green()
+                            } else {
+                                style("no").red()
+                            }
+                        };
+                        println!("── h5i host capabilities ──");
+                        println!("  os               = {}", report.os);
+                        println!(
+                            "  landlock_abi     = {}",
+                            report
+                                .landlock_abi
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "none".into())
+                        );
+                        println!("  userns           = {}", yn(report.userns));
+                        println!("  seccomp          = {}", yn(report.seccomp));
+                        println!(
+                            "  container        = {}",
+                            report.container_runtime.as_deref().unwrap_or("none")
+                        );
+                        println!("  egress_enforced  = {}", yn(report.egress_enforced));
+                        println!("  resource_limits  = {}", yn(report.resource_limits));
+                        println!(
+                            "  strongest_tier   = {}",
+                            style(report.strongest_tier).cyan().bold()
+                        );
+                        println!();
+                        for c in &report.claims {
+                            let runnable = match c.runnable {
+                                Some(true) => format!(" runnable = {}", style("yes").green()),
+                                Some(false) => format!(" runnable = {}", style("no").red()),
+                                None => String::new(),
+                            };
+                            let note = c
+                                .note
+                                .map(|n| format!("  {}", style(format!("({n})")).dim()))
+                                .unwrap_or_default();
+                            println!(
+                                "  claim {:<18} satisfiable = {}{}{}",
+                                c.claim,
+                                yn(c.satisfiable),
+                                runnable,
+                                note
+                            );
+                        }
+                    }
+                }
+
                 EnvCommands::List { json } => {
                     let envs = h5i_core::env::list(&h5i_root);
                     if json {
@@ -11851,6 +11984,246 @@ fn main() -> anyhow::Result<()> {
                 println!("{}", serde_json::to_string_pretty(&out)?);
             } else {
                 h5i_core::vibe::print_vibe_report(&report);
+            }
+        }
+
+        Commands::Maturity {
+            text,
+            oid,
+            limit,
+            json,
+        } => {
+            use h5i_core::prompt_score as ps;
+
+            // Serde shapes — kept inline (like `vibe`) so the score types stay
+            // free of a serde dependency. `breakdown_json` mirrors the HTTP
+            // `/api/prompt-score` fields so a CI consumer sees the same signal.
+            #[derive(serde::Serialize)]
+            struct BreakdownJson {
+                objective: f64,
+                grounding: f64,
+                direction: f64,
+                context: f64,
+                examples: f64,
+                structure: f64,
+                diversity: f64,
+                clarity: f64,
+                adequacy: f64,
+                evidence: f64,
+                flesch_reading_ease: f64,
+                fk_grade: f64,
+                gunning_fog: f64,
+            }
+            let breakdown_json = |b: &ps::PromptScoreBreakdown| BreakdownJson {
+                objective: b.objective,
+                grounding: b.grounding,
+                direction: b.direction,
+                context: b.context,
+                examples: b.examples,
+                structure: b.structure,
+                diversity: b.diversity,
+                clarity: b.clarity,
+                adequacy: b.adequacy,
+                evidence: b.evidence,
+                flesch_reading_ease: b.flesch_reading_ease,
+                fk_grade: b.fk_grade,
+                gunning_fog: b.gunning_fog,
+            };
+            // Human breakdown table: the three core slots, then the enrichment
+            // signals, each as a 10-cell bar. Diagnostic only — never a keyword
+            // checklist to stuff.
+            let bar = |v: f64| {
+                let filled = (v.clamp(0.0, 1.0) * 10.0).round() as usize;
+                format!("{}{}", "█".repeat(filled), "░".repeat(10 - filled))
+            };
+            let print_breakdown = |b: &ps::PromptScoreBreakdown| {
+                let rows: [(&str, f64); 9] = [
+                    ("Objective (core)", b.objective),
+                    ("Grounding (core)", b.grounding),
+                    ("Direction (core)", b.direction),
+                    ("Context", b.context),
+                    ("Examples", b.examples),
+                    ("Structure", b.structure),
+                    ("Diversity", b.diversity),
+                    ("Clarity", b.clarity),
+                    ("Adequacy", b.adequacy),
+                ];
+                for (label, v) in rows {
+                    println!(
+                        "   {:<18} {} {:.2}",
+                        label,
+                        style(bar(v)).cyan(),
+                        v
+                    );
+                }
+                if b.evidence > 0.0 {
+                    println!(
+                        "   {:<18} {} {:.2} {}",
+                        "Evidence (bonus)",
+                        style(bar(b.evidence)).green(),
+                        b.evidence,
+                        style("(+bonus)").dim()
+                    );
+                }
+            };
+
+            if text.is_some() || oid.is_some() {
+                // ── Single-prompt mode ──────────────────────────────────────
+                let prompt = if let Some(t) = text {
+                    t
+                } else {
+                    let repo = H5iRepository::open(".")?;
+                    let oid_s = oid.expect("oid set when text is None");
+                    let git_oid = git2::Oid::from_str(&oid_s)
+                        .map_err(|_| anyhow::anyhow!("`{oid_s}` is not a valid git OID"))?;
+                    repo.load_h5i_record(git_oid)
+                        .ok()
+                        .and_then(|r| r.ai_metadata)
+                        .map(|ai| ai.prompt)
+                        .filter(|p| !p.is_empty())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("commit {oid_s} has no captured prompt to score")
+                        })?
+                };
+                let s = ps::score_prompt(&prompt);
+                if json {
+                    #[derive(serde::Serialize)]
+                    struct SingleJson {
+                        mode: &'static str,
+                        score: f64,
+                        level: &'static str,
+                        words: usize,
+                        #[serde(skip_serializing_if = "Option::is_none")]
+                        unscored: Option<&'static str>,
+                        flags: Vec<&'static str>,
+                        breakdown: Option<BreakdownJson>,
+                    }
+                    let out = SingleJson {
+                        mode: "prompt",
+                        score: s.score,
+                        level: if s.is_unscored() {
+                            "unscored"
+                        } else {
+                            s.level.label()
+                        },
+                        words: s.words,
+                        unscored: s.unscored,
+                        flags: s.flags.iter().map(|f| f.label()).collect(),
+                        breakdown: if s.is_unscored() {
+                            None
+                        } else {
+                            Some(breakdown_json(&s.breakdown))
+                        },
+                    };
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                } else if let Some(reason) = s.unscored {
+                    println!(
+                        "🧠 {} — {}",
+                        style("Prompt maturity: unscored").yellow().bold(),
+                        reason
+                    );
+                } else {
+                    println!(
+                        "🧠 {}  {} {}   {}",
+                        style(format!("Prompt maturity: {:.1}/100", s.score))
+                            .bold(),
+                        s.level.emoji(),
+                        style(s.level.label()).cyan(),
+                        style(format!("({} words)", s.words)).dim()
+                    );
+                    if !s.flags.is_empty() {
+                        let flags: Vec<&str> = s.flags.iter().map(|f| f.label()).collect();
+                        println!("   {} {}", style("flags:").dim(), flags.join(", "));
+                    }
+                    print_breakdown(&s.breakdown);
+                }
+            } else {
+                // ── Branch mode: roll up every AI-commit prompt on base..HEAD ─
+                let workdir = std::env::current_dir()?;
+                let repo = H5iRepository::open(&workdir)?;
+                let base_oid = h5i_core::pr::detect_base_oid(repo.git(), &workdir);
+                let records = repo.h5i_log_since(base_oid, limit)?;
+                let ai_count = records
+                    .iter()
+                    .filter(|r| r.ai_metadata.is_some())
+                    .count();
+                let prompts: Vec<&str> = records
+                    .iter()
+                    .filter_map(|r| r.ai_metadata.as_ref())
+                    .map(|m| m.prompt.as_str())
+                    .collect();
+                let branch = ps::score_branch(prompts, ai_count);
+                if json {
+                    #[derive(serde::Serialize)]
+                    struct BranchJson {
+                        mode: &'static str,
+                        score: f64,
+                        level: &'static str,
+                        scored_prompts: usize,
+                        ai_commits: usize,
+                        coverage: f64,
+                        low_confidence: bool,
+                        flags: Vec<&'static str>,
+                        breakdown: Option<BreakdownJson>,
+                    }
+                    let out = BranchJson {
+                        mode: "branch",
+                        score: branch.score,
+                        level: if branch.is_empty() {
+                            "unscored"
+                        } else {
+                            branch.level.label()
+                        },
+                        scored_prompts: branch.scored_prompts,
+                        ai_commits: branch.ai_commits,
+                        coverage: branch.coverage,
+                        low_confidence: branch.low_confidence,
+                        flags: branch.flags.iter().map(|f| f.label()).collect(),
+                        breakdown: if branch.is_empty() {
+                            None
+                        } else {
+                            Some(breakdown_json(&branch.breakdown))
+                        },
+                    };
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                } else if branch.is_empty() {
+                    println!(
+                        "🧠 {}",
+                        style("No scorable AI-commit prompts on this branch.")
+                            .yellow()
+                    );
+                    println!(
+                        "   {}",
+                        style("Commit with `h5i capture commit` so the prompt is captured.")
+                            .dim()
+                    );
+                } else {
+                    println!(
+                        "🧠 {}  {} {}",
+                        style(format!("Prompt maturity: {:.1}/100", branch.score))
+                            .bold(),
+                        branch.level.emoji(),
+                        style(branch.level.label()).cyan()
+                    );
+                    println!(
+                        "   {} {}/{} AI commits scored ({:.0}% coverage){}",
+                        style("coverage:").dim(),
+                        branch.scored_prompts,
+                        branch.ai_commits,
+                        branch.coverage * 100.0,
+                        if branch.low_confidence {
+                            format!(" {}", style("· low confidence").yellow())
+                        } else {
+                            String::new()
+                        }
+                    );
+                    if !branch.flags.is_empty() {
+                        let flags: Vec<&str> =
+                            branch.flags.iter().map(|f| f.label()).collect();
+                        println!("   {} {}", style("common flags:").dim(), flags.join(", "));
+                    }
+                    print_breakdown(&branch.breakdown);
+                }
             }
         }
 

--- a/src/pr.rs
+++ b/src/pr.rs
@@ -574,7 +574,7 @@ fn resolve_branch_commit(repo: &git2::Repository, name: &str) -> Option<git2::Oi
 /// (`origin/HEAD`), then `main` / `master`. Returns `None` (→ unscoped, full
 /// `HEAD` walk) when nothing resolves or `HEAD` already *is* the base (e.g. the
 /// branch has not diverged), so the renderer degrades gracefully.
-fn detect_base_oid(repo: &git2::Repository, workdir: &Path) -> Option<git2::Oid> {
+pub fn detect_base_oid(repo: &git2::Repository, workdir: &Path) -> Option<git2::Oid> {
     let head = repo.head().ok()?.peel_to_commit().ok()?.id();
 
     let mut names: Vec<String> = Vec::new();

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -741,6 +741,122 @@ pub fn probe_host_for(claim: IsolationClaim) -> HostCaps {
     }
 }
 
+/// Support for one isolation claim on this host: can its policy be *resolved*
+/// (`satisfiable`), and — for the kernel tiers — does a confined command
+/// actually *exec* here (`runnable`, the functional `verify_exec` self-test)?
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimSupport {
+    pub claim: &'static str,
+    pub satisfiable: bool,
+    /// Functional exec self-test for the kernel tiers (`Some`); `None` for tiers
+    /// not exec-tested here (container needs an image; hardened/microvm aren't
+    /// built in).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runnable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<&'static str>,
+}
+
+/// Machine-readable answer to "what can h5i actually enforce here?" — the
+/// structured form of `h5i env probe`, so a downstream product adapts to the
+/// real host instead of regex-scraping a log line. Backs `env capabilities
+/// [--json]`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesReport {
+    pub os: String,
+    pub landlock_abi: Option<i32>,
+    pub userns: bool,
+    pub seccomp: bool,
+    pub container_runtime: Option<String>,
+    /// A **domain allowlist** for egress can be *enforced* here. Only the
+    /// container tier's DNS-pinned proxy enforces it; the kernel tiers can
+    /// deny-all but never allowlist, so this tracks the container runtime.
+    pub egress_enforced: bool,
+    /// Resource limits (mem / procs / wall / cpu) can be enforced — true when
+    /// any confined tier beyond `workspace` runs here (kernel rlimits or the
+    /// container runtime's cgroup limits).
+    pub resource_limits: bool,
+    pub claims: Vec<ClaimSupport>,
+    /// The strongest tier that actually runs here (`workspace` is the floor).
+    pub strongest_tier: &'static str,
+}
+
+/// Probe the host and evaluate every isolation claim, mirroring the auto-pick
+/// (`resolve` + functional `verify_exec`) used by `env create`. Shells out to
+/// `podman info` once (via [`probe_host`]) — reserve for diagnostic paths.
+pub fn capabilities_report() -> CapabilitiesReport {
+    let caps = probe_host();
+    let mut claims: Vec<ClaimSupport> = Vec::new();
+    let mut strongest = IsolationClaim::Workspace;
+
+    // Kernel tiers: resolve the built-in `probe` profile, then run the functional
+    // exec self-test (`verify_exec` is a no-op for every tier except Process, so
+    // Workspace/Supervised are gated by `resolve` alone — exactly as auto-pick).
+    for claim in [
+        IsolationClaim::Workspace,
+        IsolationClaim::Process,
+        IsolationClaim::Supervised,
+    ] {
+        let mut p = Profile::builtin("probe", claim);
+        // Workspace applies no net confinement, so probe it with host net; the
+        // confined tiers keep the built-in deny default.
+        if claim == IsolationClaim::Workspace {
+            p.net_mode = NetMode::Host;
+        }
+        let satisfiable = resolve(&p, &caps).is_ok();
+        let runnable = resolve(&p, &caps)
+            .and_then(|pol| verify_exec(&pol))
+            .is_ok();
+        if runnable && claim > strongest {
+            strongest = claim;
+        }
+        claims.push(ClaimSupport {
+            claim: claim.as_str(),
+            satisfiable,
+            runnable: Some(runnable),
+            note: None,
+        });
+    }
+
+    // Container tier: gated by a rootless-Podman runtime; a concrete run also
+    // needs a profile image, so it isn't exec-tested here.
+    let container_ok = caps.container_runtime.is_some();
+    if container_ok && IsolationClaim::Container > strongest {
+        strongest = IsolationClaim::Container;
+    }
+    claims.push(ClaimSupport {
+        claim: IsolationClaim::Container.as_str(),
+        satisfiable: container_ok,
+        runnable: None,
+        note: Some("needs rootless Podman + profile container.image"),
+    });
+    for claim in [IsolationClaim::HardenedContainer, IsolationClaim::Microvm] {
+        claims.push(ClaimSupport {
+            claim: claim.as_str(),
+            satisfiable: false,
+            runnable: None,
+            note: Some("external backend (not in this build)"),
+        });
+    }
+
+    let resource_limits = container_ok
+        || claims
+            .iter()
+            .any(|c| c.claim != "workspace" && c.runnable == Some(true));
+
+    CapabilitiesReport {
+        os: caps.os,
+        landlock_abi: caps.landlock_abi,
+        userns: caps.userns,
+        seccomp: caps.seccomp,
+        container_runtime: caps.container_runtime,
+        egress_enforced: container_ok,
+        resource_limits,
+        claims,
+        strongest_tier: strongest.as_str(),
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn probe_host_kernel_uncached() -> HostCaps {
     HostCaps {
@@ -3037,5 +3153,37 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
         assert!(p.tools.is_empty());
         let policy = ResolvedPolicy::new(IsolationClaim::Workspace, p);
         assert!(run(&policy, dir.path(), &["true".into()]).is_ok());
+    }
+
+    #[test]
+    fn capabilities_report_invariants() {
+        // Host-independent structural invariants (the actual bits vary by host,
+        // so we don't assert on landlock/podman presence).
+        let r = capabilities_report();
+        // Every claim is reported, weakest → strongest.
+        let claims: Vec<&str> = r.claims.iter().map(|c| c.claim).collect();
+        assert_eq!(
+            claims,
+            vec![
+                "workspace",
+                "process",
+                "supervised",
+                "container",
+                "hardened-container",
+                "microvm",
+            ]
+        );
+        // Workspace is the floor: no confinement needed, so always usable.
+        let ws = r.claims.iter().find(|c| c.claim == "workspace").unwrap();
+        assert!(ws.satisfiable && ws.runnable == Some(true));
+        // Not-in-this-build backends are always unsatisfiable.
+        for name in ["hardened-container", "microvm"] {
+            let c = r.claims.iter().find(|c| c.claim == name).unwrap();
+            assert!(!c.satisfiable && c.runnable.is_none());
+        }
+        // Egress allowlist enforcement tracks the container runtime exactly.
+        assert_eq!(r.egress_enforced, r.container_runtime.is_some());
+        // strongest_tier is one of the known claims.
+        assert!(claims.contains(&r.strongest_tier));
     }
 }


### PR DESCRIPTION
…surfaces

Address L1 + L2 from h5i-assess H5I-IMPROVEMENTS.md — give a headless/CI product structured surfaces it currently has to infer or self-attest.

L1: h5i audit maturity [--json] — the prompt-maturity score that feeds merge_confidence, previously only reachable via the web server. Branch mode rolls up base..HEAD AI-commit prompts (score_branch); --text/--oid score a single prompt (mirrors /api/prompt-score). Routed as an audit verb.

L2: h5i --version --json (pre-clap interceptor; name/version/features) and h5i env capabilities [--json], backed by sandbox::capabilities_report() which mirrors the env-create auto-pick (resolve + verify_exec) to report tier, egress-enforced, resource-limit support, and per-claim satisfiable/runnable.