### PR TITLE
Add --json to the `h5i env allow` list view

### DIFF
--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -287,13 +287,16 @@ Manage the persistent user-level egress allowlist: extra hosts merged into every
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBallow\fR [\fB\-\-remove\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIRULE\fR] 
+\fBallow\fR [\fB\-\-remove\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIRULE\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
 .TP
 \fB\-\-remove\fR
 Remove the rule instead of adding it
+.TP
+\fB\-\-json\fR
+Emit the stored rules and their file as JSON (list form only)
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -93,6 +93,9 @@ pub enum EnvCommands {
         /// Remove the rule instead of adding it.
         #[arg(long)]
         remove: bool,
+        /// Emit the stored rules and their file as JSON (list form only).
+        #[arg(long, conflicts_with = "rule", conflicts_with = "remove")]
+        json: bool,
     },
 
     /// Probe what isolation this host can actually provide (Landlock, user
@@ -522,7 +525,14 @@ pub fn run(action: EnvCommands) -> anyhow::Result<()> {
                     }
                 }
 
-                EnvCommands::Allow { rule, remove } => match rule {
+                EnvCommands::Allow { rule, remove, json } => match rule {
+                    None if json => {
+                        let doc = serde_json::json!({
+                            "path": h5i_core::env::user_allow_path(),
+                            "rules": h5i_core::env::user_allow_list(),
+                        });
+                        println!("{}", serde_json::to_string_pretty(&doc)?);
+                    }
                     None => {
                         let rules = h5i_core::env::user_allow_list();
                         match h5i_core::env::user_allow_path() {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -381,6 +381,47 @@ fn env_allow_add_list_remove_and_in_box_refusal() {
 }
 
 #[test]
+fn env_allow_json_lists_rules_and_rejects_mutating_forms() {
+    let r = Repo::new();
+    let cfg = TempDir::new().expect("tempdir");
+    let run = |args: &[&str]| -> Output {
+        Command::new(H5I)
+            .args(args)
+            .env("H5I_AGENT", "tester")
+            .env("H5I_DEFAULT_ISOLATION", "workspace")
+            .env("XDG_CONFIG_HOME", cfg.path())
+            .current_dir(&r.dir)
+            .output()
+            .expect("failed to run h5i")
+    };
+
+    // Empty allowlist: valid JSON with the resolved path and an empty rules array.
+    let out = run(&["env", "allow", "--json"]);
+    assert!(out.status.success(), "{}", out_str(&out));
+    let doc: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("valid JSON");
+    let expected_path = cfg.path().join("h5i").join("egress-allow");
+    assert_eq!(doc["path"], expected_path.to_str().unwrap());
+    assert_eq!(doc["rules"], serde_json::json!([]));
+
+    // After adding one rule, the JSON carries the normalized rule.
+    let out = run(&["env", "allow", "PyPI.org"]);
+    assert!(out.status.success(), "{}", out_str(&out));
+    let out = run(&["env", "allow", "--json"]);
+    assert!(out.status.success(), "{}", out_str(&out));
+    let doc: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).expect("valid JSON");
+    assert_eq!(doc["rules"], serde_json::json!(["pypi.org"]));
+
+    // `--json` only applies to the list form: a rule argument or `--remove`
+    // alongside it is a clap conflict.
+    let out = run(&["env", "allow", "pypi.org", "--json"]);
+    assert!(!out.status.success(), "rule + --json must be rejected");
+    let out = run(&["env", "allow", "--remove", "--json"]);
+    assert!(!out.status.success(), "--remove + --json must be rejected");
+}
+
+#[test]
 fn env_create_pr_pins_pr_head_as_base() {
     let r = Repo::new();
     // A "GitHub-like" remote: a bare repo exposing a PR head at refs/pull/7/head.


### PR DESCRIPTION
## Summary
`h5i env allow` (the no-rule list form) now takes `--json`, closing the last gap in the scriptable env family: the persistent user egress allowlist could only be read as styled text.

```bash
h5i env allow --json
{
  "path": "/home/user/.config/h5i/egress-allow",
  "rules": ["pypi.org"]
}
```

- `EnvCommands::Allow` gains `json: bool` with `conflicts_with = "rule"` / `conflicts_with = "remove"`, so `h5i env allow <rule> --json` and `--remove --json` are rejected by clap.
- The JSON arm reuses `user_allow_path()` + `user_allow_list()` and prints via `serde_json::to_string_pretty`, matching the other env `--json` arms; an empty allowlist yields `"rules": []`. Default styled listing and add/remove flows are unchanged.
- Integration test `env_allow_json_lists_rules_and_rejects_mutating_forms` asserts the JSON shape (empty and after adding one rule, with `$XDG_CONFIG_HOME` pointed at a temp dir) and the conflict rejections.

Fixes #339
