### PR TITLE
feat(filters): add cmake output filter

### DIFF
--- a/assets/filters/cmake.toml
+++ b/assets/filters/cmake.toml
@@ -1,0 +1,72 @@
+[filters.cmake]
+description = "Compact CMake configure/build output — strip probe chatter, keep warnings, errors, and final status"
+match_command = "^cmake\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^-- (The |Detecting |Check(ing)? |Looking for |Performing Test |Found |Using |Configuring incomplete, errors occurred!)",
+  "^-- (C|CXX|CUDA|ASM) compiler identification is ",
+  "^-- (Detecting|Check for working|Detecting .* done)",
+]
+truncate_lines_at = 240
+max_lines = 120
+on_empty = "cmake: clean"
+
+[[tests.cmake]]
+name = "configure success keeps final status and drops probes"
+input = """
+-- The C compiler identification is GNU 13.2.0
+-- The CXX compiler identification is GNU 13.2.0
+-- Detecting C compiler ABI info
+-- Detecting C compiler ABI info - done
+-- Check for working C compiler: /usr/bin/cc - skipped
+-- Found OpenSSL: /usr/lib/libssl.so
+-- Configuring done (0.4s)
+-- Generating done (0.1s)
+-- Build files have been written to: /work/build
+"""
+expected = """-- Configuring done (0.4s)
+-- Generating done (0.1s)
+-- Build files have been written to: /work/build"""
+
+[[tests.cmake]]
+name = "keeps error block while dropping probe noise"
+input = """
+-- The CXX compiler identification is GNU 13.2.0
+-- Detecting CXX compiler ABI info
+-- Detecting CXX compiler ABI info - done
+CMake Error at CMakeLists.txt:12 (find_package):
+  Could not find a package configuration file provided by "Qt6" with any of
+  the following names:
+
+    Qt6Config.cmake
+    qt6-config.cmake
+
+-- Configuring incomplete, errors occurred!
+"""
+expected = """CMake Error at CMakeLists.txt:12 (find_package):
+  Could not find a package configuration file provided by "Qt6" with any of
+  the following names:
+    Qt6Config.cmake
+    qt6-config.cmake"""
+
+[[tests.cmake]]
+name = "keeps warning and final status"
+input = """
+-- Detecting C compiler ABI info
+CMake Warning at cmake/Options.cmake:5 (message):
+  Optional feature X is disabled
+-- Configuring done
+-- Generating done
+"""
+expected = """CMake Warning at cmake/Options.cmake:5 (message):
+  Optional feature X is disabled
+-- Configuring done
+-- Generating done"""
+
+[[tests.cmake]]
+name = "empty run collapses to clean message"
+input = """
+
+"""
+expected = "cmake: clean"


### PR DESCRIPTION
## Summary
Fixes #207

Adds a declarative built-in output filter for `cmake` configure/build output, preserving warnings, errors, and final configure/generate status while dropping routine probe chatter.

## Changes
- Add `assets/filters/cmake.toml` with a `^cmake\b` matcher
- Strip common `-- Detecting` / `-- Found` / compiler probe lines and blanks
- Add inline golden tests for success, error, warning, and empty output

## Test Plan
- `python3` semantic check of the inline golden cases: pass
- `H5I_SKIP_WEB_BUILD=1 cargo test builtin_golden_tests_pass -- --nocapture` (blocked in this environment: linker `cc` is not installed)