### PR TITLE
fix(cli): treat recall log --limit 0 as no limit

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -721,7 +721,7 @@ Show commit history with full AI provenance inline. Canonical form of the legacy
 
 | Option | Description |
 |--------|-------------|
-| `--limit <n>` | Number of commits to show (default: all) |
+| `--limit <n>` | Number of commits to show (default: 10; `0` = all) |
 | `--ancestry <file>:<line>` | Trace every commit that touched a specific line, annotated with its prompt |
 
 **Example — recent commits**

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1067,7 +1067,7 @@ h5i hook codex finish [--summary &lt;text&gt;] [--quiet]
 <tbody>
 <tr>
 <td><code>--limit &lt;n&gt;</code></td>
-<td>Number of commits to show (default: all)</td>
+<td>Number of commits to show (default: 10; <code>0</code> = all)</td>
 </tr>
 <tr>
 <td><code>--ancestry &lt;file&gt;:&lt;line&gt;</code></td>

--- a/src/main.rs
+++ b/src/main.rs
@@ -826,7 +826,7 @@ enum Commands {
     /// Display the enriched 5D commit history
     #[command(hide = true)]
     Log {
-        /// Number of recent commits to display
+        /// Number of recent commits to display (0 = all)
         #[arg(short, long, default_value_t = 10)]
         limit: usize,
 
@@ -6441,7 +6441,8 @@ fn main() -> anyhow::Result<()> {
                     }
                 }
             } else {
-                repo.print_log(limit)?;
+                let log_limit = if limit == 0 { usize::MAX } else { limit };
+                repo.print_log(log_limit)?;
             }
         }
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -480,8 +480,10 @@ fn recall_log_limit_caps_entries() {
         "larger limit should include older commits: {all}"
     );
     assert!(
-        !zero.contains("limited commit"),
-        "limit 0 should not render commit entries: {zero}"
+        zero.contains("limited commit 2")
+            && zero.contains("limited commit 1")
+            && zero.contains("limited commit 0"),
+        "limit 0 should include all commits: {zero}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Treat `h5i recall log --limit 0` as uncapped instead of rendering no commits.
- Update the flag help/manual text and regression coverage.

## Why

Fixes #283. This uses Option A from the issue: `0` means no limit. The CLI now translates that value before it reaches the shared log helper, so the default and positive limits keep their existing behavior.

## Validation

- `cargo test --test cli_integration recall_log_limit_caps_entries -- --nocapture` — passed
- `cargo test --test cli_integration` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `git diff --check` — passed
- `cargo test --lib -- --skip seccomp_notify::tests::live_socket_gate_denies_raw_allows_inet` — not completed locally; this host ran out of `/tmp` space during `mcp::tests::env_lifecycle_over_mcp` while copying plugin test fixtures