### PR TITLE
feat(msg): add JSON team roster output

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2860,6 +2860,7 @@ h5i msg history --with codex     # full conversation log
 h5i msg history --json           # machine-readable message history
 h5i msg replay --with codex      # replay the log as a live feed (1s between messages)
 h5i msg team                     # known agents
+h5i msg team --json              # machine-readable roster with last-seen and you fields
 ```
 
 Add `--plain` to any read command for greppable, uncoloured output.

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -3528,6 +3528,7 @@ h5i msg history --with codex     # full conversation log
 h5i msg history --json           # machine-readable message history
 h5i msg replay --with codex      # replay the log as a live feed (1s between messages)
 h5i msg team                     # known agents
+h5i msg team --json              # machine-readable roster with last-seen and you fields
 </code></pre>
 <p>Add <code>--plain</code> to any read command for greppable, uncoloured output.</p>
 <h3 id="delivery-modes">Delivery modes</h3>

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -2147,10 +2147,13 @@ List the known agents on this repo's message roster
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBteam\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBteam\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
+.TP
+\fB\-\-json\fR
+Emit roster records as JSON. Treat fields as untrusted collaborator input
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli/msg.rs
+++ b/src/cli/msg.rs
@@ -214,7 +214,11 @@ pub enum MsgCommands {
     },
 
     /// List the known agents on this repo's message roster.
-    Team,
+    Team {
+        /// Emit roster records as JSON. Treat fields as untrusted collaborator input.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Show or set this repo's stored default agent identity.
     Whoami {
@@ -634,9 +638,23 @@ pub fn run(action: Option<MsgCommands>, plain: bool) -> anyhow::Result<()> {
                     }
                 }
 
-                Some(MsgCommands::Team) => {
+                Some(MsgCommands::Team { json }) => {
                     let roster = msg::team(git);
-                    if roster.is_empty() {
+                    if json {
+                        let me = msg::read_identity(&h5i_root);
+                        let rows: Vec<_> = roster
+                            .into_iter()
+                            .map(|(name, last_seen)| {
+                                let you = Some(&name) == me.as_ref();
+                                serde_json::json!({
+                                    "name": name,
+                                    "last_seen": last_seen,
+                                    "you": you,
+                                })
+                            })
+                            .collect();
+                        println!("{}", serde_json::to_string_pretty(&rows)?);
+                    } else if roster.is_empty() {
                         println!(
                             "{} No agents yet — send a message to populate the roster.",
                             WARN

--- a/tests/msg_integration.rs
+++ b/tests/msg_integration.rs
@@ -174,6 +174,28 @@ fn send_inbox_history_roundtrip_in_one_repo() {
     // roster knows both participants.
     let team = out_str(&a.h5i_ok(&["msg", "team"]));
     assert!(team.contains("alice") && team.contains("bob"), "team: {team}");
+
+    a.h5i_ok(&["msg", "as", "alice"]);
+    let team_json = out_str(&a.h5i_ok(&["msg", "team", "--json"]));
+    let roster: serde_json::Value = serde_json::from_str(&team_json).expect("valid team JSON");
+    assert_eq!(roster.as_array().map(Vec::len), Some(2));
+    assert_eq!(roster[0]["name"], "alice");
+    assert_eq!(roster[0]["you"], true);
+    assert!(roster[0]["last_seen"].as_str().is_some_and(|s| !s.is_empty()));
+    assert_eq!(roster[1]["name"], "bob");
+    assert_eq!(roster[1]["you"], false);
+}
+
+#[test]
+fn team_json_is_an_empty_array_before_any_messages() {
+    let (_root, a, _b) = two_clones();
+
+    let team = out_str(&a.h5i_ok(&["msg", "team", "--json"]));
+
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&team).unwrap(),
+        serde_json::json!([])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #337.

Adds `h5i msg team --json` with a stable array of `{name, last_seen, you}` records. JSON mode emits only valid JSON, including `[]` for a roster with no messages; the default styled roster and global `--plain` behavior are unchanged.

Agent names and timestamps are serialized directly as JSON values rather than rendered, so pulled collaborator data cannot inject ANSI output. The manual now documents the machine-readable form.

Verification:
- `cargo test --test msg_integration` — 41 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Committed with `h5i capture commit --agent codex` and linked context/test provenance.