### PR TITLE
feat: h5i env rm accepts multiple names

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2932,6 +2932,7 @@ another reviews and applies). See `docs/environments-design.md` and the live
 | `h5i env propose <name>` | Mediated commit (path-allowlist enforced: rejects nested `.git`, symlink escapes, `..`) + review brief. Never writes the parent. |
 | `h5i env apply <name> [--patch]` | Apply a proposed env onto its parent (reviewer-selected). Default merges; `--patch` squashes into one commit. The applied commit is **stamped with env provenance** — a note linking it back to the env and summarizing the evidence by trust lane (`host-env-run` vs box-claimed `inbox-capture`), visible in `h5i recall log`. |
 | `h5i env abort <name>` | Discard the env; manifest + workspace retained for forensics. |
+| `h5i env rm <name>… [--force]` | **Permanently** remove one or more environments: prune their worktrees, delete their code + reasoning branches, and erase their manifests. Multiple names are processed in order; a failure for one does not abort the rest, but the exit code is non-zero if any removal failed. A still-live env (created/running/proposed) needs `--force`. Only the `removed` event in `refs/h5i/env` survives. |
 | `h5i env gc` | Reclaim worktrees of applied/aborted envs. Manifests, branches, and captures are retained. |
 
 `<name>` accepts a bare slug, `agent/slug`, or the full `env/agent/slug`.

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3659,6 +3659,10 @@ another reviews and applies). See <code>docs/environments-design.md</code> and t
 <td>Discard the env; manifest + workspace retained for forensics.</td>
 </tr>
 <tr>
+<td><code>h5i env rm &lt;name&gt;… [--force]</code></td>
+<td><strong>Permanently</strong> remove one or more environments: prune their worktrees, delete their code + reasoning branches, and erase their manifests. Multiple names are processed in order; a failure for one does not abort the rest, but the exit code is non-zero if any removal failed. A still-live env (created/running/proposed) needs <code>--force</code>. Only the <code>removed</code> event in <code>refs/h5i/env</code> survives.</td>
+</tr>
+<tr>
 <td><code>h5i env gc</code></td>
 <td>Reclaim worktrees of applied/aborted envs. Manifests, branches, and captures are retained.</td>
 </tr>

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -664,23 +664,23 @@ Print help
 <\fINAME\fR>
 
 .SH "H5I ENV RM"
-Permanently remove an environment from this clone: prune its worktree, delete its code + reasoning branches, and erase its manifest. Destroys local provenance (only the `removed` event in refs/h5i/env survives). A still-live env (created/running/proposed) needs --force
+Permanently remove one or more environments from this clone: prune their worktrees, delete their code + reasoning branches, and erase their manifests. Destroys local provenance (only the `removed` event in refs/h5i/env survives). A still-live env (created/running/proposed) needs --force. Multiple names are processed in order; a failure for one env is reported but does not abort the rest
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBrm\fR [\fB\-\-force\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fINAME\fR> 
+\fBrm\fR [\fB\-\-force\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fINAMES\fR> 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
 .TP
 \fB\-\-force\fR
-Remove even if the env is still live (not applied/aborted)
+Remove even if the env is still live (not applied/aborted). Applies to every listed env
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .TP
-<\fINAME\fR>
-
+<\fINAMES\fR>
+One or more environment names (slug, `agent/slug`, or full `env/agent/slug`)
 .SH "H5I ENV GC"
 Reclaim workspaces of applied/aborted environments (worktree prune). Manifests, branches, and captures are retained
 .ie \n(.g .ds Aq \(aq

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -236,13 +236,18 @@ pub enum EnvCommands {
     /// Abort an environment — manifest and workspace preserved for forensics
     Abort { name: String },
 
-    /// Permanently remove an environment from this clone: prune its worktree,
-    /// delete its code + reasoning branches, and erase its manifest. Destroys
-    /// local provenance (only the `removed` event in refs/h5i/env survives).
-    /// A still-live env (created/running/proposed) needs --force.
+    /// Permanently remove one or more environments from this clone: prune
+    /// their worktrees, delete their code + reasoning branches, and erase
+    /// their manifests. Destroys local provenance (only the `removed` event
+    /// in refs/h5i/env survives). A still-live env (created/running/proposed)
+    /// needs --force. Multiple names are processed in order; a failure for one
+    /// env is reported but does not abort the rest.
     Rm {
-        name: String,
-        /// Remove even if the env is still live (not applied/aborted)
+        /// One or more environment names (slug, `agent/slug`, or full `env/agent/slug`)
+        #[arg(required = true, num_args = 1..)]
+        names: Vec<String>,
+        /// Remove even if the env is still live (not applied/aborted).
+        /// Applies to every listed env.
         #[arg(long)]
         force: bool,
     },
@@ -936,13 +941,37 @@ pub fn run(action: EnvCommands) -> anyhow::Result<()> {
                     );
                 }
 
-                EnvCommands::Rm { name, force } => {
-                    let m = h5i_core::env::find(&h5i_root, &name)?;
-                    h5i_core::env::rm(git, &h5i_root, &m, force)?;
-                    println!(
-                        "{} {} removed (workspace, branches, and manifest erased)",
-                        SUCCESS, m.id
-                    );
+                EnvCommands::Rm { names, force } => {
+                    let mut any_failed = false;
+                    for name in &names {
+                        match h5i_core::env::find(&h5i_root, name) {
+                            Ok(m) => match h5i_core::env::rm(git, &h5i_root, &m, force) {
+                                Ok(()) => println!(
+                                    "{} {} removed (workspace, branches, and manifest erased)",
+                                    SUCCESS, m.id
+                                ),
+                                Err(e) => {
+                                    eprintln!(
+                                        "{} failed to remove {}: {e}",
+                                        style("error:").red().bold(),
+                                        name
+                                    );
+                                    any_failed = true;
+                                }
+                            },
+                            Err(e) => {
+                                eprintln!(
+                                    "{} env '{}' not found: {e}",
+                                    style("error:").red().bold(),
+                                    name
+                                );
+                                any_failed = true;
+                            }
+                        }
+                    }
+                    if any_failed {
+                        std::process::exit(1);
+                    }
                 }
 
                 EnvCommands::Gc => {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -5341,3 +5341,72 @@ fn create_rejects_bad_service_name_in_config() {
         out_str(&out)
     );
 }
+
+// ─── env rm: multi-name and partial-failure ──────────────────────────────────
+
+/// `h5i env rm a b --force` removes both envs in a single call.
+/// Single-name behavior is unchanged: exit 0, both manifests and worktrees gone.
+#[test]
+fn env_rm_removes_multiple_envs() {
+    let r = Repo::new();
+    r.h5i_ok(&["env", "create", "alpha"]);
+    r.h5i_ok(&["env", "create", "beta"]);
+
+    // Sanity: both worktrees exist before rm.
+    assert!(r.work("alpha").exists(), "alpha worktree should exist");
+    assert!(r.work("beta").exists(), "beta worktree should exist");
+
+    // Remove both in one call with --force (they are in `created` status).
+    let out = r.h5i_ok(&["env", "rm", "alpha", "beta", "--force"]);
+    let text = out_str(&out);
+    assert!(text.contains("alpha"), "should confirm removal of alpha:\n{text}");
+    assert!(text.contains("beta"), "should confirm removal of beta:\n{text}");
+
+    // Worktrees and manifest files must be gone.
+    assert!(!r.env_dir("alpha").join("manifest.json").exists(), "alpha manifest still present");
+    assert!(!r.env_dir("beta").join("manifest.json").exists(), "beta manifest still present");
+    assert!(!r.work("alpha").exists(), "alpha worktree still present");
+    assert!(!r.work("beta").exists(), "beta worktree still present");
+
+    // h5i env list should show no envs remaining.
+    let list_out = out_str(&r.h5i_ok(&["env", "list"]));
+    assert!(
+        !list_out.contains("env/tester/alpha") && !list_out.contains("env/tester/beta"),
+        "alpha or beta still visible in env list:\n{list_out}"
+    );
+}
+
+/// `h5i env rm good nope` — one missing env must not abort the other.
+/// The present env is removed; exit code is non-zero; both failures are reported.
+#[test]
+fn env_rm_partial_failure_continues_and_exits_nonzero() {
+    let r = Repo::new();
+    r.h5i_ok(&["env", "create", "good"]);
+
+    // Attempt to remove both a real env and a nonexistent one.
+    let out = r.h5i(&["env", "rm", "good", "nope", "--force"]);
+
+    // The real env must be gone.
+    assert!(!r.env_dir("good").join("manifest.json").exists(), "good manifest still present");
+    assert!(!r.work("good").exists(), "good worktree still present");
+
+    // The command must exit non-zero because `nope` failed.
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit when a name fails, got 0"
+    );
+
+    // stderr must mention the missing env.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("nope"),
+        "expected 'nope' mentioned in stderr:\n{stderr}"
+    );
+
+    // But the successful removal must still appear in stdout.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("good"),
+        "expected 'good' removal confirmation in stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
Closes #326

Acceptance criteria


- [x] h5i env rm <n1> <n2> … removes every named env; single-name behavior unchanged

- [x] A failing name doesn't abort the rest; the exit code is non-zero if any failed

- [x] Docs regenerated (MANUAL.md, man page, HTML manual)

- [x] Integration test in tests/env_integration.rs covering the multi-name and partial-failure paths
