### PR TITLE
feat(env): add limit to event log

### DIFF
--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -518,10 +518,13 @@ Show the event log (refs/h5i/env) for one environment
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBlog\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fINAME\fR> 
+\fBlog\fR [\fB\-\-limit\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fINAME\fR> 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
+.TP
+\fB\-\-limit\fR \fI<LIMIT>\fR [default: 0]
+Show only the newest N events (0 shows the full log)
 .TP
 \fB\-\-json\fR
 Emit the event records as JSON instead of the human view

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -164,6 +164,9 @@ pub enum EnvCommands {
     /// Show the event log (refs/h5i/env) for one environment
     Log {
         name: String,
+        /// Show only the newest N events (0 shows the full log)
+        #[arg(long, default_value_t = 0)]
+        limit: usize,
         /// Emit the event records as JSON instead of the human view
         #[arg(long)]
         json: bool,
@@ -826,9 +829,12 @@ pub fn run(action: EnvCommands) -> anyhow::Result<()> {
                     println!("{} {}", SUCCESS, msg_out);
                 }
 
-                EnvCommands::Log { name, json } => {
+                EnvCommands::Log { name, limit, json } => {
                     let m = h5i_core::env::find(&h5i_root, &name)?;
-                    let events = h5i_core::env::read_events(git, Some(&m.id));
+                    let mut events = h5i_core::env::read_events(git, Some(&m.id));
+                    if limit > 0 && events.len() > limit {
+                        events.drain(..events.len() - limit);
+                    }
                     if json {
                         println!("{}", serde_json::to_string_pretty(&events)?);
                     } else {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -4627,6 +4627,45 @@ fn log_json_emits_env_event_records() {
     assert!(text.contains("exec"), "{text}");
 }
 
+#[test]
+fn env_log_limit_returns_the_newest_events() {
+    let r = Repo::new();
+    r.h5i_ok(&["env", "create", "limited-log"]);
+    for marker in ["first", "second", "third"] {
+        r.h5i_ok(&[
+            "env",
+            "run",
+            "limited-log",
+            "--",
+            "sh",
+            "-c",
+            &format!("echo {marker}"),
+        ]);
+    }
+
+    let all: serde_json::Value = serde_json::from_slice(
+        &r.h5i_ok(&["env", "log", "limited-log", "--json"]).stdout,
+    )
+    .expect("full env log must be valid JSON");
+    let limited: serde_json::Value = serde_json::from_slice(
+        &r.h5i_ok(&["env", "log", "limited-log", "--limit", "2", "--json"])
+            .stdout,
+    )
+    .expect("limited env log must be valid JSON");
+
+    let all = all.as_array().expect("full event log is an array");
+    let limited = limited.as_array().expect("limited event log is an array");
+    assert_eq!(limited.len(), 2);
+    assert_eq!(limited, &all[all.len() - 2..]);
+
+    let unlimited: serde_json::Value = serde_json::from_slice(
+        &r.h5i_ok(&["env", "log", "limited-log", "--limit", "0", "--json"])
+            .stdout,
+    )
+    .expect("zero limit env log must be valid JSON");
+    assert_eq!(unlimited.as_array().unwrap(), all);
+}
+
 // ─── 14. shareable environments across clones (the multi-agent review loop) ──
 
 /// A clone addressed through the h5i binary under a fixed agent identity.


### PR DESCRIPTION
## Summary

- add `--limit N` to `h5i env log`, preserving the current unlimited default
- retain the newest N events rather than the oldest N
- apply the tail before both text rendering and JSON serialization

Closes #323.

## Validation

- `H5I_SKIP_WEB_BUILD=1 cargo check --bin h5i`
- `H5I_SKIP_WEB_BUILD=1 cargo clippy --bin h5i -- -D warnings`
- `git diff --check`
- added a Linux integration regression covering newest-event ordering, JSON composition, and `--limit 0`

The full integration target cannot compile on native Windows because existing tests import `std::os::unix::fs::PermissionsExt` unconditionally. A native CLI smoke test is also blocked by a pre-existing stack overflow in the freshly built Windows binary. Upstream Linux CI will run the added end-to-end test.
