### PR TITLE
docs: mention elvish completion support

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -3313,7 +3313,7 @@ default to the **current team** when you omit it — set it with `h5i team
 use <name>` (or let `create` set it). `add-env`/`verify` keep `<team>` required
 (they take a second positional). The flat CLI stays canonical, so this never
 changes scripting/cron/agent behavior (always pass `<team>` there). For fast
-typing, generate shell completion: `h5i completion <bash|zsh|fish|powershell> >
+typing, generate shell completion: `h5i completion <bash|elvish|fish|powershell|zsh> >
 …` (e.g. `h5i completion bash | sudo tee /etc/bash_completion.d/h5i`).
 
 **Dispatching the task to the whole ensemble.** `h5i team dispatch` sends the

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -4125,7 +4125,7 @@ default to the <strong>current team</strong> when you omit it — set it with <c
 use &lt;name&gt;</code> (or let <code>create</code> set it). <code>add-env</code>/<code>verify</code> keep <code>&lt;team&gt;</code> required
 (they take a second positional). The flat CLI stays canonical, so this never
 changes scripting/cron/agent behavior (always pass <code>&lt;team&gt;</code> there). For fast
-typing, generate shell completion: <code>h5i completion &lt;bash|zsh|fish|powershell&gt; &gt;
+typing, generate shell completion: <code>h5i completion &lt;bash|elvish|fish|powershell|zsh&gt; &gt;
 …</code> (e.g. <code>h5i completion bash | sudo tee /etc/bash_completion.d/h5i</code>).</p>
 <p><strong>Dispatching the task to the whole ensemble.</strong> <code>h5i team dispatch</code> sends the
 task to every roster agent at once (you never paste the prompt per env). It is a


### PR DESCRIPTION
## Summary
Fixes #276

Documents `elvish` in the `h5i completion` shell list in `MANUAL.md`, matching the shells supported by the CLI.

## Verification
- `grep -q 'h5i completion <bash|elvish|fish|powershell|zsh>' MANUAL.md`