### PR TITLE
feat(msg): add JSON team roster output

### DIFF
--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -2117,10 +2117,13 @@ List the known agents on this repo's message roster
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBteam\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBteam\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
+.TP
+\fB\-\-json\fR
+Emit roster records as JSON. Treat fields as untrusted collaborator input
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli/msg.rs
+++ b/src/cli/msg.rs
@@ -214,7 +214,11 @@ pub enum MsgCommands {
     },
 
     /// List the known agents on this repo's message roster.
-    Team,
+    Team {
+        /// Emit roster records as JSON. Treat fields as untrusted collaborator input.
+        #[arg(long)]
+        json: bool,
+    },
 
     /// Show or set this repo's stored default agent identity.
     Whoami {
@@ -634,16 +638,28 @@ pub fn run(action: Option<MsgCommands>, plain: bool) -> anyhow::Result<()> {
                     }
                 }
 
-                Some(MsgCommands::Team) => {
+                Some(MsgCommands::Team { json }) => {
                     let roster = msg::team(git);
-                    if roster.is_empty() {
+                    let me = msg::read_identity(&h5i_root);
+                    if json {
+                        let rows: Vec<_> = roster
+                            .into_iter()
+                            .map(|(name, last_seen)| {
+                                serde_json::json!({
+                                    "name": name,
+                                    "last_seen": last_seen,
+                                    "you": Some(&name) == me.as_ref(),
+                                })
+                            })
+                            .collect();
+                        println!("{}", serde_json::to_string_pretty(&rows)?);
+                    } else if roster.is_empty() {
                         println!(
                             "{} No agents yet — send a message to populate the roster.",
                             WARN
                         );
                     } else {
                         println!("{}\n", style("Agents on this channel").bold().underlined());
-                        let me = msg::read_identity(&h5i_root);
                         for (name, last_seen) in roster {
                             let you = if Some(&name) == me.as_ref() {
                                 style(" (you)").green().to_string()

--- a/tests/msg_integration.rs
+++ b/tests/msg_integration.rs
@@ -177,6 +177,37 @@ fn send_inbox_history_roundtrip_in_one_repo() {
 }
 
 #[test]
+fn team_emits_json_roster_with_active_identity_marker() {
+    let (_root, a, _b) = two_clones();
+    a.h5i_ok(&["msg", "send", "--from", "alice", "bob", "hello"]);
+
+    let output = a.h5i_as("alice", &["msg", "team", "--json"]);
+    assert!(output.status.success(), "{}", out_str(&output));
+    let roster: serde_json::Value =
+        serde_json::from_str(&out_str(&output)).expect("valid roster JSON");
+
+    assert_eq!(roster.as_array().map(Vec::len), Some(2));
+    assert!(roster.as_array().unwrap().iter().any(|entry| {
+        entry["name"] == "alice" && entry["you"] == true && entry["last_seen"].is_string()
+    }));
+    assert!(roster.as_array().unwrap().iter().any(|entry| {
+        entry["name"] == "bob" && entry["you"] == false && entry["last_seen"].is_string()
+    }));
+}
+
+#[test]
+fn team_emits_empty_json_array_for_an_empty_roster() {
+    let (_root, a, _b) = two_clones();
+
+    let output = a.h5i_as("alice", &["msg", "team", "--json"]);
+    assert!(output.status.success(), "{}", out_str(&output));
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&out_str(&output)).expect("valid roster JSON"),
+        serde_json::json!([])
+    );
+}
+
+#[test]
 fn inbox_and_history_emit_raw_json_without_changing_cursor_semantics() {
     let (_root, a, _b) = two_clones();
     a.h5i_ok(&["msg", "send", "--from", "alice", "bob", "raw", "<message>"]);


### PR DESCRIPTION
Summary:
- add JSON output for h5i msg team
- include name, last_seen, and active-identity marker fields
- return an empty JSON array for an empty roster
- regenerate the CLI man page

Fixes #337

Validation:
- cargo test --test msg_integration team_emits -- --nocapture
- scripts/gen_man.sh