### PR TITLE
feat(log): add JSON output

### DIFF
--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -1,7 +1,7 @@
 //! `h5i log` — CLI handler (migrated from main.rs).
 use crate::*;
 
-pub fn run(limit: usize, ancestry: Option<String>) -> anyhow::Result<()> {
+pub fn run(limit: usize, json: bool, ancestry: Option<String>) -> anyhow::Result<()> {
     {
             let repo = H5iRepository::open(".")?;
 
@@ -72,7 +72,11 @@ pub fn run(limit: usize, ancestry: Option<String>) -> anyhow::Result<()> {
                 }
             } else {
                 let log_limit = if limit == 0 { usize::MAX } else { limit };
-                repo.print_log(log_limit)?;
+                if json {
+                    println!("{}", serde_json::to_string_pretty(&repo.get_log(log_limit)?)?);
+                } else {
+                    repo.print_log(log_limit)?;
+                }
             }
         }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -847,6 +847,10 @@ enum Commands {
         #[arg(short, long, default_value_t = 10)]
         limit: usize,
 
+        /// Emit commit provenance records as JSON
+        #[arg(long, conflicts_with = "ancestry")]
+        json: bool,
+
         /// Show the full prompt ancestry chain for a specific line.
         /// Format: <file>:<line>  e.g.  src/model.py:42
         /// Prints every commit that ever touched that line, annotated with the
@@ -3598,7 +3602,11 @@ fn main() -> anyhow::Result<()> {
 
         Commands::Commit { message, intent, model, agent, tests, test_results, test_cmd, audit, force, caused_by, decisions, add } => cli::commit::run(message, intent, model, agent, tests, test_results, test_cmd, audit, force, caused_by, decisions, add)?,
 
-        Commands::Log { limit, ancestry } => cli::log::run(limit, ancestry)?,
+        Commands::Log {
+            limit,
+            json,
+            ancestry,
+        } => cli::log::run(limit, json, ancestry)?,
 
         Commands::Blame { file, show_prompt } => cli::blame::run(file, show_prompt)?,
 

--- a/tests/e2e_noun_workflow.rs
+++ b/tests/e2e_noun_workflow.rs
@@ -322,3 +322,19 @@ fn legacy_log_verb_still_works_and_hints_to_recall() {
         "legacy `h5i log` should hint at `h5i recall log`; got:\n{combined}"
     );
 }
+
+#[test]
+fn recall_log_json_emits_limited_commit_records() {
+    let repo = Repo::new();
+    repo.h5i_ok(&["init"]);
+    repo.capture_commit("a.txt", "alpha\n", "json log", "record JSON provenance");
+
+    let out = repo.h5i_ok(&["recall", "log", "--limit", "1", "--json"]);
+    let records: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("recall log --json must emit valid JSON");
+    let records = records.as_array().expect("JSON log must be an array");
+
+    assert_eq!(records.len(), 1, "--limit applies to JSON output");
+    assert!(records[0]["git_oid"].is_string(), "record includes the commit SHA");
+    assert!(records[0]["ai_metadata"].is_object(), "record includes provenance metadata");
+}


### PR DESCRIPTION
## Summary

- add `--json` to `h5i recall log` and the legacy `h5i log` alias
- serialize the existing enriched commit records, including `git_oid` and provenance metadata
- preserve the current human-readable output and apply `--limit` identically to both views
- reject the incompatible `--json --ancestry` combination at argument parsing

Closes #322.

## Validation

- Linux: `H5I_SKIP_WEB_BUILD=1 cargo test --test e2e_noun_workflow log_` — 3 passed
- Windows: `H5I_SKIP_WEB_BUILD=1 cargo clippy --bin h5i -- -D warnings`
- Windows: `H5I_SKIP_WEB_BUILD=1 cargo check --bin h5i`
- `git diff --check` on changed source/test files

The regression compiles on Windows, but execution there remains blocked by the repository's pre-existing startup stack overflow. The same end-to-end test passes under Linux, matching upstream CI.
