### PR TITLE
feat(filters): add clang output filter

### DIFF
--- a/assets/filters/clang.toml
+++ b/assets/filters/clang.toml
@@ -1,0 +1,54 @@
+[filters.clang]
+description = "Compact clang/clang++ compiler output — strip include notes, keep errors and warnings"
+match_command = "^clang(\\+\\+)?\\b"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s+\\|\\s*$",
+  "^In file included from",
+  "^\\s+from\\s",
+  "^\\d+ warnings? generated",
+  "^\\d+ errors? generated",
+]
+max_lines = 50
+on_empty = "clang: ok"
+
+[[tests.clang]]
+name = "strips include chain, keeps errors and warnings"
+input = """
+In file included from /usr/include/stdio.h:42:
+                 from main.c:1:
+main.c:10:5: error: use of undeclared identifier 'foo'
+    foo();
+    ^
+main.c:15:12: warning: unused variable 'x' [-Wunused-variable]
+    int x = 42;
+        ^
+2 warnings generated.
+1 error generated.
+"""
+expected = "main.c:10:5: error: use of undeclared identifier 'foo'\n    foo();\n    ^\nmain.c:15:12: warning: unused variable 'x' [-Wunused-variable]\n    int x = 42;\n        ^"
+
+[[tests.clang]]
+name = "clean compilation"
+input = """
+"""
+expected = "clang: ok"
+
+[[tests.clang]]
+name = "linker error kept"
+input = """
+/usr/bin/ld: /tmp/main.o: undefined reference to 'missing_func'
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+"""
+expected = "/usr/bin/ld: /tmp/main.o: undefined reference to 'missing_func'\nclang: error: linker command failed with exit code 1 (use -v to see invocation)"
+
+[[tests.clang]]
+name = "clang++ command uses same rule"
+input = """
+hello.cc:3:10: fatal error: 'missing.hpp' file not found
+#include <missing.hpp>
+         ^~~~~~~~~~~~~
+1 error generated.
+"""
+expected = "hello.cc:3:10: fatal error: 'missing.hpp' file not found\n#include <missing.hpp>\n         ^~~~~~~~~~~~~"

--- a/src/filter_rules.rs
+++ b/src/filter_rules.rs
@@ -700,6 +700,8 @@ mod tests {
             (&["gradlew", "build"], "gradle"),
             (&["./gradlew", "build"], "gradle"),
             (&["gcc", "-O2", "main.c"], "gcc"),
+            (&["clang", "-Wall", "main.c"], "clang"),
+            (&["clang++", "main.cc"], "clang"),
             (&["make", "all"], "make"),
             // Narrowed ecosystem rules: noisy subcommands route…
             (&["npm", "run", "build"], "npm"),
@@ -758,7 +760,7 @@ mod tests {
         sorted.sort();
         assert_eq!(names, sorted, "filters must be globally name-sorted");
 
-        for sample in ["gradle build", "gcc main.c", "make all", "terraform plan", "docker build ."] {
+        for sample in ["gradle build", "gcc main.c", "clang main.c", "clang++ main.cc", "make all", "terraform plan", "docker build ."] {
             let n = reg.filters.iter().filter(|f| f.match_regex.is_match(sample)).count();
             assert!(n <= 1, "command {sample:?} matched {n} rules (ambiguous routing)");
         }


### PR DESCRIPTION
## Summary
Fixes #282

Adds a built-in declarative output filter for `clang` / `clang++`, mirroring the existing gcc/g++ behavior so compiler output keeps diagnostics while stripping include-chain/noise lines.

## Changes
- Adds `assets/filters/clang.toml` with inline golden cases.
- Adds clang/clang++ route coverage to filter rule tests.

## Verification
- `python3`/`tomllib` parse check for `assets/filters/clang.toml` ✅
- `cargo test filter_rules --quiet` attempted, but this runner lacks a C linker: `linker cc not found`.