### PR TITLE
fix(serve): friendly error when the dashboard port is already in use

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -3259,7 +3259,15 @@ pub async fn serve(repo_path: PathBuf, port: u16) -> anyhow::Result<()> {
     let app = build_router(state);
 
     let addr = format!("127.0.0.1:{}", port);
-    let listener = TcpListener::bind(&addr).await?;
+    let listener = match TcpListener::bind(&addr).await {
+        Ok(listener) => listener,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            anyhow::bail!(
+                "port {port} is already in use — pick another with `h5i serve --port <N>`"
+            );
+        }
+        Err(e) => return Err(e.into()),
+    };
     println!("  h5i UI →  http://{}", addr);
     axum::serve(listener, app).await?;
     Ok(())
@@ -3311,4 +3319,37 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/prompt-score", get(api_prompt_score))
         .route("/api/radio", get(api_radio))
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // #277: binding an already-used port must produce a friendly, actionable
+    // error that names the port and points at `--port`, rather than a raw OS
+    // "Address already in use (os error 98)".
+    #[tokio::test]
+    async fn serve_reports_friendly_error_when_port_in_use() {
+        // Occupy an OS-assigned port and keep the listener alive across the call.
+        let occupied = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = occupied.local_addr().unwrap().port();
+
+        let err = serve(std::path::PathBuf::from("."), port)
+            .await
+            .expect_err("binding an already-used port must fail");
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("already in use"),
+            "expected an 'already in use' message, got: {msg}"
+        );
+        assert!(
+            msg.contains(&port.to_string()),
+            "expected the port number in the message, got: {msg}"
+        );
+        assert!(
+            msg.contains("--port"),
+            "expected a `--port` hint, got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
## What

`h5i serve` now gives a clear, actionable error when the dashboard port is already in use instead of a raw OS error.

Before:
```
Error: Address already in use (os error 98)
```
After:
```
Error: port 7150 is already in use — pick another with `h5i serve --port <N>`
```

## Why

Fixes #277. For a UI command this is a common, self-inflicted papercut, and the raw error gives no hint that `--port` exists.

## How

In `server::serve`, match on the `TcpListener::bind` result and special-case only `std::io::ErrorKind::AddrInUse`, returning an `anyhow` error that names the actual port and points at `h5i serve --port <N>`. Every other bind error (permission denied, invalid address, …) keeps the existing `?` fallthrough, and the successful path is unchanged.

## Testing

Added a unit test (`server::tests::serve_reports_friendly_error_when_port_in_use`) that occupies an OS-assigned port, calls `serve` on it, and asserts the error names the port, says "already in use", and mentions `--port`.

```
cargo test --lib serve_reports_friendly   # passes
cargo clippy --all-targets --all-features -- -D warnings   # clean
```

## Compatibility

No CLI flags, commands, stored refs, or output on the success path change — only the failure message for the in-use case. No docs/manual regeneration needed (the clap command tree is untouched).
