### PR TITLE
Disable debug information in development profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ axum = "0.7"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [profile.dev]
-debug = "false"
+debug = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,5 @@ serde_json = { workspace = true }
 axum = "0.7"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
-# Big translation units (main.rs, and the core lib's repository.rs/env.rs): full
-# debuginfo dominates rustc memory + link time and has OOM'd parallel test
-# compiles on 8GB hosts. Line tables keep usable backtraces.
 [profile.dev]
-debug = "line-tables-only"
+debug = "false"


### PR DESCRIPTION
Changed debug profile setting to false to reduce memory usage during compilation.