### PR TITLE
Add JSON output to recall search

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -47,7 +47,7 @@ emits `--json` is safe to consume from a script or another agent.)
 | Record what an AI change was (model, agent, prompt) | [`h5i capture commit`](#h5i-capture-commit) | Provenance stored in Git notes; the human prompt is auto-captured in Claude Code. |
 | Keep noisy command output out of my context | [`h5i capture run -- <cmd>`](#h5i-capture-run) | Prints a compact summary, stores the full output out-of-band, passes the exit code through. |
 | Read history with AI authorship | [`h5i recall log`](#h5i-recall-log), [`recall blame`](#h5i-recall-blame) | Who / which model wrote each line, with the prompt and test metrics. |
-| Inspect or grade what commands actually ran | [`h5i recall objects [--json]`](#h5i-recall-object--objects), [`recall search`](#h5i-recall-object--objects) | Typed feed: `cmd`, `exit`, **action** (test/build/read/write/egress), **tool**, validated **status**, enforced **egress** verdicts. |
+| Inspect or grade what commands actually ran | [`h5i recall objects [--json]`](#h5i-recall-object--objects), [`recall search [--json]`](#h5i-recall-object--objects) | Typed feed: `cmd`, `exit`, **action** (test/build/read/write/egress), **tool**, validated **status**, enforced **egress** verdicts. |
 | Track my goal + reasoning across a task | [`h5i recall context`](#h5i-recall-context) | Goal + auto-derived reasoning trace; snapshotted per commit. |
 | Triage the risk of an AI branch | [`h5i audit review`](#h5i-audit-review), [`audit scan`](#h5i-audit-scan) | Rank commits by risk; scan reasoning traces for prompt-injection. |
 | Score how well the engineer prompted | [`h5i audit maturity [--json]`](#h5i-audit-maturity) | Headless / CI prompt-maturity score (feeds merge confidence). |
@@ -1871,6 +1871,8 @@ h5i recall objects --status failed       # filter by structured status
 h5i recall objects --tool pytest         # by tool  (compose with --branch/--file/--diff)
 h5i recall objects --env fix-auth --json # typed feed for headless / CI grading
 h5i recall objects --env none            # only workspace captures (taken outside any env)
+h5i recall search "connection refused" --severity error --json
+                                             # typed matching findings for headless consumers
 h5i recall object <id>                    # rehydrate the FULL raw bytes
 h5i recall object <id> --summary          # the reduced summary only
 h5i recall object <id> --manifest         # the full manifest JSON record
@@ -1899,6 +1901,11 @@ independent, non-inferred signals. Note that in the default `signal` capture
 mode small **successful** commands aren't stored; create the env with
 `h5i env create <name> --audit all` (or set `H5I_ENV_AUDIT_CAPTURE=all`) to
 record every wrapped command for a complete ledger.
+
+`recall search --json` uses the same capture-level field names, adds a
+`findings` array containing only the findings selected by the query and filters,
+and honors `--limit`. A search with no matches emits `[]`; without `--json`, the
+existing human-readable output is unchanged.
 
 Inside a sandboxed env, a capture you just made is **staged** in the box's spool
 and not yet ingested into `refs/h5i/objects`; `h5i recall object <cap-id>` still

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -334,7 +334,7 @@ emits <code>--json</code> is safe to consume from a script or another agent.)</p
 </tr>
 <tr>
 <td>Inspect or grade what commands actually ran</td>
-<td><a href="#h5i-recall-object--objects"><code>h5i recall objects [--json]</code></a>, <a href="#h5i-recall-object--objects"><code>recall search</code></a></td>
+<td><a href="#h5i-recall-object--objects"><code>h5i recall objects [--json]</code></a>, <a href="#h5i-recall-object--objects"><code>recall search [--json]</code></a></td>
 <td>Typed feed: <code>cmd</code>, <code>exit</code>, <strong>action</strong> (test/build/read/write/egress), <strong>tool</strong>, validated <strong>status</strong>, enforced <strong>egress</strong> verdicts.</td>
 </tr>
 <tr>
@@ -2293,6 +2293,8 @@ h5i recall objects --status failed       # filter by structured status
 h5i recall objects --tool pytest         # by tool  (compose with --branch/--file/--diff)
 h5i recall objects --env fix-auth --json # typed feed for headless / CI grading
 h5i recall objects --env none            # only workspace captures (taken outside any env)
+h5i recall search &quot;connection refused&quot; --severity error --json
+                                             # typed matching findings for headless consumers
 h5i recall object &lt;id&gt;                    # rehydrate the FULL raw bytes
 h5i recall object &lt;id&gt; --summary          # the reduced summary only
 h5i recall object &lt;id&gt; --manifest         # the full manifest JSON record
@@ -2343,6 +2345,10 @@ independent, non-inferred signals. Note that in the default <code>signal</code> 
 mode small <strong>successful</strong> commands aren't stored; create the env with
 <code>h5i env create &lt;name&gt; --audit all</code> (or set <code>H5I_ENV_AUDIT_CAPTURE=all</code>) to
 record every wrapped command for a complete ledger.</p>
+<p><code>recall search --json</code> uses the same capture-level field names, adds a
+<code>findings</code> array containing only the findings selected by the query and filters,
+and honors <code>--limit</code>. A search with no matches emits <code>[]</code>; without <code>--json</code>, the
+existing human-readable output is unchanged.</p>
 <p>Inside a sandboxed env, a capture you just made is <strong>staged</strong> in the box's spool
 and not yet ingested into <code>refs/h5i/objects</code>; <code>h5i recall object &lt;cap-id&gt;</code> still
 rehydrates its full raw bytes from the spool (so an agent can re-read output that

--- a/src/cli/objects.rs
+++ b/src/cli/objects.rs
@@ -152,6 +152,10 @@ pub enum ObjectsCommands {
         /// Maximum number of matching captures to show.
         #[arg(short, long, default_value_t = 20)]
         limit: usize,
+        /// Emit a structured JSON array containing capture metadata and only
+        /// the findings matched by this search.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Evict local raw blobs to reclaim space. Manifests/summaries are kept.
@@ -931,6 +935,7 @@ pub fn run(action: ObjectsCommands) -> anyhow::Result<()> {
                     env,
                     since,
                     limit,
+                    json,
                 } => {
                     // Validate enum-valued filters up front against the canonical
                     // vocabularies, case-insensitively (mirrors `list --status`).
@@ -1003,6 +1008,70 @@ pub fn run(action: ObjectsCommands) -> anyhow::Result<()> {
                     // reverse to newest-first for display.
                     let newest: Vec<objects::Manifest> = all.into_iter().rev().collect();
                     let hits = objects::search_manifests(&newest, &filters);
+
+                    if json {
+                        // Mirror `recall objects --json` for capture-level fields,
+                        // then attach only the findings selected by the search.
+                        let store = objects::LocalStore::new(&h5i_root);
+                        #[derive(serde::Serialize)]
+                        struct SearchJson<'a> {
+                            id: &'a str,
+                            timestamp: &'a str,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            cmd: Option<&'a str>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            exit_code: Option<i32>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            action: Option<&'a str>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            tool: Option<&'a str>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            status: Option<String>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            duration_ms: Option<u64>,
+                            kind: &'a str,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            branch: Option<&'a str>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            env_id: Option<&'a str>,
+                            #[serde(skip_serializing_if = "Option::is_none")]
+                            egress: Option<&'a h5i_core::sandbox_policy::EgressSummary>,
+                            raw_size: u64,
+                            raw_present: bool,
+                            findings: Vec<&'a h5i_core::structured::Finding>,
+                        }
+                        let rows: Vec<SearchJson> = hits
+                            .iter()
+                            .take(limit)
+                            .map(|hit| {
+                                let m = hit.manifest;
+                                let st = m.structured.as_ref();
+                                SearchJson {
+                                    id: &m.id,
+                                    timestamp: &m.timestamp,
+                                    cmd: m.cmd.as_deref(),
+                                    exit_code: m.exit_code,
+                                    action: m.action.as_deref(),
+                                    tool: st.map(|s| s.tool.as_str()),
+                                    status: st.and_then(|s| {
+                                        serde_json::to_value(s.status)
+                                            .ok()
+                                            .and_then(|v| v.as_str().map(str::to_string))
+                                    }),
+                                    duration_ms: st.and_then(|s| s.duration_ms),
+                                    kind: &m.kind,
+                                    branch: m.branch.as_deref(),
+                                    env_id: m.env_id.as_deref(),
+                                    egress: m.egress.as_ref(),
+                                    raw_size: m.raw_size,
+                                    raw_present: store.has(m.hex()),
+                                    findings: hit.findings.clone(),
+                                }
+                            })
+                            .collect();
+                        println!("{}", serde_json::to_string_pretty(&rows)?);
+                        return Ok(());
+                    }
 
                     if hits.is_empty() {
                         println!("No captured findings match that search.");

--- a/tests/objects_e2e.rs
+++ b/tests/objects_e2e.rs
@@ -499,6 +499,50 @@ fn search_finds_findings_by_text_path_and_metadata() {
 }
 
 #[test]
+fn search_json_emits_typed_hits_and_an_empty_array() {
+    let (_root, a) = single();
+    install_fake_tool(&a.dir, "pytest", FAILING_PYTEST);
+    h5i_path(&a, &["capture", "run", "--min-bytes", "0", "--", "pytest", "-q"]);
+
+    let matched = h5i_path(&a, &["recall", "search", "100", "--json"]);
+    assert!(
+        matched.status.success(),
+        "recall search --json failed:\nstdout: {}\nstderr: {}",
+        stdout(&matched),
+        stderr(&matched)
+    );
+    let rows: serde_json::Value =
+        serde_json::from_slice(&matched.stdout).expect("search output should be valid JSON");
+    let rows = rows
+        .as_array()
+        .expect("search output should be a JSON array");
+    assert_eq!(rows.len(), 1, "one capture should match: {rows:#?}");
+    assert!(rows[0]["id"].as_str().is_some_and(|id| !id.is_empty()));
+    assert!(rows[0]["timestamp"]
+        .as_str()
+        .is_some_and(|timestamp| !timestamp.is_empty()));
+    assert_eq!(rows[0]["cmd"], "pytest -q");
+    assert_eq!(rows[0]["exit_code"], 1);
+    assert_eq!(rows[0]["action"], "test");
+    assert_eq!(rows[0]["tool"], "pytest");
+    assert_eq!(rows[0]["status"], "failed");
+    assert_eq!(rows[0]["findings"][0]["kind"], "test_failure");
+    assert_eq!(rows[0]["findings"][0]["severity"], "failure");
+    assert_eq!(rows[0]["findings"][0]["message"], "assert 0 == 100");
+    assert_eq!(rows[0]["findings"][0]["location"]["path"], "tests/t.py");
+    assert!(rows[0]["findings"][0]["fingerprint"]
+        .as_str()
+        .is_some_and(|fingerprint| !fingerprint.is_empty()));
+
+    let empty = h5i_path(
+        &a,
+        &["recall", "search", "not-a-matching-finding", "--json"],
+    );
+    assert!(empty.status.success(), "empty JSON search should succeed");
+    assert_eq!(stdout(&empty).trim(), "[]");
+}
+
+#[test]
 fn search_validates_enum_and_duration_arguments() {
     let (_root, a) = single();
     // Each invalid enum value is rejected before any work, with a helpful message.


### PR DESCRIPTION
Adds `--json` to `h5i recall search`, returning the same capture metadata as `recall objects --json` plus only the findings matched by the query and filters. Empty searches return `[]`; the existing human output is unchanged.

Adds integration coverage for typed metadata, finding fields, and zero-match output, and documents the new flag.

Closes #336

### Testing

- `cargo test --locked --test objects_e2e search_json_emits_typed_hits_and_an_empty_array -- --exact --nocapture`
- `cargo test --locked --test objects_e2e search_ -- --nocapture`
- `cargo test --locked -p h5i-core objects::tests::search -- --nocapture`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --verbose --all-targets`
- `cargo check --locked --target x86_64-pc-windows-msvc`
- `cargo test --verbose` (217 passed; the same seven WSL process-tier integration failures reproduce on the exact base)