### PR TITLE
Add --json output to env inspect

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2892,7 +2892,7 @@ another reviews and applies). See `docs/environments-design.md` and the live
 | `h5i env ports <name> [--json]` | The per-env **injected** port map: each running service with a declared port and the free host port h5i allocated and injected as `PORT` / `H5I_ENV_PORT_<NAME>`. v1 is injection only — there is **no host→box forwarder**, so a port is reachable only if the service binds the injected value (the URL is shown as conditional, not a guarantee). |
 | `h5i env log <name>` | The event log (`created`/`exec`/`service`/`proposed`/`applied`/`aborted`/`gc`/`violation`/`secret`). |
 | `h5i env diff <name> [--stat]` | Diff the env's work against its pinned base. |
-| `h5i env inspect <name> --capture <id>` | Render one evidence capture (structured findings, exit code, policy digest, redactions). |
+| `h5i env inspect <name> --capture <id> [--json]` | Render one evidence capture (structured findings, exit code, policy digest, redactions). `--json` emits the stored capture manifest for tooling instead of the human view. |
 | `h5i env compare <names…> [--json]` | The "arena": rank N envs side by side (changes + latest run results). Best on envs sharing one base. |
 | `h5i env rebase <name>` | Re-pin the base onto the parent branch's advanced tip (3-way; refuses on conflict). |
 | `h5i env propose <name>` | Mediated commit (path-allowlist enforced: rejects nested `.git`, symlink escapes, `..`) + review brief. Never writes the parent. |

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3604,8 +3604,8 @@ another reviews and applies). See <code>docs/environments-design.md</code> and t
 <td>Diff the env's work against its pinned base.</td>
 </tr>
 <tr>
-<td><code>h5i env inspect &lt;name&gt; --capture &lt;id&gt;</code></td>
-<td>Render one evidence capture (structured findings, exit code, policy digest, redactions).</td>
+<td><code>h5i env inspect &lt;name&gt; --capture &lt;id&gt; [--json]</code></td>
+<td>Render one evidence capture (structured findings, exit code, policy digest, redactions). <code>--json</code> emits the stored capture manifest for tooling instead of the human view.</td>
 </tr>
 <tr>
 <td><code>h5i env compare &lt;names…&gt; [--json]</code></td>

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -545,13 +545,16 @@ Inspect one of an environment's evidence captures (structured findings, exit cod
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBinspect\fR <\fB\-\-capture\fR> [\fB\-h\fR|\fB\-\-help\fR] <\fINAME\fR> 
+\fBinspect\fR <\fB\-\-capture\fR> [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fINAME\fR> 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
 .TP
 \fB\-\-capture\fR \fI<CAPTURE>\fR
 Capture id (from `h5i env status`/`log`)
+.TP
+\fB\-\-json\fR
+Emit the stored capture manifest as JSON instead of the human view
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/env.rs
+++ b/src/env.rs
@@ -5398,7 +5398,11 @@ fn stamp_apply_provenance(
 /// (or text summary), exit code, policy digest, and any redactions. The
 /// capture must belong to this env — a capture id from another env is refused
 /// so `inspect` can't be used to read unrelated evidence.
-pub fn inspect(repo: &Repository, m: &EnvManifest, capture_id: &str) -> Result<String, H5iError> {
+pub fn inspect_manifest(
+    repo: &Repository,
+    m: &EnvManifest,
+    capture_id: &str,
+) -> Result<objects::Manifest, H5iError> {
     let manifest = objects::resolve_manifest(repo, capture_id)?;
     if manifest.env_id.as_deref() != Some(m.id.as_str()) {
         return Err(H5iError::Metadata(format!(
@@ -5408,6 +5412,15 @@ pub fn inspect(repo: &Repository, m: &EnvManifest, capture_id: &str) -> Result<S
             manifest.env_id.as_deref().unwrap_or("<none>")
         )));
     }
+    Ok(manifest)
+}
+
+/// Render one of an environment's evidence captures: its structured findings
+/// (or text summary), exit code, policy digest, and any redactions. The
+/// capture must belong to this env — a capture id from another env is refused
+/// so `inspect` can't be used to read unrelated evidence.
+pub fn inspect(repo: &Repository, m: &EnvManifest, capture_id: &str) -> Result<String, H5iError> {
+    let manifest = inspect_manifest(repo, m, capture_id)?;
     let mut out = String::new();
     out.push_str(&format!("── Capture {} ({}) ──\n", manifest.id, m.id));
     if let Some(cmd) = &manifest.cmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2016,6 +2016,9 @@ enum EnvCommands {
         /// Capture id (from `h5i env status`/`log`)
         #[arg(long)]
         capture: String,
+        /// Emit the stored capture manifest as JSON instead of the human view
+        #[arg(long)]
+        json: bool,
     },
 
     /// Compare environments side by side — changes + latest run results (the
@@ -11543,9 +11546,18 @@ fn main() -> anyhow::Result<()> {
                     print!("{}", h5i_core::env::diff(git, &h5i_root, &m, stat)?);
                 }
 
-                EnvCommands::Inspect { name, capture } => {
+                EnvCommands::Inspect {
+                    name,
+                    capture,
+                    json,
+                } => {
                     let m = h5i_core::env::find(&h5i_root, &name)?;
-                    print!("{}", h5i_core::env::inspect(git, &m, &capture)?);
+                    if json {
+                        let manifest = h5i_core::env::inspect_manifest(git, &m, &capture)?;
+                        println!("{}", serde_json::to_string_pretty(&manifest)?);
+                    } else {
+                        print!("{}", h5i_core::env::inspect(git, &m, &capture)?);
+                    }
                 }
 
                 EnvCommands::Compare { names, json } => {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -3710,6 +3710,46 @@ fn inspect_renders_all_capture_fields() {
     );
 }
 
+/// `inspect --json` emits the same stored manifest that backs the human view,
+/// after applying the same env ownership check. Tooling can consume it without
+/// scraping the pretty renderer, while cross-env evidence remains refused.
+#[test]
+fn inspect_json_renders_the_capture_manifest() {
+    let r = Repo::new();
+    r.h5i_ok(&["env", "create", "json"]);
+    r.h5i_ok(&["env", "create", "other"]);
+    r.h5i_ok(&["env", "run", "json", "--", "sh", "-c", "echo json-body"]);
+
+    let env_m = r.manifest("json");
+    let cap = env_m["captures"][0].as_str().unwrap().to_string();
+    let digest = env_m["policy_digest"].as_str().unwrap();
+
+    let out = r.h5i_ok(&["env", "inspect", "json", "--capture", &cap, "--json"]);
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("inspect --json is valid JSON");
+
+    assert_eq!(v["id"].as_str(), Some(cap.as_str()), "{v:#}");
+    assert_eq!(v["env_id"].as_str(), Some("env/tester/json"), "{v:#}");
+    assert_eq!(v["exit_code"].as_i64(), Some(0), "{v:#}");
+    assert_eq!(v["policy_digest"].as_str(), Some(digest), "{v:#}");
+    assert!(
+        v["raw_oid"]
+            .as_str()
+            .is_some_and(|oid| oid.starts_with("sha256:")),
+        "{v:#}"
+    );
+    assert!(
+        v["summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("json-body")),
+        "{v:#}"
+    );
+
+    let out = r.h5i(&["env", "inspect", "other", "--capture", &cap, "--json"]);
+    assert!(!out.status.success(), "cross-env JSON inspect must be refused");
+    assert!(out_str(&out).contains("not evidence for"), "{}", out_str(&out));
+}
+
 /// A capture handle that resolves to nothing, and one too short to be a prefix,
 /// both fail loudly with an actionable message rather than rendering an empty or
 /// wrong capture.


### PR DESCRIPTION
## Summary

- Add `--json` to `h5i env inspect`.
- Reuse the stored capture manifest and existing ownership check for the JSON path.
- Document the flag and refresh the generated manuals.

## Why

Closes #281. `env inspect` had a human view only, so tooling had to scrape rendered text to consume a single capture.

## Validation

- `cargo test --test env_integration inspect_json_renders_the_capture_manifest -- --nocapture` - passed
- `cargo test --test env_integration inspect_ -- --nocapture` - passed
- `cargo clippy --all-targets --all-features -- -D warnings` - passed
- `scripts/gen_man.sh` - passed
- `python3 scripts/gen_manual.py` - passed
- `git diff --check -- . ':(exclude)man/man1/h5i.1'` - passed