### PR TITLE
fix(team): deliver same-round review/revise turns after submit

### DIFF
--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -82,6 +82,41 @@ const ENV_INBOX_DIR: &str = "inbox";
 const RUN_LOCK_FILE: &str = "run.lock";
 #[cfg(unix)] // only the unix-gated RunLock references this
 const OBSERVERS_LOCK_FILE: &str = "observers.lock";
+#[cfg(unix)]
+const DRAIN_LOCK_FILE: &str = "drain.lock";
+
+/// Blocking exclusive lock serializing outbound-spool drains for one env
+/// ([`ingest_team_outbound`]). The drain is read-file → apply-to-team-log →
+/// remove-file; it runs concurrently from every orchestra turn wait polling
+/// `team sync` AND from a session's at-exit ingest in another process, and
+/// without serialization two drains can both read a staged record before
+/// either removes it and apply it twice (observed live: one peer review
+/// ingested twice, 5 ms apart → duplicate discussion messages). Blocking is
+/// safe: a drain never takes `run.lock` (mid-session sync must run while the
+/// live session holds it), so no ordering cycle exists — and listing happens
+/// after the lock, so a waiter picks up records staged during the holder's
+/// drain. Non-unix: no-op (the confined-env backends are unix-only).
+#[cfg(unix)]
+fn acquire_drain_lock(env_dir: &Path) -> Result<Option<std::fs::File>, H5iError> {
+    use std::os::unix::io::AsRawFd;
+    let path = env_dir.join(DRAIN_LOCK_FILE);
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .map_err(|e| H5iError::with_path(e, &path))?;
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if rc != 0 {
+        return Err(H5iError::with_path(std::io::Error::last_os_error(), &path));
+    }
+    Ok(Some(file))
+}
+
+#[cfg(not(unix))]
+fn acquire_drain_lock(_env_dir: &Path) -> Result<Option<std::fs::File>, H5iError> {
+    Ok(None)
+}
 
 /// Advisory `flock`s that coordinate concurrent work on one environment. The
 /// kernel releases a lock when the holding process exits — including on a crash
@@ -4391,6 +4426,9 @@ pub fn ingest_team_outbound(
     if !spool.is_dir() {
         return Ok(0);
     }
+    // One drain at a time per env — every lane below is read → apply → remove,
+    // and a record read by two unserialized drains is applied twice.
+    let _drain_lock = acquire_drain_lock(&m.dir(h5i_root))?;
     let env_tip = repo
         .find_reference(&m.branch)
         .ok()

--- a/crates/h5i-core/src/team.rs
+++ b/crates/h5i-core/src/team.rs
@@ -1308,6 +1308,30 @@ pub const GRANTABLE_ARTIFACT_KINDS: [&str; 4] = ["diff", "summary", "tests", "te
 
 
 
+/// Resolve a review's `--target` against authoritative run state: a roster
+/// member's agent id passes through, and a submission *artifact id* resolves
+/// to its owner agent — the review request tells the boxed reviewer the
+/// artifact id ("Artifact ids: sub-codex-r1-…"), so that is what agents
+/// routinely pass. Anything else is an error naming the roster, raised BEFORE
+/// any event is recorded.
+fn resolve_review_target(run: &TeamRun, run_id: &str, target: &str) -> Result<String, H5iError> {
+    if run.agents.iter().any(|a| a.agent_id == target) {
+        return Ok(target.to_string());
+    }
+    if let Some(s) = run.submissions.iter().find(|s| s.id == target) {
+        return Ok(s.owner_agent.clone());
+    }
+    Err(H5iError::Metadata(format!(
+        "team '{run_id}' has no member '{target}' and no submission with that artifact id — \
+         pass the reviewed teammate's agent id or their submission's artifact id (roster: {})",
+        run.agents
+            .iter()
+            .map(|a| a.agent_id.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn submit_review(
     repo: &Repository,
@@ -1321,6 +1345,17 @@ pub fn submit_review(
     validate_agent_id(reviewer)?;
     validate_agent_id(target)?;
     let current = status(repo, run_id)?.run;
+    // Fail closed BEFORE recording anything: a bad reviewer/target used to
+    // append the `review_submitted` event and only then die inside `discuss`
+    // (roster check), leaving a half-applied review under a bogus target while
+    // the host ingest surfaced only a warning the boxed reviewer never sees.
+    if !current.agents.iter().any(|a| a.agent_id == reviewer) {
+        return Err(H5iError::Metadata(format!(
+            "team '{run_id}' has no reviewer '{reviewer}'"
+        )));
+    }
+    let target = resolve_review_target(&current, run_id, target)?;
+    let target = target.as_str();
     let referenced_artifacts: Vec<String> = current
         .submissions
         .iter()
@@ -3454,6 +3489,98 @@ mod tests {
         assert!(!codex_revised.influence_event_ids.is_empty());
         // The submission predating the review stays independent.
         assert!(codex_sub.independent);
+    }
+
+    /// A boxed reviewer is told the *artifact id* ("Artifact ids: sub-…") and
+    /// routinely passes it as `--target`. It must resolve to the owner agent;
+    /// a target that is neither a roster member nor an artifact id must fail
+    /// BEFORE any event is recorded (a bad target used to append the
+    /// review_submitted event and only then die delivering the discussion —
+    /// a half-applied review under a bogus target, surfaced only as a host
+    /// warning the boxed reviewer never sees).
+    #[test]
+    fn submit_review_resolves_artifact_id_target_and_fails_closed_before_recording() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hello\n");
+        let h5i_root = dir.path();
+        let codex = manifest(&repo, h5i_root, "codex", "fix");
+        let claude = manifest(&repo, h5i_root, "claude", "fix");
+        let codex_commit = commit_file(&repo, "codex.txt", "ok\n");
+        repo.reference(&codex.branch, codex_commit, true, "codex")
+            .unwrap();
+        let claude_commit = commit_file(&repo, "claude.txt", "ok\n");
+        repo.reference(&claude.branch, claude_commit, true, "claude")
+            .unwrap();
+
+        create(&repo, "run-tid", "run-tid", "HEAD~2", 1, "human").unwrap();
+        add_env(&repo, h5i_root, "run-tid", "env/codex/fix", "codex-fix", None, None, None, "human")
+            .unwrap();
+        add_env(
+            &repo, h5i_root, "run-tid", "env/claude/fix", "claude-fix", None, None, None, "human",
+        )
+        .unwrap();
+        let codex_sub = submit(&repo, h5i_root, "run-tid", "codex-fix", None, None, "codex").unwrap();
+        submit(&repo, h5i_root, "run-tid", "claude-fix", None, None, "claude").unwrap();
+        freeze(&repo, "run-tid", false, "human").unwrap();
+
+        // Target given as the artifact id → resolved to the owner agent, and
+        // the review both records and delivers under that agent.
+        let review = submit_review(
+            &repo,
+            h5i_root,
+            "run-tid",
+            "claude-fix",
+            &codex_sub.id,
+            "resolved via artifact id".into(),
+            "claude-fix",
+        )
+        .unwrap();
+        assert_eq!(review.target, "codex-fix");
+        assert_eq!(review.referenced_artifacts, vec![codex_sub.id.clone()]);
+        let events = read_events(&repo, "run-tid").unwrap();
+        assert!(events
+            .iter()
+            .any(|e| e.kind == "review_submitted" && e.idempotency_key.contains(":codex-fix:")));
+
+        // A target that resolves to nothing fails closed: clear error naming
+        // the roster, and NO review_submitted event appended.
+        let before = read_events(&repo, "run-tid")
+            .unwrap()
+            .iter()
+            .filter(|e| e.kind == "review_submitted")
+            .count();
+        let err = submit_review(
+            &repo,
+            h5i_root,
+            "run-tid",
+            "claude-fix",
+            "sub-nobody-r1-deadbeefdead",
+            "goes nowhere".into(),
+            "claude-fix",
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no member"), "must explain the bad target: {msg}");
+        assert!(msg.contains("codex-fix"), "must name the roster: {msg}");
+        // An unknown reviewer fails the same way.
+        let err = submit_review(
+            &repo,
+            h5i_root,
+            "run-tid",
+            "intruder",
+            "codex-fix",
+            "not on this team".into(),
+            "intruder",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("no reviewer"), "{err}");
+        let after = read_events(&repo, "run-tid")
+            .unwrap()
+            .iter()
+            .filter(|e| e.kind == "review_submitted")
+            .count();
+        assert_eq!(before, after, "a refused review must record no event");
     }
 
     #[test]

--- a/crates/h5i-core/src/team.rs
+++ b/crates/h5i-core/src/team.rs
@@ -901,6 +901,18 @@ pub fn is_noop_submission_err(e: &H5iError) -> bool {
 /// finished with `h5i team agent reply`, never `h5i team agent submit`.
 pub const TURN_KIND_ASK: &str = "ask";
 
+/// `links.turn` stamped on an orchestra `revise` dispatch (address a review,
+/// then re-submit). Mirrors `TurnKind::label()` in h5i-orchestra.
+pub const TURN_KIND_REVISE: &str = "revise";
+
+/// `links.turn` stamped on an orchestra `review` dispatch. (Today the review
+/// turn is delivered by `grant_review`'s REVIEW_REQUEST, but the label is part
+/// of the wire contract — see `TurnKind::label()` in h5i-orchestra.)
+pub const TURN_KIND_REVIEW: &str = "review";
+
+/// Message kind of a `grant_review` review request (classic and orchestra).
+pub const REVIEW_REQUEST_KIND: &str = "REVIEW_REQUEST";
+
 /// The orchestra turn kind riding in a team message's i5h `links.turn`
 /// (stamped by the orchestra's `dispatch_turn`). `None` for classic
 /// `team dispatch` messages and non-team mail.
@@ -912,6 +924,56 @@ pub fn msg_turn_kind(m: &msg::Message) -> Option<&str> {
 /// way to finish it is `h5i team agent reply '<json>'`, not a submission.
 pub fn is_data_request(m: &msg::Message) -> bool {
     msg_turn_kind(m) == Some(TURN_KIND_ASK)
+}
+
+/// Whether this team message opens a turn that legitimately arrives in the
+/// SAME round the box has already submitted for. The classic in-round sequence
+/// is work → submit → REVIEW_REQUEST → review → (revise →) re-submit, so a
+/// review or revise turn always lands AFTER a submit of its own round — the
+/// Stop hook's "submit == done for this round" filter must never swallow one
+/// (it would be consumed unseen and the blocking hook would hang the agent at
+/// the review phase). Re-fanned standing copies of these requests are muted by
+/// content ([`msg_refan_fingerprint`]), not by round.
+pub fn is_post_submit_turn(m: &msg::Message) -> bool {
+    m.kind.as_deref() == Some(REVIEW_REQUEST_KIND)
+        || matches!(
+            msg_turn_kind(m),
+            Some(TURN_KIND_REVIEW) | Some(TURN_KIND_REVISE)
+        )
+}
+
+/// Content fingerprint of a team message, used by the box inbox cursor to mute
+/// host *re-fans* of the same standing request under a fresh message id (which
+/// defeats the id-based seen cursor — re-granting a review on a resumed run,
+/// re-dispatching a round prompt). Two sends with identical sender, recipient,
+/// kind, body, focus, and i5h links are the same request; the round and
+/// artifact ids ride in `links`, so a genuinely new round or new artifact
+/// yields a new fingerprint. `None` for non-team mail (never muted) and for
+/// the TEAM_DONE control signal (releasing a waiting hook must never be
+/// suppressed).
+pub fn msg_refan_fingerprint(m: &msg::Message) -> Option<String> {
+    let links = m.links.as_ref()?;
+    links.get("team")?.as_str()?;
+    if m.kind.as_deref() == Some(TEAM_DONE_KIND) {
+        return None;
+    }
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    for part in [
+        m.from.as_str(),
+        m.to.as_str(),
+        m.kind.as_deref().unwrap_or(""),
+        m.body.as_str(),
+    ] {
+        h.update(part.as_bytes());
+        h.update([0u8]);
+    }
+    for f in &m.focus {
+        h.update(f.as_bytes());
+        h.update([0u8]);
+    }
+    h.update(links.to_string().as_bytes());
+    Some(format!("fp:{:x}", h.finalize()))
 }
 
 /// The standing instruction the team Stop hook appends when it blocks an agent
@@ -1197,7 +1259,7 @@ pub fn grant_review(
         reviewer,
         &body,
         msg::SendOpts {
-            kind: Some("REVIEW_REQUEST".into()),
+            kind: Some(REVIEW_REQUEST_KIND.into()),
             focus: artifact_ids.clone(),
             links: Some(serde_json::json!({
                 "team": run_id,
@@ -2456,6 +2518,54 @@ mod tests {
         let text = release_instruction(&[ask, work]);
         assert!(text.contains("improve and re-submit"));
         assert!(text.contains("team agent reply"));
+    }
+
+    #[test]
+    fn post_submit_turns_are_exempt_from_the_round_filter() {
+        let review_turn =
+            msg_with_links(serde_json::json!({"team": "r", "round": 1, "turn": "review"}));
+        let revise_turn =
+            msg_with_links(serde_json::json!({"team": "r", "round": 1, "turn": "revise"}));
+        let work = msg_with_links(serde_json::json!({"team": "r", "round": 1, "turn": "work"}));
+        let mut review_req = msg_with_links(
+            serde_json::json!({"team": "r", "round": 1, "reviewer": "a", "target": "b"}),
+        );
+        review_req.kind = Some(REVIEW_REQUEST_KIND.into());
+
+        assert!(is_post_submit_turn(&review_turn));
+        assert!(is_post_submit_turn(&revise_turn));
+        assert!(is_post_submit_turn(&review_req));
+        assert!(!is_post_submit_turn(&work));
+        assert!(!is_post_submit_turn(&msg_with_links(serde_json::Value::Null)));
+    }
+
+    #[test]
+    fn refan_fingerprint_keys_on_content_not_id() {
+        let links = serde_json::json!({"team": "r", "round": 1, "target": "b"});
+        let mut a = msg_with_links(links.clone());
+        let mut b = msg_with_links(links);
+        b.id = "m2".into();
+        // Same content under a fresh id (a host re-fan) → same fingerprint.
+        assert_eq!(msg_refan_fingerprint(&a), msg_refan_fingerprint(&b));
+        assert!(msg_refan_fingerprint(&a).is_some());
+
+        // A new round is a new request.
+        let next = msg_with_links(serde_json::json!({"team": "r", "round": 2, "target": "b"}));
+        assert_ne!(msg_refan_fingerprint(&a), msg_refan_fingerprint(&next));
+
+        // Body, focus, and kind are all identity.
+        b.body = "y".into();
+        assert_ne!(msg_refan_fingerprint(&a), msg_refan_fingerprint(&b));
+        a.focus = vec!["sub-1".into()];
+        let mut c = a.clone();
+        c.focus = vec!["sub-2".into()];
+        assert_ne!(msg_refan_fingerprint(&a), msg_refan_fingerprint(&c));
+
+        // Non-team mail and the TEAM_DONE release signal are never muted.
+        assert_eq!(msg_refan_fingerprint(&msg_with_links(serde_json::Value::Null)), None);
+        let mut done = msg_with_links(serde_json::json!({"team": "r", "round": 1}));
+        done.kind = Some(TEAM_DONE_KIND.into());
+        assert_eq!(msg_refan_fingerprint(&done), None);
     }
 
     #[test]

--- a/crates/h5i-core/src/team.rs
+++ b/crates/h5i-core/src/team.rs
@@ -3491,6 +3491,81 @@ mod tests {
         assert!(codex_sub.independent);
     }
 
+    /// Two concurrent drains of the same staged review must apply it exactly
+    /// once. `sync_outbound` is polled by every in-flight orchestra turn wait
+    /// while a session's at-exit ingest can run in another process; before the
+    /// per-env drain lock, two drains could both read a `team-review-*.json`
+    /// before either removed it and apply it twice (observed live: one peer
+    /// review ingested twice, 5 ms apart → duplicate discussion messages in
+    /// the radio dashboard).
+    #[test]
+    fn concurrent_outbound_drains_apply_a_staged_review_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hello\n");
+        let h5i_root = dir.path().to_path_buf();
+        let codex = manifest(&repo, &h5i_root, "codex", "fix");
+        let claude = manifest(&repo, &h5i_root, "claude", "fix");
+        let codex_commit = commit_file(&repo, "codex.txt", "ok\n");
+        repo.reference(&codex.branch, codex_commit, true, "codex")
+            .unwrap();
+        let claude_commit = commit_file(&repo, "claude.txt", "ok\n");
+        repo.reference(&claude.branch, claude_commit, true, "claude")
+            .unwrap();
+
+        create(&repo, "run-dd", "run-dd", "HEAD~2", 1, "human").unwrap();
+        add_env(&repo, &h5i_root, "run-dd", "env/codex/fix", "codex-fix", None, None, None, "human")
+            .unwrap();
+        add_env(
+            &repo, &h5i_root, "run-dd", "env/claude/fix", "claude-fix", None, None, None, "human",
+        )
+        .unwrap();
+        submit(&repo, &h5i_root, "run-dd", "codex-fix", None, None, "codex").unwrap();
+        submit(&repo, &h5i_root, "run-dd", "claude-fix", None, None, "claude").unwrap();
+        freeze(&repo, "run-dd", false, "human").unwrap();
+
+        // claude's box staged ONE review of codex for host ingest.
+        let spool = claude.dir(&h5i_root).join("spool");
+        crate::env::write_team_review_spool(
+            &spool,
+            &crate::env::TeamReviewSpool {
+                target: "codex-fix".into(),
+                body: "dedupe me".into(),
+            },
+        )
+        .unwrap();
+
+        // Two drains race on the same spool (each with its own repo handle,
+        // as two processes would).
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let root = h5i_root.clone();
+                let m = claude.clone();
+                let b = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let repo = Repository::open(&root).unwrap();
+                    b.wait();
+                    crate::env::ingest_team_outbound(&repo, &root, &m).unwrap()
+                })
+            })
+            .collect();
+        let applied: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+
+        assert_eq!(applied, 1, "the staged review must be applied exactly once");
+        let events = read_events(&repo, "run-dd").unwrap();
+        assert_eq!(
+            events.iter().filter(|e| e.kind == "review_submitted").count(),
+            1,
+            "one review event"
+        );
+        assert_eq!(
+            events.iter().filter(|e| e.kind == "discussion_msg").count(),
+            1,
+            "one delivered discussion — a duplicate here is what the radio dashboard showed twice"
+        );
+    }
+
     /// A boxed reviewer is told the *artifact id* ("Artifact ids: sub-…") and
     /// routinely passes it as `--target`. It must resolve to the owner agent;
     /// a target that is neither a roster member nor an artifact id must fail

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -1286,7 +1286,7 @@ Submit a review body
 Reviewing team agent id
 .TP
 \fB\-\-target\fR \fI<TARGET>\fR
-Target team agent id
+Reviewed teammate: their agent id, or their submission\*(Aqs artifact id (e.g. `sub\-codex\-r1\-4ea2333c040f`, resolved to its owner)
 .TP
 \fB\-\-file\fR \fI<FILE>\fR
 Review text file

--- a/src/cli/team.rs
+++ b/src/cli/team.rs
@@ -1714,12 +1714,22 @@ pub fn run(action: TeamCommands) -> anyhow::Result<()> {
                                         // A data request (orchestra ask) is a fresh,
                                         // targeted, deliver-once message — the seen
                                         // cursor already dedupes it. The round filter
-                                        // exists to mute *re-fanned* standing review
-                                        // requests of an already-submitted round;
-                                        // letting it swallow a same-round ask sent
-                                        // after this box submitted would lose the turn
-                                        // (consumed above, then filtered → never seen).
+                                        // exists to mute stale *work* prompts of an
+                                        // already-submitted round; letting it swallow
+                                        // a same-round ask sent after this box
+                                        // submitted would lose the turn (consumed
+                                        // above, then filtered → never seen).
                                         if h5i_core::team::is_data_request(m) {
+                                            return true;
+                                        }
+                                        // Review and revise turns arrive in the SAME
+                                        // round the box just submitted for (work →
+                                        // submit → review → revise → re-submit) —
+                                        // filtering them by round consumed the review
+                                        // phase unseen and hung the agent. Re-fanned
+                                        // standing copies are muted by content
+                                        // fingerprint in box_team_inbox instead.
+                                        if h5i_core::team::is_post_submit_turn(m) {
                                             return true;
                                         }
                                         match (submitted_round, msg_round(m)) {

--- a/src/cli/team.rs
+++ b/src/cli/team.rs
@@ -383,7 +383,8 @@ pub enum TeamReviewCommands {
         /// Reviewing team agent id
         #[arg(long)]
         reviewer: String,
-        /// Target team agent id
+        /// Reviewed teammate: their agent id, or their submission's artifact
+        /// id (e.g. `sub-codex-r1-4ea2333c040f`, resolved to its owner)
         #[arg(long)]
         target: String,
         /// Review text file

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,20 +254,34 @@ fn box_team_inbox(consume: bool) -> Option<Vec<msg::Message>> {
     let inbox = std::path::PathBuf::from(std::env::var_os(h5i_core::env::H5I_ENV_INBOX_VAR)?);
     let spool = std::env::var_os(h5i_core::env::H5I_ENV_CAPTURE_SPOOL_VAR)
         .map(std::path::PathBuf::from);
-    let seen = spool
+    let mut seen = spool
         .as_deref()
         .map(h5i_core::env::read_inbox_cursor)
         .unwrap_or_default();
-    let unread: Vec<msg::Message> = h5i_core::env::read_env_inbox(&inbox)
-        .into_iter()
-        .filter(|m| !seen.contains(&m.id))
-        .collect();
-    if consume && !unread.is_empty() {
-        if let Some(spool) = spool.as_deref() {
-            let mut seen = seen;
-            for m in &unread {
+    // Dedupe twice: by id (normal redelivery), then by content fingerprint —
+    // a host *re-fan* of an already-delivered standing request arrives under a
+    // fresh id (re-granted review on a resumed run, re-dispatched round
+    // prompt), which the id cursor can't catch. A content-duplicate is
+    // consumed silently (cursor advances) so it can never re-block the hook.
+    let mut unread: Vec<msg::Message> = Vec::new();
+    let mut advanced = false;
+    for m in h5i_core::env::read_env_inbox(&inbox) {
+        if seen.contains(&m.id) {
+            continue;
+        }
+        advanced = true;
+        let fp = h5i_core::team::msg_refan_fingerprint(&m);
+        if let Some(fp) = fp {
+            if !seen.insert(fp) {
                 seen.insert(m.id.clone());
+                continue;
             }
+        }
+        seen.insert(m.id.clone());
+        unread.push(m);
+    }
+    if consume && advanced {
+        if let Some(spool) = spool.as_deref() {
             let _ = h5i_core::env::write_inbox_cursor(spool, &seen);
         }
     }

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -1113,6 +1113,97 @@ fn box_team_hook_surfaces_ask_turns_and_steers_to_reply() {
     );
 }
 
+/// The classic in-round sequence is work → submit → REVIEW_REQUEST → review →
+/// (revise →) re-submit: the round's review request reaches the box AFTER its
+/// own work submit. The hook's "submit == done for this round" filter must not
+/// swallow that first delivery (a regression consumed it unseen — the cursor
+/// advanced before the filter ran — and the blocking hook hung every boxed
+/// agent at the review phase). Same for an orchestra revise turn. A host
+/// *re-fan* of the identical request under a fresh id is still muted, now by
+/// content fingerprint rather than by round.
+#[test]
+fn box_team_hook_delivers_review_and_revise_turns_after_submit() {
+    let r = Repo::new();
+    let inbox = r.dir.join("ibox");
+    let spool = r.dir.join("ispool");
+    std::fs::create_dir_all(&inbox).unwrap();
+    std::fs::create_dir_all(&spool).unwrap();
+
+    // The box already submitted its round-1 work…
+    h5i_core::env::write_submitted_round(&spool, 1).unwrap();
+
+    let review_req = |id: &str| h5i_core::msg::Message {
+        id: id.into(),
+        ts: "2026-07-15T00:00:00Z".into(),
+        from: "human".into(),
+        to: "hana".into(),
+        body: "Review rohan's team submission for demo".into(),
+        kind: Some("REVIEW_REQUEST".into()),
+        focus: vec!["sub-rohan-r1-aaaaaaaaaaaa".into()],
+        links: Some(serde_json::json!({
+            "team": "demo",
+            "round": 1,
+            "reviewer": "hana",
+            "target": "rohan",
+            "artifact_kinds": ["diff", "summary"],
+        })),
+        ..Default::default()
+    };
+    let run_hook = || -> String {
+        let out = Command::new(H5I)
+            .args(["team", "agent", "hook", "--quiet"])
+            .env("H5I_AGENT", "hana")
+            .env(h5i_core::env::H5I_ENV_INBOX_VAR, &inbox)
+            .env(h5i_core::env::H5I_ENV_CAPTURE_SPOOL_VAR, &spool)
+            .current_dir(&r.dir)
+            .output()
+            .expect("run team agent hook");
+        out_str(&out)
+    };
+
+    // …then the round-1 review request arrives. It must surface.
+    let m = review_req("rev-after-submit-0001");
+    std::fs::write(inbox.join("m1.json"), serde_json::to_vec(&m).unwrap()).unwrap();
+    let first = run_hook();
+    assert!(
+        first.contains("Review rohan's team submission"),
+        "a round-1 REVIEW_REQUEST arriving after the round-1 submit must surface: {first}"
+    );
+
+    // A host re-fan of the SAME request under a fresh id stays muted
+    // (content-duplicate), so a resumed run can't loop the reviewer.
+    let m = review_req("rev-after-submit-0002");
+    std::fs::write(inbox.join("m2.json"), serde_json::to_vec(&m).unwrap()).unwrap();
+    let refan = run_hook();
+    assert!(
+        !refan.contains("Review rohan's team submission"),
+        "an identical re-fanned request must not re-surface: {refan}"
+    );
+
+    // An orchestra revise turn is also same-round-after-submit by design.
+    let m = h5i_core::msg::Message {
+        id: "revise-after-submit-0001".into(),
+        ts: "2026-07-15T00:01:00Z".into(),
+        from: "human".into(),
+        to: "hana".into(),
+        body: "Your teammate reviewed your submission; address the feedback".into(),
+        kind: Some("ASK".into()),
+        links: Some(serde_json::json!({
+            "team": "demo",
+            "round": 1,
+            "agent_id": "hana",
+            "turn": "revise",
+        })),
+        ..Default::default()
+    };
+    std::fs::write(inbox.join("m3.json"), serde_json::to_vec(&m).unwrap()).unwrap();
+    let revise = run_hook();
+    assert!(
+        revise.contains("address the feedback"),
+        "a round-1 revise turn arriving after the round-1 submit must surface: {revise}"
+    );
+}
+
 /// In-box `team agent submit` with provably nothing to submit — clean worktree
 /// AND branch tip identical to the exported `$H5I_ENV_BASE_TREE` — must refuse
 /// in front of the agent (steering an ask turn to `team agent reply`) instead


### PR DESCRIPTION
PR #342 made the in-box submit fast path record submitted-round (previously dead code), which armed the Stop hook's round filter. But the classic in-round sequence is work -> submit -> REVIEW_REQUEST -> review -> revise -> re-submit: the round's review request reaches the box AFTER its own work submit, and the filter swallowed it. Worse, box_team_inbox advances the seen cursor before the filter runs, so the request was consumed unseen and the blocking hook hung every boxed agent at the review phase (both ensemble agents stuck waiting).

- Exempt post-submit turns (REVIEW_REQUEST kind, review/revise links.turn) from the round filter, like asks; only work-shaped prompts stay muted.
- Mute host re-fans by content instead: box_team_inbox now records a content fingerprint (from/to/kind/body/focus/links) per delivered team message and silently consumes a duplicate arriving under a fresh id - the actual defect the round filter over-approximated. TEAM_DONE and non-team mail are never fingerprint-muted.
- Regression test: a round-1 REVIEW_REQUEST and revise turn arriving after the round-1 submit must surface; an identical re-fan must not.