### PR TITLE
core: jittered backoff + error reporting for CAS ref-append loops

### DIFF
--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -591,7 +591,9 @@ pub fn append_env_commit(
     };
     let message = format!("h5i env: {} {}", ev.event, ev.env_id);
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        objects::cas_backoff(attempt);
         let tip = repo.refname_to_id(ENV_REF).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -641,19 +643,16 @@ pub fn append_env_commit(
         let parents: Vec<&git2::Commit> = parent.iter().collect();
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        let cas_ok = match tip {
-            None => repo.reference(ENV_REF, new_oid, false, &message).is_ok(),
-            Some(old) => repo
-                .reference_matching(ENV_REF, new_oid, true, old, &message)
-                .is_ok(),
-        };
-        if cas_ok {
-            return Ok(());
+        match objects::cas_ref_update(repo, ENV_REF, tip, new_oid, &message) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
         }
     }
     Err(H5iError::Internal(format!(
-        "h5i env: event {} for {} could not be appended after {MAX_ATTEMPTS} attempts",
-        ev.event, ev.env_id
+        "h5i env: event {} for {} could not be appended after {MAX_ATTEMPTS} attempts{}",
+        ev.event,
+        ev.env_id,
+        objects::cas_error_detail(&last_err)
     )))
 }
 
@@ -670,7 +669,9 @@ fn append_removed_and_strip(repo: &Repository, ev: &EnvEvent) -> Result<(), H5iE
     let event_line = serde_json::to_string(ev)?;
     let message = format!("h5i env: removed {}", ev.env_id);
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        objects::cas_backoff(attempt);
         let tip = repo.refname_to_id(ENV_REF).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -708,19 +709,15 @@ fn append_removed_and_strip(repo: &Repository, ev: &EnvEvent) -> Result<(), H5iE
         let parents: Vec<&git2::Commit> = parent.iter().collect();
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        let cas_ok = match tip {
-            None => repo.reference(ENV_REF, new_oid, false, &message).is_ok(),
-            Some(old) => repo
-                .reference_matching(ENV_REF, new_oid, true, old, &message)
-                .is_ok(),
-        };
-        if cas_ok {
-            return Ok(());
+        match objects::cas_ref_update(repo, ENV_REF, tip, new_oid, &message) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
         }
     }
     Err(H5iError::Internal(format!(
-        "h5i env: removal of {} could not be committed after {MAX_ATTEMPTS} attempts",
-        ev.env_id
+        "h5i env: removal of {} could not be committed after {MAX_ATTEMPTS} attempts{}",
+        ev.env_id,
+        objects::cas_error_detail(&last_err)
     )))
 }
 

--- a/crates/h5i-core/src/msg.rs
+++ b/crates/h5i-core/src/msg.rs
@@ -440,7 +440,9 @@ fn append_message_cas(repo: &Repository, msg: &Message) -> Result<(), H5iError> 
     let line = serde_json::to_string(msg)?;
     let message = format!("h5i msg: {} → {}", msg.from, msg.to);
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        crate::objects::cas_backoff(attempt);
         let tip = repo.refname_to_id(MSG_REF).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -478,24 +480,18 @@ fn append_message_cas(repo: &Repository, msg: &Message) -> Result<(), H5iError> 
         // Create the commit object WITHOUT moving the ref.
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        // Compare-and-swap the ref.
-        let cas_ok = match tip {
-            // No tip yet: create only if still absent (force=false fails if a
-            // racing writer created it first).
-            None => repo.reference(MSG_REF, new_oid, false, &message).is_ok(),
-            // Tip existed: overwrite only if it still equals what we read.
-            Some(old) => repo
-                .reference_matching(MSG_REF, new_oid, true, old, &message)
-                .is_ok(),
-        };
-        if cas_ok {
-            return Ok(());
+        // Compare-and-swap the ref; on failure loop, re-read the new tip
+        // (after a jittered backoff), and re-append.
+        match crate::objects::cas_ref_update(repo, MSG_REF, tip, new_oid, &message) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
         }
-        // Lost the race — loop, re-read the new tip, and re-append.
     }
     Err(H5iError::Internal(format!(
-        "h5i msg: {} → {} could not be appended after {MAX_ATTEMPTS} attempts (ref kept moving)",
-        msg.from, msg.to
+        "h5i msg: {} → {} could not be appended after {MAX_ATTEMPTS} attempts{}",
+        msg.from,
+        msg.to,
+        crate::objects::cas_error_detail(&last_err)
     )))
 }
 
@@ -515,7 +511,9 @@ pub fn remove_branch_scoped(repo: &Repository, branch: &str) -> Result<usize, H5
     const MAX_ATTEMPTS: usize = 64;
     let message = format!("h5i recall rm: drop messages scoped to branch {branch}");
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        crate::objects::cas_backoff(attempt);
         let tip = repo.refname_to_id(MSG_REF).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -549,15 +547,14 @@ pub fn remove_branch_scoped(repo: &Repository, branch: &str) -> Result<usize, H5
         let parents: Vec<&git2::Commit> = parent.iter().collect();
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        let cas_ok = repo
-            .reference_matching(MSG_REF, new_oid, true, tip.unwrap(), &message)
-            .is_ok();
-        if cas_ok {
-            return Ok(removed);
+        match crate::objects::cas_ref_update(repo, MSG_REF, tip, new_oid, &message) {
+            Ok(()) => return Ok(removed),
+            Err(e) => last_err = Some(e),
         }
     }
     Err(H5iError::Internal(format!(
-        "h5i recall rm: msg ref could not be rewritten after {MAX_ATTEMPTS} attempts"
+        "h5i recall rm: msg ref could not be rewritten after {MAX_ATTEMPTS} attempts{}",
+        crate::objects::cas_error_detail(&last_err)
     )))
 }
 

--- a/crates/h5i-core/src/objects.rs
+++ b/crates/h5i-core/src/objects.rs
@@ -759,6 +759,52 @@ fn attach_egress_findings(
     s.counts.insert("egress_denied".into(), eg.denied);
 }
 
+/// One compare-and-swap ref update: create `refname` at `new_oid` when `tip`
+/// is `None` (`force = false`, so a racing creator wins), otherwise move it to
+/// `new_oid` only if it still points at `tip`. Both failure modes — a CAS
+/// mismatch (the ref moved under us) and the loose-ref lock being held by a
+/// concurrent writer — are retryable; the returned error says which.
+pub(crate) fn cas_ref_update(
+    repo: &Repository,
+    refname: &str,
+    tip: Option<git2::Oid>,
+    new_oid: git2::Oid,
+    message: &str,
+) -> Result<(), git2::Error> {
+    match tip {
+        None => repo.reference(refname, new_oid, false, message).map(|_| ()),
+        Some(old) => repo
+            .reference_matching(refname, new_oid, true, old, message)
+            .map(|_| ()),
+    }
+}
+
+/// Randomized full-jitter sleep before CAS retry `attempt` (no-op before the
+/// first attempt). The append loops have no cross-process coordination:
+/// without jitter, concurrent writers retry in lockstep and can livelock on
+/// the loose-ref lock until the whole attempt budget is spent — the flaky
+/// "could not be appended after 64 attempts" failures on slow CI runners.
+/// Capped at 50ms so a fully spent 64-attempt budget waits ~1.5s on average.
+pub(crate) fn cas_backoff(attempt: usize) {
+    if attempt == 0 {
+        return;
+    }
+    const BASE_US: u64 = 500; // 0.5 ms
+    const CAP_US: u64 = 50_000; // 50 ms
+    let ceiling = CAP_US.min(BASE_US << attempt.min(7));
+    std::thread::sleep(std::time::Duration::from_micros(fastrand::u64(1..=ceiling)));
+}
+
+/// Render the last CAS failure for an attempts-exhausted error message, so a
+/// held lock ("failed to lock") is distinguishable from a ref that kept
+/// moving ("old reference value does not match").
+pub(crate) fn cas_error_detail(last_err: &Option<git2::Error>) -> String {
+    match last_err {
+        Some(e) => format!(" (last git error: {e})"),
+        None => String::new(),
+    }
+}
+
 /// Append `manifest` to `refs/h5i/objects` with compare-and-swap semantics,
 /// mirroring the i5h message log: build a commit off the current tip, then move
 /// the ref only if it hasn't moved under us. Retries on a lost race.
@@ -767,7 +813,9 @@ pub fn append_manifest(repo: &Repository, manifest: &Manifest) -> Result<(), H5i
     let line = serde_json::to_string(manifest)?;
     let message = format!("h5i objects: {} ({})", manifest.id, manifest.kind);
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        cas_backoff(attempt);
         let tip = repo.refname_to_id(OBJECTS_REF).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -789,19 +837,15 @@ pub fn append_manifest(repo: &Repository, manifest: &Manifest) -> Result<(), H5i
         let parents: Vec<&git2::Commit> = parent.iter().collect();
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        let cas_ok = match tip {
-            None => repo.reference(OBJECTS_REF, new_oid, false, &message).is_ok(),
-            Some(old) => repo
-                .reference_matching(OBJECTS_REF, new_oid, true, old, &message)
-                .is_ok(),
-        };
-        if cas_ok {
-            return Ok(());
+        match cas_ref_update(repo, OBJECTS_REF, tip, new_oid, &message) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
         }
     }
     Err(H5iError::Internal(format!(
-        "h5i objects: manifest {} could not be appended after {MAX_ATTEMPTS} attempts",
-        manifest.id
+        "h5i objects: manifest {} could not be appended after {MAX_ATTEMPTS} attempts{}",
+        manifest.id,
+        cas_error_detail(&last_err)
     )))
 }
 
@@ -1003,7 +1047,9 @@ pub fn remove_branch_scoped(
     const MAX_ATTEMPTS: usize = 64;
     let message = format!("h5i recall rm: drop objects scoped to branch {branch}");
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        cas_backoff(attempt);
         let tip = repo.refname_to_id(OBJECTS_REF).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -1038,15 +1084,14 @@ pub fn remove_branch_scoped(
         let parents: Vec<&git2::Commit> = parent.iter().collect();
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        let cas_ok = repo
-            .reference_matching(OBJECTS_REF, new_oid, true, tip.unwrap(), &message)
-            .is_ok();
-        if cas_ok {
-            return Ok(removed);
+        match cas_ref_update(repo, OBJECTS_REF, tip, new_oid, &message) {
+            Ok(()) => return Ok(removed),
+            Err(e) => last_err = Some(e),
         }
     }
     Err(H5iError::Internal(format!(
-        "h5i recall rm: objects ref could not be rewritten after {MAX_ATTEMPTS} attempts"
+        "h5i recall rm: objects ref could not be rewritten after {MAX_ATTEMPTS} attempts{}",
+        cas_error_detail(&last_err)
     )))
 }
 
@@ -1485,7 +1530,9 @@ impl<'a> GitRefStore<'a> {
             Some(_) => format!("h5i objects-data: + {hex}"),
             None => format!("h5i objects-data: - {hex}"),
         };
-        for _ in 0..MAX_ATTEMPTS {
+        let mut last_err: Option<git2::Error> = None;
+        for attempt in 0..MAX_ATTEMPTS {
+            cas_backoff(attempt);
             let tip = self.repo.refname_to_id(OBJECTS_DATA_REF).ok();
             let parent = match tip {
                 Some(oid) => Some(self.repo.find_commit(oid)?),
@@ -1505,19 +1552,14 @@ impl<'a> GitRefStore<'a> {
             let sig = signature(self.repo)?;
             let parents: Vec<&git2::Commit> = parent.iter().collect();
             let new_oid = self.repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
-            let cas_ok = match tip {
-                None => self.repo.reference(OBJECTS_DATA_REF, new_oid, false, &msg).is_ok(),
-                Some(old) => self
-                    .repo
-                    .reference_matching(OBJECTS_DATA_REF, new_oid, true, old, &msg)
-                    .is_ok(),
-            };
-            if cas_ok {
-                return Ok(());
+            match cas_ref_update(self.repo, OBJECTS_DATA_REF, tip, new_oid, &msg) {
+                Ok(()) => return Ok(()),
+                Err(e) => last_err = Some(e),
             }
         }
         Err(H5iError::Internal(format!(
-            "h5i objects-data: could not update {hex} after {MAX_ATTEMPTS} attempts"
+            "h5i objects-data: could not update {hex} after {MAX_ATTEMPTS} attempts{}",
+            cas_error_detail(&last_err)
         )))
     }
 }

--- a/crates/h5i-core/src/team.rs
+++ b/crates/h5i-core/src/team.rs
@@ -386,7 +386,9 @@ pub fn append_event(repo: &Repository, ev: &TeamEvent) -> Result<(), H5iError> {
     let line = serde_json::to_string(ev)?;
     let message = format!("h5i team {}: {}", ev.run_id, ev.kind);
 
-    for _ in 0..MAX_ATTEMPTS {
+    let mut last_err: Option<git2::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        objects::cas_backoff(attempt);
         let tip = repo.refname_to_id(&refname).ok();
         let parent = match tip {
             Some(oid) => Some(repo.find_commit(oid)?),
@@ -408,20 +410,17 @@ pub fn append_event(repo: &Repository, ev: &TeamEvent) -> Result<(), H5iError> {
         let parents: Vec<&git2::Commit> = parent.iter().collect();
         let new_oid = repo.commit(None, &sig, &sig, &message, &tree, &parents)?;
 
-        let cas_ok = match tip {
-            None => repo.reference(&refname, new_oid, false, &message).is_ok(),
-            Some(old) => repo
-                .reference_matching(&refname, new_oid, true, old, &message)
-                .is_ok(),
-        };
-        if cas_ok {
-            return Ok(());
+        match objects::cas_ref_update(repo, &refname, tip, new_oid, &message) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
         }
     }
 
     Err(H5iError::Internal(format!(
-        "h5i team: event {} for {} could not be appended after {MAX_ATTEMPTS} attempts",
-        ev.kind, ev.run_id
+        "h5i team: event {} for {} could not be appended after {MAX_ATTEMPTS} attempts{}",
+        ev.kind,
+        ev.run_id,
+        objects::cas_error_detail(&last_err)
     )))
 }
 
@@ -2381,6 +2380,53 @@ mod tests {
         };
         write_env(h5i_root, &m);
         m
+    }
+
+    #[test]
+    fn append_event_survives_concurrent_writers() {
+        // 8 writers × 16 appends into one clone, each writer on its own
+        // Repository handle — the shape of several agent processes sharing a
+        // repo. Every append must land (the CAS loop converges under
+        // contention) with no event lost or duplicated.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        commit_file(&repo, "README.md", "hello\n");
+        create(&repo, "run1", "run1", "HEAD", 1, "human").unwrap();
+
+        let handles: Vec<_> = (0..8)
+            .map(|w| {
+                let path = dir.path().to_path_buf();
+                std::thread::spawn(move || {
+                    let repo = Repository::open(&path).unwrap();
+                    for i in 0..16 {
+                        let ev = event(
+                            "run1",
+                            "human",
+                            "note_added",
+                            1,
+                            None,
+                            None,
+                            format!("writer{w}-note{i}"),
+                            serde_json::json!({ "text": format!("w{w} n{i}") }),
+                        );
+                        append_event(&repo, &ev).unwrap();
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let notes: Vec<_> = read_events(&repo, "run1")
+            .unwrap()
+            .into_iter()
+            .filter(|e| e.kind == "note_added")
+            .collect();
+        assert_eq!(notes.len(), 8 * 16);
+        let unique: std::collections::HashSet<String> =
+            notes.iter().map(|e| e.idempotency_key.clone()).collect();
+        assert_eq!(unique.len(), 8 * 16);
     }
 
     #[test]


### PR DESCRIPTION
All eight append/rewrite loops on refs/h5i/* (team events, msg log, env events/manifests, object manifests, objects-data store) retried a lost compare-and-swap in a tight spin: concurrent writers — e.g. two parallel 'team review submit' processes plus the orchestra bridge — could retry in lockstep on the loose-ref lock and exhaust all 64 attempts on slow CI runners (flaky 'could not be appended after 64 attempts' failures).

Shared helpers in objects.rs now back every loop: cas_ref_update returns the real git2 error instead of is_ok(), cas_backoff sleeps with full jitter (0.5ms doubling, 50ms cap — ~1.5s worst case over a spent budget), and the attempts-exhausted message reports the last git error so a held lock is distinguishable from a ref that kept moving.

Regression test: 8 writers x 16 appends on separate Repository handles must all land with no event lost or duplicated.