### PR TITLE
feat(filters): add glab list output filter

### DIFF
--- a/assets/filters/glab.toml
+++ b/assets/filters/glab.toml
@@ -1,0 +1,45 @@
+[filters.glab]
+description = "Compact GitLab CLI list output - strip banners and padding, keep result rows and errors"
+match_command = "^glab\\s+(mr|issue|pipeline|ci|release)\\s+(list|ls)\\b"
+strip_ansi = true
+replace = [
+  { pattern = "^\\s+|\\s+$", replacement = "" },
+]
+strip_lines_matching = [
+  "^\\s*$",
+  "^Showing \\d+ .+ \\(Page \\d+\\)$",
+]
+max_lines = 40
+on_empty = "glab: no results"
+
+[[tests.glab]]
+name = "keeps merge request rows and removes the list banner"
+input = """
+Showing 3 open merge requests on gitlab-org/cli. (Page 1)
+
+!3500\tgitlab-org/cli!3500\tchore(deps): update bubbletea\t(main) ← (renovate/bubbletea)
+!3499\tgitlab-org/cli!3499\tperf(issue): fetch board issues in parallel\t(main) ← (fetch-issues-parallel)
+!3494\tgitlab-org/cli!3494\tfeat(securefile): update existing files\t(main) ← (securefile-update)
+"""
+expected = """
+!3500\tgitlab-org/cli!3500\tchore(deps): update bubbletea\t(main) ← (renovate/bubbletea)
+!3499\tgitlab-org/cli!3499\tperf(issue): fetch board issues in parallel\t(main) ← (fetch-issues-parallel)
+!3494\tgitlab-org/cli!3494\tfeat(securefile): update existing files\t(main) ← (securefile-update)
+"""
+
+[[tests.glab]]
+name = "preserves a padded error diagnostic"
+input = """
+   \u001B[31mERROR\u001B[0m
+
+  404 Not Found.
+"""
+expected = """
+ERROR
+404 Not Found.
+"""
+
+[[tests.glab]]
+name = "reports an empty result"
+input = ""
+expected = "glab: no results"

--- a/crates/h5i-core/src/filter_rules.rs
+++ b/crates/h5i-core/src/filter_rules.rs
@@ -718,6 +718,8 @@ mod tests {
             (&["php", "-d", "xdebug.mode=coverage", "vendor/bin/phpunit"], "phpunit"),
             (&["php", "-c", "php.ini", "./vendor/bin/phpunit"], "phpunit"),
             (&["php", "-n", "phpunit.phar"], "phpunit"),
+            (&["glab", "mr", "list", "--per-page", "20"], "glab"),
+            (&["/usr/bin/glab", "issue", "ls"], "glab"),
         ];
         for (cmd, expected) in cases {
             let argv: Vec<String> = cmd.iter().map(|s| s.to_string()).collect();
@@ -762,6 +764,8 @@ mod tests {
             &["npm", "ls", "--json"],
             &["pnpm", "list", "--json"],
             &["yarn", "info", "react", "--json"],
+            &["glab", "mr", "view", "42"],
+            &["glab", "api", "projects/1"],
         ];
         for cmd in none {
             let argv: Vec<String> = cmd.iter().map(|s| s.to_string()).collect();

--- a/crates/h5i-core/tests/filter_quality.rs
+++ b/crates/h5i-core/tests/filter_quality.rs
@@ -176,6 +176,51 @@ fn gcc_rule_cuts_tokens_keeps_errors_drops_include_chain() {
     assert_token_cut(&res, 200, 0.5);
 }
 
+#[test]
+fn glab_rule_caps_long_lists_without_mutating_json() {
+    let mut raw = String::from("Showing 100 open merge requests on gitlab-org/cli. (Page 1)\n\n");
+    for i in 0..100 {
+        let id = 3500 - i;
+        raw.push_str(&format!(
+            "!{id}\tgitlab-org/cli!{id}\tfix(cli): preserve result signal for case {i}\t(main) ← (fix/case-{i})\n"
+        ));
+    }
+
+    let res = filter(
+        &raw,
+        &cfg(
+            OutputKind::Auto,
+            Some(argv(&["glab", "mr", "list", "--per-page", "100"])),
+        ),
+    );
+    keeps(
+        &res,
+        &[
+            "!3500\tgitlab-org/cli!3500",
+            "!3461\tgitlab-org/cli!3461",
+            "... (60 lines truncated)",
+        ],
+    );
+    drops(
+        &res,
+        &[
+            "Showing 100 open merge requests",
+            "!3460\tgitlab-org/cli!3460",
+        ],
+    );
+    assert_token_cut(&res, 1_500, 0.5);
+
+    let json = r#"[{"iid":3500,"title":"preserve  internal spacing","state":"opened"}]"#;
+    let json_res = filter(
+        json,
+        &cfg(
+            OutputKind::Auto,
+            Some(argv(&["glab", "mr", "list", "--output", "json"])),
+        ),
+    );
+    assert_eq!(json_res.summary, json);
+}
+
 // ── 1+2: declarative rules for common JS/Go/JVM/TS tools ─────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- add a declarative filter for human-readable `glab` list commands
- keep result rows and errors while removing ANSI, list banners, and edge padding
- cover routing, golden output, token reduction, and JSON preservation

## Why

`glab` list output includes presentation noise and can grow well beyond its default page size. The filter keeps the useful rows intact for normal pages and caps oversized lists without changing non-list commands or one-line JSON output.

Closes #203.

## Validation

- `cargo test -p h5i-core --lib filter_rules::tests::` — 8 passed
- `cargo test -p h5i-core --test filter_quality` — 14 passed
- `cargo test -p h5i-core --lib -- --skip mcp::tests::env_lifecycle_over_mcp` — 840 passed, 3 ignored
- `cargo clippy -p h5i-core --all-targets --all-features -- -D warnings` — passed
- `git diff --check` — passed