### PR TITLE
test: add filter edge-case goldens

### DIFF
--- a/assets/filters/flake8.toml
+++ b/assets/filters/flake8.toml
@@ -24,3 +24,17 @@ src/a.py:10:80: E501 line too long (88 > 79 characters)
 name = "clean run collapses to message"
 input = ""
 expected = "flake8: clean"
+
+[[tests.flake8]]
+name = "syntax error keeps filename and code while dropping blanks"
+input = """
+
+src/bad.py:3:7: E999 SyntaxError: invalid syntax
+
+src/bad.py:4:1: F821 undefined name 'result'
+
+"""
+expected = """
+src/bad.py:3:7: E999 SyntaxError: invalid syntax
+src/bad.py:4:1: F821 undefined name 'result'
+"""

--- a/assets/filters/go.toml
+++ b/assets/filters/go.toml
@@ -45,3 +45,21 @@ PASS
 ok  \texample/m\t0.012s
 """
 expected = "go: ok"
+
+[[tests.go]]
+name = "compile error keeps package and source diagnostics"
+input = """
+go: downloading golang.org/x/text v0.14.0
+# example.com/app/cmd
+cmd/main.go:12:9: undefined: missingSymbol
+cmd/main.go:13:2: declared and not used: value
+FAIL\texample.com/app/cmd [build failed]
+FAIL
+"""
+expected = """
+# example.com/app/cmd
+cmd/main.go:12:9: undefined: missingSymbol
+cmd/main.go:13:2: declared and not used: value
+FAIL\texample.com/app/cmd [build failed]
+FAIL
+"""

--- a/assets/filters/jest.toml
+++ b/assets/filters/jest.toml
@@ -42,3 +42,24 @@ PASS src/b.test.ts
 Tests:       13 passed, 13 total
 """
 expected = "Tests:       13 passed, 13 total"
+
+[[tests.jest]]
+name = "setup failure keeps suite error and summary"
+input = """
+PASS src/ok.test.ts
+FAIL src/config.test.ts
+  ● Test suite failed to run
+    Cannot find module './missing-config' from 'src/config.test.ts'
+    > 1 | import './missing-config'
+A worker process has failed to exit gracefully
+Test Suites: 1 failed, 1 passed, 2 total
+Tests:       3 passed, 3 total
+"""
+expected = """
+FAIL src/config.test.ts
+  ● Test suite failed to run
+    Cannot find module './missing-config' from 'src/config.test.ts'
+    > 1 | import './missing-config'
+Test Suites: 1 failed, 1 passed, 2 total
+Tests:       3 passed, 3 total
+"""

--- a/assets/filters/npm.toml
+++ b/assets/filters/npm.toml
@@ -43,3 +43,20 @@ audited 50 packages in 1s
 found 0 vulnerabilities
 """
 expected = "npm: ok"
+
+[[tests.npm]]
+name = "dependency resolution failure keeps npm ERR details"
+input = """
+npm WARN using --force Recommended protections disabled.
+npm notice New major version of npm available! 10.8.2 -> 11.0.0
+npm ERR! code ERESOLVE
+npm ERR! ERESOLVE unable to resolve dependency tree
+npm ERR! While resolving: demo@1.0.0
+npm ERR! Found: react@18.2.0
+"""
+expected = """
+npm ERR! code ERESOLVE
+npm ERR! ERESOLVE unable to resolve dependency tree
+npm ERR! While resolving: demo@1.0.0
+npm ERR! Found: react@18.2.0
+"""

--- a/assets/filters/pip.toml
+++ b/assets/filters/pip.toml
@@ -38,3 +38,23 @@ expected = """
 ERROR: Could not find a version that satisfies the requirement nope
 ERROR: No matching distribution found for nope
 """
+
+[[tests.pip]]
+name = "build failure keeps subprocess error details"
+input = """
+Collecting broken-package
+  Using cached broken-package-1.0.0.tar.gz (12 kB)
+  Preparing metadata (pyproject.toml) ... done
+Building wheels for collected packages: broken-package
+  Building wheel for broken-package (pyproject.toml) ... error
+  error: subprocess-exited-with-error
+  × Building wheel for broken-package did not run successfully.
+  │ exit code: 1
+ERROR: Failed building wheel for broken-package
+"""
+expected = """
+  error: subprocess-exited-with-error
+  × Building wheel for broken-package did not run successfully.
+  │ exit code: 1
+ERROR: Failed building wheel for broken-package
+"""

--- a/assets/filters/yarn.toml
+++ b/assets/filters/yarn.toml
@@ -39,3 +39,19 @@ success Already up-to-date.
 Done in 0.5s
 """
 expected = "yarn: ok"
+
+[[tests.yarn]]
+name = "engine mismatch keeps package error"
+input = """
+yarn install v1.22.19
+[1/4] Resolving packages...
+[2/4] Fetching packages...
+warning package-a@1.0.0: The engine "node" appears to be invalid.
+error package-b@2.0.0: The engine "node" is incompatible with this module. Expected version ">=20". Got "18.19.0"
+error Found incompatible module.
+Done in 1.23s
+"""
+expected = """
+error package-b@2.0.0: The engine "node" is incompatible with this module. Expected version ">=20". Got "18.19.0"
+error Found incompatible module.
+"""


### PR DESCRIPTION
## Summary
Fixes #211

Adds meaningful error/edge-case golden coverage for six thinly-tested built-in filters.

## Changes
- Add npm dependency-resolution failure golden coverage
- Add pip wheel-build failure golden coverage
- Add Go compile-error golden coverage
- Add flake8 syntax-error/blank-line golden coverage
- Add Jest setup-failure golden coverage
- Add Yarn engine-mismatch golden coverage

## Verification
- `cargo test builtin_golden_tests_pass` (blocked locally: rustc could not find linker `cc` in this environment)
- `python3` TOML parse + local rule-emulator check for the six touched filters: passed (18 cases checked; all filter TOML files parse)