### PR TITLE
test(filters): golden-test the on_empty path for the remaining filters

### DIFF
--- a/assets/filters/jest.toml
+++ b/assets/filters/jest.toml
@@ -63,3 +63,8 @@ FAIL src/config.test.ts
 Test Suites: 1 failed, 1 passed, 2 total
 Tests:       3 passed, 3 total
 """
+
+[[tests.jest]]
+name = "clean run collapses to message"
+input = ""
+expected = "jest: ok"

--- a/assets/filters/mvn-build.toml
+++ b/assets/filters/mvn-build.toml
@@ -42,3 +42,8 @@ input = """
 [INFO] Finished at: 2024-01-15T10:30:00Z
 """
 expected = "[INFO] BUILD SUCCESS\n[INFO] Total time: 4.123 s\n[INFO] Finished at: 2024-01-15T10:30:00Z"
+
+[[tests.mvn-build]]
+name = "clean run collapses to message"
+input = ""
+expected = "mvn: ok"

--- a/assets/filters/mypy.toml
+++ b/assets/filters/mypy.toml
@@ -26,3 +26,8 @@ Found 2 errors in 2 files (checked 9 source files)
 name = "keeps success line"
 input = "Success: no issues found in 5 source files"
 expected = "Success: no issues found in 5 source files"
+
+[[tests.mypy]]
+name = "clean run collapses to message"
+input = ""
+expected = "mypy: ok"

--- a/assets/filters/pip.toml
+++ b/assets/filters/pip.toml
@@ -58,3 +58,8 @@ expected = """
   │ exit code: 1
 ERROR: Failed building wheel for broken-package
 """
+
+[[tests.pip]]
+name = "clean run collapses to message"
+input = ""
+expected = "pip: ok"

--- a/assets/filters/ruff.toml
+++ b/assets/filters/ruff.toml
@@ -39,3 +39,8 @@ input = """
 error: invalid value '--bad' for '--select'
 """
 expected = "error: invalid value '--bad' for '--select'"
+
+[[tests.ruff]]
+name = "clean run collapses to message"
+input = ""
+expected = "ruff: clean"

--- a/assets/filters/terraform-plan.toml
+++ b/assets/filters/terraform-plan.toml
@@ -33,3 +33,8 @@ expected = "Terraform will perform the following actions:\n  # aws_instance.web 
 name = "strips noise, preserves non-blank content"
 input = "Refreshing state... [id=vpc-abc]\nNo changes. Your infrastructure matches the configuration."
 expected = "No changes. Your infrastructure matches the configuration."
+
+[[tests.terraform-plan]]
+name = "clean run collapses to message"
+input = ""
+expected = "terraform plan: no changes detected"

--- a/assets/filters/tsc.toml
+++ b/assets/filters/tsc.toml
@@ -42,3 +42,8 @@ input = """
 error TS5023: Unknown compiler option '--bad'.
 """
 expected = "error TS5023: Unknown compiler option '--bad'."
+
+[[tests.tsc]]
+name = "clean run collapses to message"
+input = ""
+expected = "tsc: ok"

--- a/assets/filters/vitest.toml
+++ b/assets/filters/vitest.toml
@@ -39,3 +39,8 @@ input = """
       Tests  5 passed (5)
 """
 expected = "      Tests  5 passed (5)"
+
+[[tests.vitest]]
+name = "clean run collapses to message"
+input = ""
+expected = "vitest: ok"


### PR DESCRIPTION
Closes #210.

## What

Adds a "clean run collapses to message" golden test to the eight filters that declared an `on_empty` message but had no test exercising the empty path: jest, mvn-build, mypy, pip, ruff, terraform-plan, tsc, vitest.

## Why

Without a test for the empty case, a regression in the empty-handling could silently stop emitting the `on_empty` message. The other 33 `on_empty` filters already have this coverage.

## How

Each new case feeds empty input and expects the filter's `on_empty` string, matching the existing pattern (e.g. `eslint`'s "clean run collapses to message"). For these keep-by-default filters, blank input is the only thing that reaches the `on_empty` branch, so it is the right exercise.

Verified with the golden-test runner (`cargo test builtin_golden_tests_pass`, and the `objects_e2e` integration check) — confirmed the new cases actually run by temporarily breaking one and seeing it caught.

AI-assisted.