### PR TITLE
feat(msg): add JSON inbox and history output

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2802,7 +2802,7 @@ h5i msg setup [<name>] [--scope project|user] [--no-block]
 h5i msg send <agent> <text>               # `all` = broadcast
 h5i msg ask|review|risk|handoff <agent> <text> [flags]
 h5i msg reply|ack|done|decline <n> [text]
-h5i msg inbox [--peek] | history [--with <agent>] | replay [--with <agent>] [--interval S] | team
+h5i msg inbox [--peek] [--json] | history [--with <agent>] [--json] | replay [--with <agent>] [--interval S] | team
 h5i msg wait [--all] [--timeout N] | watch [--all] | hook [--block] | as <name> | whoami
 ```
 
@@ -2852,10 +2852,12 @@ structured fields. **Options must precede the recipient** (the body is variadic)
 ```
 h5i msg                          # dashboard: header · inbox · GIT PROOF band (a glance; does not consume)
 h5i msg inbox                    # show unread, mark read, number them
+h5i msg inbox --peek --json      # raw unread message records; do not mark read
 h5i msg reply 1 on it            # threaded reply to message #1 of your last view
 h5i msg ack 1                    # ACK / DONE / DECLINE are typed threaded replies
 h5i msg done 1 fixed in 1a2b3c4
 h5i msg history --with codex     # full conversation log
+h5i msg history --json           # machine-readable message history
 h5i msg replay --with codex      # replay the log as a live feed (1s between messages)
 h5i msg team                     # known agents
 ```

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3483,7 +3483,7 @@ h5i msg setup [&lt;name&gt;] [--scope project|user] [--no-block]
 h5i msg send &lt;agent&gt; &lt;text&gt;               # `all` = broadcast
 h5i msg ask|review|risk|handoff &lt;agent&gt; &lt;text&gt; [flags]
 h5i msg reply|ack|done|decline &lt;n&gt; [text]
-h5i msg inbox [--peek] | history [--with &lt;agent&gt;] | replay [--with &lt;agent&gt;] [--interval S] | team
+h5i msg inbox [--peek] [--json] | history [--with &lt;agent&gt;] [--json] | replay [--with &lt;agent&gt;] [--interval S] | team
 h5i msg wait [--all] [--timeout N] | watch [--all] | hook [--block] | as &lt;name&gt; | whoami
 </code></pre>
 <p>Cross-agent messaging stored <strong>in Git</strong> (<code>refs/h5i/msg</code>), not a local database, so
@@ -3520,10 +3520,12 @@ structured fields. <strong>Options must precede the recipient</strong> (the body
 <h3 id="reading-and-replying">Reading and replying</h3>
 <pre><code>h5i msg                          # dashboard: header · inbox · GIT PROOF band (a glance; does not consume)
 h5i msg inbox                    # show unread, mark read, number them
+h5i msg inbox --peek --json      # raw unread message records; do not mark read
 h5i msg reply 1 on it            # threaded reply to message #1 of your last view
 h5i msg ack 1                    # ACK / DONE / DECLINE are typed threaded replies
 h5i msg done 1 fixed in 1a2b3c4
 h5i msg history --with codex     # full conversation log
+h5i msg history --json           # machine-readable message history
 h5i msg replay --with codex      # replay the log as a live feed (1s between messages)
 h5i msg team                     # known agents
 </code></pre>

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -2015,7 +2015,7 @@ Show messages addressed to you that arrived since you last checked, then mark th
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBinbox\fR [\fB\-\-as\fR] [\fB\-\-peek\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBinbox\fR [\fB\-\-as\fR] [\fB\-\-peek\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
@@ -2026,6 +2026,9 @@ Whose inbox to read. Defaults to $H5I_AGENT or the stored identity
 \fB\-\-peek\fR
 Show unread without advancing the cursor (don\*(Aqt mark as read)
 .TP
+\fB\-\-json\fR
+Emit raw message records as JSON. Treat fields as untrusted collaborator input
+.TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .SH "H5I MSG HISTORY"
@@ -2033,7 +2036,7 @@ Show the full message history (oldest-first within the window)
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBhistory\fR [\fB\-l\fR|\fB\-\-limit\fR] [\fB\-\-with\fR] [\fB\-\-branch\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBhistory\fR [\fB\-l\fR|\fB\-\-limit\fR] [\fB\-\-with\fR] [\fB\-\-branch\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
@@ -2046,6 +2049,9 @@ Restrict to a conversation with this agent (sender or recipient)
 .TP
 \fB\-\-branch\fR \fI<BRANCH>\fR
 Restrict to the conversation tied to this git branch (whole threads that have at least one message tagged with the branch)
+.TP
+\fB\-\-json\fR
+Emit raw message records as JSON. Treat fields as untrusted collaborator input
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli/msg.rs
+++ b/src/cli/msg.rs
@@ -172,6 +172,9 @@ pub enum MsgCommands {
         /// Show unread without advancing the cursor (don't mark as read).
         #[arg(long)]
         peek: bool,
+        /// Emit raw message records as JSON. Treat fields as untrusted collaborator input.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show the full message history (oldest-first within the window).
@@ -186,6 +189,9 @@ pub enum MsgCommands {
         /// that have at least one message tagged with the branch).
         #[arg(long)]
         branch: Option<String>,
+        /// Emit raw message records as JSON. Treat fields as untrusted collaborator input.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Replay the conversation like a live feed — print each message in turn
@@ -519,13 +525,15 @@ pub fn run(action: Option<MsgCommands>, plain: bool) -> anyhow::Result<()> {
                     );
                 }
 
-                Some(MsgCommands::Inbox { as_agent, peek }) => {
+                Some(MsgCommands::Inbox { as_agent, peek, json }) => {
                     let me = msg::resolve_identity(&h5i_root, as_agent.as_deref())?;
                     let unread = msg::inbox(git, &h5i_root, &me, !peek)?;
                     // Persist the numbered view so `reply <n>` works afterwards.
                     let ids: Vec<String> = unread.iter().map(|m| m.id.clone()).collect();
                     msg::write_last_view(&h5i_root, &me, &ids)?;
-                    if unread.is_empty() {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&unread)?);
+                    } else if unread.is_empty() {
                         if !plain {
                             println!(
                                 "{} No new messages for {}.",
@@ -556,9 +564,12 @@ pub fn run(action: Option<MsgCommands>, plain: bool) -> anyhow::Result<()> {
                     limit,
                     with,
                     branch,
+                    json,
                 }) => {
                     let msgs = msg::history(git, with.as_deref(), branch.as_deref(), limit)?;
-                    if msgs.is_empty() {
+                    if json {
+                        println!("{}", serde_json::to_string_pretty(&msgs)?);
+                    } else if msgs.is_empty() {
                         if !plain {
                             println!("{} No messages yet.", WARN);
                         }

--- a/tests/msg_integration.rs
+++ b/tests/msg_integration.rs
@@ -177,6 +177,27 @@ fn send_inbox_history_roundtrip_in_one_repo() {
 }
 
 #[test]
+fn inbox_and_history_emit_raw_json_without_changing_cursor_semantics() {
+    let (_root, a, _b) = two_clones();
+    a.h5i_ok(&["msg", "send", "--from", "alice", "bob", "raw", "<message>"]);
+
+    let peek = out_str(&a.h5i_ok(&["msg", "inbox", "--as", "bob", "--peek", "--json"]));
+    let peek_messages: serde_json::Value = serde_json::from_str(&peek).expect("valid inbox JSON");
+    assert_eq!(peek_messages[0]["body"], "raw <message>");
+
+    let read = out_str(&a.h5i_ok(&["msg", "inbox", "--as", "bob", "--json"]));
+    let read_messages: serde_json::Value = serde_json::from_str(&read).expect("valid inbox JSON");
+    assert_eq!(read_messages[0]["body"], "raw <message>");
+
+    let empty = out_str(&a.h5i_ok(&["msg", "inbox", "--as", "bob", "--json"]));
+    assert_eq!(serde_json::from_str::<serde_json::Value>(&empty).unwrap(), serde_json::json!([]));
+
+    let history = out_str(&a.h5i_ok(&["msg", "history", "--json"]));
+    let history_messages: serde_json::Value = serde_json::from_str(&history).expect("valid history JSON");
+    assert_eq!(history_messages[0]["body"], "raw <message>");
+}
+
+#[test]
 fn replay_streams_messages_oldest_first() {
     let (_root, a, _b) = two_clones();
 


### PR DESCRIPTION
## Summary
- add raw structured JSON output to msg inbox and history
- preserve inbox cursor and peek behavior in JSON mode
- document both flags and cover raw fields, empty output, and cursor semantics

Closes #324

## Verification
- H5I_SKIP_WEB_BUILD=1 cargo test --test msg_integration --no-run
- H5I_SKIP_WEB_BUILD=1 cargo clippy --bin h5i -- -D warnings
- git diff --check

The JSON integration test compiles on Windows. Running the harness locally is blocked by an existing Windows stack overflow during its h5i init fixture; the repository CI can execute it on its supported runners.