### PR TITLE
fix(orchestra): fail closed when a seat's env no longer exists

### DIFF
--- a/crates/h5i-core/src/team.rs
+++ b/crates/h5i-core/src/team.rs
@@ -18,6 +18,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const TEAM_REF_PREFIX: &str = "refs/h5i/team/";
+/// Where `rm` parks a removed run's event log: out of `list`, but the audit
+/// trail survives and the run is recoverable by moving the ref back.
+const TEAM_ATTIC_REF_PREFIX: &str = "refs/h5i/team-attic/";
 const EVENTS_FILE: &str = "events.jsonl";
 const MAX_ATTEMPTS: usize = 64;
 
@@ -467,6 +470,98 @@ pub fn list(repo: &Repository) -> Result<Vec<TeamRun>, H5iError> {
     }
     out.sort_by(|a, b| a.created_at.cmp(&b.created_at));
     Ok(out)
+}
+
+/// What `rm` did, for the caller to report (and act on, e.g. `--envs`).
+#[derive(Debug, Clone, Serialize)]
+pub struct RmOutcome {
+    pub run_id: String,
+    /// Where the event log was archived; `None` when purged.
+    pub attic_ref: Option<String>,
+    /// Envs the roster was bound to — still present after `rm` (they may hold
+    /// uncommitted agent work); the caller decides whether to remove them.
+    pub env_ids: Vec<String>,
+    /// Whether the current-team pointer named this run and was cleared.
+    pub cleared_current: bool,
+}
+
+/// Remove a team run from the listing.
+///
+/// By default the run's ref (and with it the whole append-only event log) is
+/// *archived* — moved to `refs/h5i/team-attic/<run_id>` (suffixed `-2`, `-3`, …
+/// on collision) after a final `run_removed` event — so the audit trail
+/// survives and a mistaken removal is recoverable by moving the ref back.
+/// `purge` deletes the ref outright instead. Either way the removal is
+/// clone-local (team refs are not part of `share push` today); there is no
+/// cross-clone tombstone, so a manually synced ref would re-introduce the run.
+///
+/// A run with submissions but no verdict is plausibly live work; removing it
+/// requires `force`. Bound envs are never touched — their ids are returned so
+/// the caller can remove them explicitly.
+pub fn rm(
+    repo: &Repository,
+    h5i_root: &Path,
+    run_id: &str,
+    purge: bool,
+    force: bool,
+    actor: &str,
+) -> Result<RmOutcome, H5iError> {
+    let run = status(repo, run_id)?.run;
+    if !force && run.verdict.is_none() && !run.submissions.is_empty() {
+        return Err(H5iError::Metadata(format!(
+            "team '{run_id}' has {} submission(s) but no verdict — this looks like live work; \
+             finish it (`h5i team finalize`) or pass --force to remove it anyway",
+            run.submissions.len()
+        )));
+    }
+    let refname = refname(run_id)?;
+    let attic_ref = if purge {
+        None
+    } else {
+        // First free attic slot: the base name, then `-2`, `-3`, …
+        let mut candidate = format!("{TEAM_ATTIC_REF_PREFIX}{run_id}");
+        let mut n = 1;
+        while repo.find_reference(&candidate).is_ok() {
+            n += 1;
+            candidate = format!("{TEAM_ATTIC_REF_PREFIX}{run_id}-{n}");
+        }
+        Some(candidate)
+    };
+    // The removal is itself evidence — journal it before moving the ref, so
+    // the attic copy records why its run disappeared from the listing.
+    let tip = repo.refname_to_id(&refname)?;
+    let ev = event(
+        run_id,
+        actor,
+        "run_removed",
+        run.current_round,
+        Some(run.phase.clone()),
+        None,
+        format!("run_removed:{run_id}:{tip}"),
+        serde_json::json!({
+            "purged": purge,
+            "attic_ref": attic_ref,
+            "forced": force,
+        }),
+    );
+    append_event(repo, &ev)?;
+
+    let tip = repo.refname_to_id(&refname)?;
+    if let Some(attic) = &attic_ref {
+        repo.reference(attic, tip, false, &format!("h5i team rm: archived {run_id}"))?;
+    }
+    repo.find_reference(&refname)?.delete()?;
+
+    let cleared_current = get_current(h5i_root).as_deref() == Some(run_id);
+    if cleared_current {
+        clear_current(h5i_root)?;
+    }
+    Ok(RmOutcome {
+        run_id: run_id.to_string(),
+        attic_ref,
+        env_ids: run.agents.iter().map(|a| a.env_id.clone()).collect(),
+        cleared_current,
+    })
 }
 
 pub fn status(repo: &Repository, run_id: &str) -> Result<TeamStatus, H5iError> {
@@ -2412,6 +2507,87 @@ mod tests {
         assert_eq!(id.trim(), "codex-impl");
         let team = std::fs::read_to_string(m.dir(h5i_root).join("team-run")).unwrap();
         assert_eq!(team.trim(), "run-i");
+    }
+
+
+    #[test]
+    fn rm_archives_the_run_and_clears_the_pointer() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hi\n");
+        let h5i_root = dir.path();
+        manifest(&repo, h5i_root, "codex", "fix");
+        create(&repo, "gone", "gone", "HEAD", 1, "human").unwrap();
+        add_env(
+            &repo, h5i_root, "gone", "env/codex/fix", "codex-fix", None, None, "human",
+        )
+        .unwrap();
+        set_current(h5i_root, "gone").unwrap();
+
+        let out = rm(&repo, h5i_root, "gone", false, false, "human").unwrap();
+
+        // Out of the listing, pointer cleared, envs reported but untouched.
+        assert!(list(&repo).unwrap().is_empty());
+        assert!(get_current(h5i_root).is_none());
+        assert!(out.cleared_current);
+        assert_eq!(out.env_ids, vec!["env/codex/fix".to_string()]);
+        assert!(env::find(h5i_root, "env/codex/fix").is_ok(), "envs are kept");
+
+        // The attic holds the whole event log, final run_removed included.
+        let attic = out.attic_ref.unwrap();
+        assert_eq!(attic, "refs/h5i/team-attic/gone");
+        let tip = repo.refname_to_id(&attic).unwrap();
+        let tree = repo.find_commit(tip).unwrap().tree().unwrap();
+        let log = objects::read_blob_from_tree(&repo, Some(&tree), EVENTS_FILE).unwrap();
+        assert!(log.contains("\"kind\":\"created\""));
+        assert!(log.contains("\"kind\":\"run_removed\""));
+
+        // The name is free again; a second rm lands in the next attic slot.
+        create(&repo, "gone", "gone", "HEAD", 1, "human").unwrap();
+        let again = rm(&repo, h5i_root, "gone", false, false, "human").unwrap();
+        assert_eq!(again.attic_ref.as_deref(), Some("refs/h5i/team-attic/gone-2"));
+        assert!(!again.cleared_current);
+    }
+
+    #[test]
+    fn rm_refuses_live_work_unless_forced() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hello\n");
+        let h5i_root = dir.path();
+        let m = manifest(&repo, h5i_root, "codex", "fix");
+        let candidate = commit_file(&repo, "feature.txt", "ok\n");
+        repo.reference(&m.branch, candidate, true, "candidate").unwrap();
+        create(&repo, "live", "live", "HEAD~1", 1, "human").unwrap();
+        add_env(
+            &repo, h5i_root, "live", "env/codex/fix", "codex-fix",
+            Some("codex".into()), None, "human",
+        )
+        .unwrap();
+        submit(&repo, h5i_root, "live", "codex-fix", None, Some("done".into()), "codex").unwrap();
+
+        let err = rm(&repo, h5i_root, "live", false, false, "human").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no verdict"), "says why: {msg}");
+        assert!(msg.contains("--force"), "says how: {msg}");
+
+        rm(&repo, h5i_root, "live", false, true, "human").unwrap();
+        assert!(list(&repo).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rm_purge_deletes_the_ref_outright() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hi\n");
+        let h5i_root = dir.path();
+        create(&repo, "junk", "junk", "HEAD", 1, "human").unwrap();
+
+        let out = rm(&repo, h5i_root, "junk", true, false, "human").unwrap();
+        assert!(out.attic_ref.is_none());
+        assert!(list(&repo).unwrap().is_empty());
+        assert!(repo.find_reference("refs/h5i/team-attic/junk").is_err());
+        assert!(rm(&repo, h5i_root, "junk", true, false, "human").is_err(), "already gone");
     }
 
     #[test]

--- a/crates/h5i-orchestra/src/agent.rs
+++ b/crates/h5i-orchestra/src/agent.rs
@@ -96,6 +96,21 @@ impl AgentBuilder {
                 seat.agent_id, hire_core.run_id
             )));
         }
+        // The env behind the seat must still exist — a seat bound to a removed
+        // env otherwise dispatches turns into the void (the resident session
+        // dies instantly on `h5i env shell`, and the score hangs waiting).
+        let env_core = hire_core.clone();
+        let env_id = seat.env_id.clone();
+        let env_exists =
+            run_blocking(move || Ok(env::find(&env_core.h5i_root, &env_id).is_ok())).await?;
+        if !env_exists {
+            return Err(H5iError::Metadata(format!(
+                "orchestra resume divergence: hired agent '{}' is bound to env '{}', which no \
+                 longer exists (it was removed after the run began) — start a fresh run id to \
+                 re-hire on new envs, or hire with .env(...) pointing at an existing one",
+                seat.agent_id, seat.env_id
+            )));
+        }
         Ok(Agent {
             core: hire_core,
             name: seat.agent_id,

--- a/crates/h5i-orchestra/src/launcher.rs
+++ b/crates/h5i-orchestra/src/launcher.rs
@@ -75,6 +75,17 @@ impl RuntimeLauncher for LaunchResident {
         if alive {
             return Ok(());
         }
+        // Fail closed on a missing env *before* spawning: `tmux new-session`
+        // succeeds even when the inner `h5i env shell` dies instantly, leaving
+        // no visible session and a score waiting forever.
+        if env::find(&turn.h5i_root, &turn.env_id).is_err() {
+            return Err(H5iError::Metadata(format!(
+                "orchestra LaunchResident: env '{}' for agent '{}' no longer exists — it was \
+                 removed after the run began; start a fresh run id or rebind the seat to an \
+                 existing env",
+                turn.env_id, turn.agent_id
+            )));
+        }
         // A roster model override (`--model`) — keeps a trivial run on a fast
         // model instead of the session default.
         let model_flag = turn

--- a/crates/h5i-orchestra/src/tests.rs
+++ b/crates/h5i-orchestra/src/tests.rs
@@ -1051,3 +1051,64 @@ async fn revise_completes_on_unchanged_resubmit() {
     assert_eq!(revised.id, first.id, "unchanged re-submit returns the same candidate");
     assert_eq!(turns.load(Ordering::SeqCst), 2, "one work + one revise turn");
 }
+
+#[tokio::test]
+async fn hire_fails_closed_when_the_seat_env_was_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_repo(dir.path());
+    let h5i_root = repo.commondir().join(".h5i");
+    let m = fabricate_env(&repo, &h5i_root, "claude", "gone");
+
+    let script = scripted("fine");
+    let c1 = conductor(dir.path(), "stale", Script::launcher(&script));
+    c1.agent("claude")
+        .runtime("claude")
+        .env("env/claude/gone")
+        .hire()
+        .await
+        .unwrap();
+
+    // The env vanishes between runs (an `h5i env rm` / abort during cleanup).
+    fs::remove_dir_all(m.dir(&h5i_root)).unwrap();
+
+    // Resume: the journaled hire replays, but must fail closed on the dead
+    // env instead of letting turns dispatch into the void.
+    let c2 = conductor(dir.path(), "stale", Script::launcher(&script));
+    let err = match c2
+        .agent("claude")
+        .runtime("claude")
+        .env("env/claude/gone")
+        .hire()
+        .await
+    {
+        Ok(_) => panic!("hire must fail closed on a removed env"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("env/claude/gone"), "names the env: {msg}");
+    assert!(msg.contains("no longer exists"), "says why: {msg}");
+    assert!(msg.contains("fresh run id"), "says how to recover: {msg}");
+}
+
+#[tokio::test]
+async fn launch_resident_fails_closed_on_a_missing_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = init_repo(dir.path());
+    let h5i_root = repo.commondir().join(".h5i");
+    let turn = TurnContext {
+        run_id: "r".into(),
+        agent_id: "claude".into(),
+        env_id: "env/claude/never-created".into(),
+        kind: TurnKind::Work,
+        instruction: "task".into(),
+        repo_workdir: dir.path().to_path_buf(),
+        h5i_root,
+        work_dir: None,
+        runtime: Some("claude".into()),
+        model: None,
+    };
+    let err = LaunchResident.on_turn(&turn).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("env/claude/never-created"), "names the env: {msg}");
+    assert!(msg.contains("no longer exists"), "says why: {msg}");
+}

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -4089,6 +4089,10 @@ inboxes and never locks the round.</p>
 <td>Pin a <strong>current team</strong> (like git's current branch) so other subcommands can drop <code>&lt;team&gt;</code>. No arg prints the current; <code>--clear</code> unsets. <code>create</code> auto-pins the new run.</td>
 </tr>
 <tr>
+<td><code>h5i team rm &lt;team&gt; [--purge] [--envs] [--force] [--json]</code></td>
+<td>Remove a run from the listing. By default the whole event log is <strong>archived</strong> to <code>refs/h5i/team-attic/&lt;team&gt;</code> (a final <code>run_removed</code> event is appended first) — auditable, and recoverable by moving the ref back; <code>--purge</code> deletes the ref outright. Bound envs are kept unless <code>--envs</code> (they may hold uncommitted agent work). A run with submissions but no verdict is plausibly live and needs <code>--force</code>. Clone-local: there is no cross-clone tombstone, so a manually synced team ref would re-introduce the run.</td>
+</tr>
+<tr>
 <td><code>h5i team submit &lt;team&gt; --agent &lt;id&gt; [--commit OID] [--summary-file F] [--json]</code></td>
 <td>Freeze the agent's candidate as an <strong>immutable</strong> submission — frozen commit/tree oids + diffstat + capture ids, reviewable even if the env later changes. Without <code>--commit</code> it first <strong>mediates-commits the env worktree</strong> onto the env branch (so uncommitted edits are captured, not silently lost) and freezes the result; with <code>--commit</code> it pins that exact commit. A submission whose tree is identical to the team base is <strong>refused</strong> (nothing to review).</td>
 </tr>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -4089,10 +4089,6 @@ inboxes and never locks the round.</p>
 <td>Pin a <strong>current team</strong> (like git's current branch) so other subcommands can drop <code>&lt;team&gt;</code>. No arg prints the current; <code>--clear</code> unsets. <code>create</code> auto-pins the new run.</td>
 </tr>
 <tr>
-<td><code>h5i team rm &lt;team&gt; [--purge] [--envs] [--force] [--json]</code></td>
-<td>Remove a run from the listing. By default the whole event log is <strong>archived</strong> to <code>refs/h5i/team-attic/&lt;team&gt;</code> (a final <code>run_removed</code> event is appended first) — auditable, and recoverable by moving the ref back; <code>--purge</code> deletes the ref outright. Bound envs are kept unless <code>--envs</code> (they may hold uncommitted agent work). A run with submissions but no verdict is plausibly live and needs <code>--force</code>. Clone-local: there is no cross-clone tombstone, so a manually synced team ref would re-introduce the run.</td>
-</tr>
-<tr>
 <td><code>h5i team submit &lt;team&gt; --agent &lt;id&gt; [--commit OID] [--summary-file F] [--json]</code></td>
 <td>Freeze the agent's candidate as an <strong>immutable</strong> submission — frozen commit/tree oids + diffstat + capture ids, reviewable even if the env later changes. Without <code>--commit</code> it first <strong>mediates-commits the env worktree</strong> onto the env branch (so uncommitted edits are captured, not silently lost) and freezes the result; with <code>--commit</code> it pins that exact commit. A submission whose tree is identical to the team base is <strong>refused</strong> (nothing to review).</td>
 </tr>

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -876,6 +876,33 @@ Print help
 .TP
 [\fINAME\fR]
 Team id to make current; omit to print the current team
+.SH "H5I TEAM RM"
+Remove a team run from the listing. By default the run's event log is archived to refs/h5i/team-attic/ (auditable, recoverable by moving the ref back); bound envs are kept unless --envs
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS SYNOPSIS
+\fBrm\fR [\fB\-\-purge\fR] [\fB\-\-envs\fR] [\fB\-\-force\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fITEAM\fR> 
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS OPTIONS
+.TP
+\fB\-\-purge\fR
+Delete the run\*(Aqs ref outright instead of archiving it to the attic
+.TP
+\fB\-\-envs\fR
+Also remove the run\*(Aqs bound envs (workspaces, branches, manifests)
+.TP
+\fB\-\-force\fR
+Required for a run with submissions but no verdict (plausibly live work); with \-\-envs, also forces removal of still\-live envs
+.TP
+\fB\-\-json\fR
+Emit JSON
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fITEAM\fR>
+Team id
 .SH "H5I TEAM ADD-ENV"
 Add an existing env to a team roster
 .ie \n(.g .ds Aq \(aq

--- a/src/cli/team.rs
+++ b/src/cli/team.rs
@@ -921,13 +921,13 @@ pub fn run(action: TeamCommands) -> anyhow::Result<()> {
                     let mut envs_failed: Vec<(String, String)> = Vec::new();
                     if envs {
                         for env_id in &outcome.env_ids {
-                            match h5i_core::env::find(&h5i_root, env_id) {
-                                Ok(m) => match h5i_core::env::rm(git, &h5i_root, &m, force) {
+                            // An env that is already gone (the zombie-run
+                            // case) needs nothing done.
+                            if let Ok(m) = h5i_core::env::find(&h5i_root, env_id) {
+                                match h5i_core::env::rm(git, &h5i_root, &m, force) {
                                     Ok(()) => envs_removed.push(m.id.clone()),
                                     Err(e) => envs_failed.push((env_id.clone(), e.to_string())),
-                                },
-                                // Already gone (the zombie-run case) — nothing to do.
-                                Err(_) => {}
+                                }
                             }
                         }
                     }

--- a/src/cli/team.rs
+++ b/src/cli/team.rs
@@ -114,6 +114,26 @@ pub enum TeamCommands {
         #[arg(long)]
         clear: bool,
     },
+    /// Remove a team run from the listing. By default the run's event log is
+    /// archived to refs/h5i/team-attic/ (auditable, recoverable by moving the
+    /// ref back); bound envs are kept unless --envs
+    Rm {
+        /// Team id
+        team: String,
+        /// Delete the run's ref outright instead of archiving it to the attic
+        #[arg(long)]
+        purge: bool,
+        /// Also remove the run's bound envs (workspaces, branches, manifests)
+        #[arg(long)]
+        envs: bool,
+        /// Required for a run with submissions but no verdict (plausibly live
+        /// work); with --envs, also forces removal of still-live envs
+        #[arg(long)]
+        force: bool,
+        /// Emit JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Add an existing env to a team roster
     AddEnv {
         /// Team id
@@ -887,6 +907,76 @@ pub fn run(action: TeamCommands) -> anyhow::Result<()> {
                             Some(c) => println!("{c}"),
                             None => println!("(no current team — set one: h5i team use <name>)"),
                         }
+                    }
+                }
+                TeamCommands::Rm {
+                    team,
+                    purge,
+                    envs,
+                    force,
+                    json,
+                } => {
+                    let outcome = h5i_core::team::rm(git, &h5i_root, &team, purge, force, &actor)?;
+                    let mut envs_removed: Vec<String> = Vec::new();
+                    let mut envs_failed: Vec<(String, String)> = Vec::new();
+                    if envs {
+                        for env_id in &outcome.env_ids {
+                            match h5i_core::env::find(&h5i_root, env_id) {
+                                Ok(m) => match h5i_core::env::rm(git, &h5i_root, &m, force) {
+                                    Ok(()) => envs_removed.push(m.id.clone()),
+                                    Err(e) => envs_failed.push((env_id.clone(), e.to_string())),
+                                },
+                                // Already gone (the zombie-run case) — nothing to do.
+                                Err(_) => {}
+                            }
+                        }
+                    }
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "run_id": outcome.run_id,
+                                "attic_ref": outcome.attic_ref,
+                                "cleared_current": outcome.cleared_current,
+                                "envs_removed": envs_removed,
+                                "envs_failed": envs_failed
+                                    .iter()
+                                    .map(|(id, e)| serde_json::json!({"env_id": id, "error": e}))
+                                    .collect::<Vec<_>>(),
+                                "envs_kept": if envs { Vec::new() } else { outcome.env_ids.clone() },
+                            }))?
+                        );
+                    } else {
+                        match &outcome.attic_ref {
+                            Some(attic) => println!(
+                                "{} team '{}' removed — event log archived at {attic}",
+                                SUCCESS, outcome.run_id
+                            ),
+                            None => println!(
+                                "{} team '{}' purged (event log deleted locally)",
+                                SUCCESS, outcome.run_id
+                            ),
+                        }
+                        if outcome.cleared_current {
+                            println!("  cleared the current-team pointer");
+                        }
+                        for id in &envs_removed {
+                            println!("  {} {} removed", SUCCESS, id);
+                        }
+                        for (id, e) in &envs_failed {
+                            eprintln!("{} failed to remove {id}: {e}", style("error:").red().bold());
+                        }
+                        if !envs && !outcome.env_ids.is_empty() {
+                            println!(
+                                "\u{2139} {} bound env(s) kept: {} — remove with `h5i team rm --envs` \
+                                 next time, or `h5i env rm <env>`",
+                                outcome.env_ids.len(),
+                                outcome.env_ids.join(", ")
+                            );
+                        }
+                    }
+                    if !envs_failed.is_empty() {
+                        std::process::exit(1);
                     }
                 }
                 TeamCommands::AddEnv {


### PR DESCRIPTION
A team run whose envs were removed after hire stayed silently resumable: the journaled hire replayed (roster check passes), turns dispatched, and LaunchResident's tmux session died instantly on 'h5i env shell <missing env>' — invisible in tmux ls — while the score hung forever in wait_until.

Two checks now surface it: hire verifies the seat's env still exists after replay (clear resume-divergence error naming the env and the recovery), and LaunchResident verifies the env before spawning, so an env deleted mid-run errors the turn instead of evaporating.