### PR TITLE
docs: document the top-level `h5i doctor` command

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -76,6 +76,7 @@ emits `--json` is safe to consume from a script or another agent.)
 - [Core commands](#core-commands)
   - [h5i init](#h5i-init)
   - [h5i resolve](#h5i-resolve)
+  - [h5i doctor](#h5i-doctor)
 - [h5i capture](#h5i-capture)
   - [h5i capture commit](#h5i-capture-commit)
   - [h5i capture memory](#h5i-capture-memory)
@@ -291,6 +292,38 @@ status 1; otherwise it exits 0.
 > reading from a per-commit `crdt_states` field. That dependency has been
 > removed; `resolve` now behaves like a deterministic, git-native 3-way
 > merge.
+
+---
+
+### h5i doctor
+
+```
+h5i doctor [--repair] [--export <DIR>] [--json]
+```
+
+Validate and repair h5i's sidecar storage and refs. Run it when the sidecar
+looks damaged or after recovering a repository — for example if `.git/.h5i/` is
+missing directories, or refs under `refs/h5i/*` were lost by an aggressive
+prune. By default it only reports; nothing is changed unless you pass `--repair`.
+
+- `--repair` — create missing sidecar directories and schema metadata. Existing
+  data is left untouched; this only fills in what is absent.
+- `--export <DIR>` — write a recovery copy of `.git/.h5i` plus a refs manifest
+  into `<DIR>`, so the sidecar state can be archived or moved.
+- `--json` — emit the raw report instead of the pretty view, for tooling.
+
+The command exits non-zero when the sidecar is unhealthy, so it is safe to gate
+scripts on it.
+
+```bash
+h5i doctor                     # report only
+h5i doctor --repair            # fix missing dirs and schema metadata
+h5i doctor --export /tmp/h5i-backup
+```
+
+> **Note:** This is the top-level command for the whole sidecar. The per-env
+> health check is separate — see [`h5i env doctor`](#h5i-env) for enforcement
+> readiness and structural health of a single environment.
 
 ---
 

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -165,6 +165,7 @@
 <div class="t3group">
 <a class="t3" href="#h5i-init">h5i init</a>
 <a class="t3" href="#h5i-resolve">h5i resolve</a>
+<a class="t3" href="#h5i-doctor">h5i doctor</a>
 </div>
 <a class="t2" href="#h5i-capture">h5i capture</a>
 <div class="t3group">
@@ -595,6 +596,32 @@ status 1; otherwise it exits 0.</p>
 reading from a per-commit <code>crdt_states</code> field. That dependency has been
 removed; <code>resolve</code> now behaves like a deterministic, git-native 3-way
 merge.</p>
+</blockquote>
+<hr />
+<h3 id="h5i-doctor">h5i doctor</h3>
+<pre><code>h5i doctor [--repair] [--export &lt;DIR&gt;] [--json]
+</code></pre>
+<p>Validate and repair h5i's sidecar storage and refs. Run it when the sidecar
+looks damaged or after recovering a repository — for example if <code>.git/.h5i/</code> is
+missing directories, or refs under <code>refs/h5i/*</code> were lost by an aggressive
+prune. By default it only reports; nothing is changed unless you pass <code>--repair</code>.</p>
+<ul>
+<li><code>--repair</code> — create missing sidecar directories and schema metadata. Existing
+  data is left untouched; this only fills in what is absent.</li>
+<li><code>--export &lt;DIR&gt;</code> — write a recovery copy of <code>.git/.h5i</code> plus a refs manifest
+  into <code>&lt;DIR&gt;</code>, so the sidecar state can be archived or moved.</li>
+<li><code>--json</code> — emit the raw report instead of the pretty view, for tooling.</li>
+</ul>
+<p>The command exits non-zero when the sidecar is unhealthy, so it is safe to gate
+scripts on it.</p>
+<pre><code class="language-bash">h5i doctor                     # report only
+h5i doctor --repair            # fix missing dirs and schema metadata
+h5i doctor --export /tmp/h5i-backup
+</code></pre>
+<blockquote>
+<p><strong>Note:</strong> This is the top-level command for the whole sidecar. The per-env
+health check is separate — see <a href="#h5i-env"><code>h5i env doctor</code></a> for enforcement
+readiness and structural health of a single environment.</p>
 </blockquote>
 <hr />
 <h2 id="h5i-capture">h5i capture</h2>


### PR DESCRIPTION
Closes #275.

## What

Adds a `h5i doctor` section to `MANUAL.md` (Core commands group), plus a TOC entry and the regenerated `docs/manual/index.html` mirror.

## Why

`h5i doctor` was the only top-level command missing from the manual — the reference documents `h5i env doctor` but not the top-level one, so a reader had no way to discover it.

## How

New section covering `--repair`, `--export <DIR>`, and `--json`, with flag descriptions taken from `h5i doctor --help`, and a cross-reference disambiguating it from the per-env `h5i env doctor`. Regenerated the HTML mirror via `scripts/gen_manual.py` (additive, no churn).

AI-assisted; verified locally that the cross-reference anchor resolves and the mirror renders the new section.