### PR TITLE
feat(sandbox): the microvm tier, via a microsandbox (msb) backend

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -151,7 +151,7 @@ unsatisfiable request fails closed rather than leaving half a box behind.
 | `--new` | Empty box (a fresh repository with one empty commit). Detached. |
 | `--profile <p>` | See [Profiles](#profiles). |
 | `--isolation <tier>` | See [Isolation tiers](#isolation-tiers). |
-| `--image <img>` | Container base image for `isolation=container`. |
+| `--image <img>` | Base image for `isolation=container` and `isolation=microvm`. Pre-pulled; runs never pull. |
 
 ### Working in a box
 
@@ -517,6 +517,7 @@ wall  = "30m"
 | `process` | Landlock + seccomp + namespaces, with a supervisor and a private pid namespace. | deny or host |
 | `supervised` | Adds a private netns with an nftables egress allowlist pinned to resolved IPs, DNS pinned by a hosts file, and a seccomp-notify gate on `socket()`. | **L3/L4** |
 | `container` | Rootless Podman: a portable image, with a CONNECT-proxy egress allowlist. | L7 |
+| `microvm` | A hardware-isolated guest with its own kernel, booted by [microsandbox](https://microsandbox.dev) (`msb`) from the same OCI images. Egress rules are evaluated by the VM's network stack. | **L3/L4** |
 
 `auto` (the default) picks the strongest tier the host can actually run. An
 explicit tier **fails closed** if the host cannot satisfy it — h5i never
@@ -526,6 +527,42 @@ Worth being clear about, because two drafts of the design got it backwards: the
 container tier buys **portability**, not tighter network control. Its allowlist
 is a proxy, so it binds proxy-respecting tooling only. `supervised` enforces at
 L3/L4 and does not have that hole.
+
+#### The microvm tier
+
+`microvm` is the one tier where the boundary is a virtual machine rather than a
+policy applied to a host process. A kernel exploit inside the box meets the
+hypervisor, not the host kernel it just subverted. Its `net.egress` allowlist
+becomes default-deny plus one address rule per allowed destination, so a raw
+socket to an unlisted IP is dropped rather than merely un-proxied.
+
+Requirements, all three, or the tier refuses:
+
+- microsandbox's `msb` on `PATH`, version 0.6 or newer.
+- Host virtualization: `/dev/kvm` openable on Linux, Apple Silicon on macOS.
+  A stock WSL2 kernel and most cloud CI runners have neither.
+- A base image, from `--image`, the profile's `container.image`, or the
+  repo-level `[container] image` — the same images the container tier runs,
+  pre-pulled with `msb pull`.
+
+`h5i box probe` reports which of the three is missing, since "install a package"
+and "enable nested virtualization" are different problems.
+
+Two things it does **not** do yet, stated rather than left to be discovered:
+
+- **No per-request egress tally.** The container tier's proxy sees every CONNECT
+  and records allow/deny counts in the capture manifest. A netstack filter drops
+  packets without reporting them, so a microvm receipt carries no egress
+  summary. Stronger enforcement, thinner evidence.
+- **No authenticated-egress grants.** `[[profile.X.auth]]` hands the box a base
+  URL pointing at a credential proxy on the *host's* loopback, which a microVM
+  guest cannot dial. A profile that declares grants is refused at this tier
+  rather than handed an origin that resolves to nothing.
+
+In-box observation works as it does under `container`: the read-only
+managed-settings mount carrying the `wrap-bash` hook, and the capture spool at
+`/.h5i/spool`. The container tier's tee shim has no analogue here (it depends on
+self-mounting the image, which a VM has nothing to do).
 
 ### AF_UNIX sockets
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1022,10 +1022,17 @@ Being explicit about these is a feature, since the claim is a security claim.
   agent from touching the host. It does not stop it from putting private code in
   a prompt. That is a separate control (self hosted model, or no model egress at
   all) and we will not imply otherwise.
-- **Shared kernel.** Podman and the kernel tiers share the host kernel. Good
-  against a runaway agent and against careless dependency code. Not a claim
-  against a targeted kernel exploit. A microVM backend is the answer, and it is
-  post M6.
+- **Shared kernel, unless you pick the microVM tier.** Podman and the kernel
+  tiers share the host kernel. Good against a runaway agent and against careless
+  dependency code. Not a claim against a targeted kernel exploit. The answer
+  ships as `isolation=microvm`, a microsandbox (`msb`) backend that boots the
+  same OCI images into a guest with its own kernel and filters egress by address
+  in the VM's network stack. What it costs is honest and stated in MANUAL.md: it
+  needs host virtualization (`/dev/kvm`, or Apple Silicon), it produces no
+  per-request egress tally, and it does not yet route the authenticated-egress
+  credential proxy. **Not yet demonstrated end to end** — this development host
+  has no nested virtualization, so the adapter is unit-tested against its argv
+  and rule translation and has never booted a real guest here.
 - **The container tier's egress scoping is L7.** Its allowlist is a proxy, so
   it binds proxy respecting tooling only. The `supervised` tier enforces at
   L3/L4 with nftables and does not have that hole, which is why M4 starts

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -73,8 +73,10 @@ pub const H5I_ENV_INBOX_VAR: &str = "H5I_ENV_INBOX";
 /// `h5i team agent submit` can refuse a provably empty submission in-box
 /// (the box can't read the sealed team refs to learn the base itself).
 pub const H5I_ENV_BASE_TREE_VAR: &str = "H5I_ENV_BASE_TREE";
-const CONTAINER_CAPTURE_SPOOL: &str = "/.h5i/spool";
-const CONTAINER_INBOX_MOUNT: &str = "/.h5i/inbox";
+/// In-box mountpoints, identical on every image-backed tier so nothing running
+/// *inside* a box needs to know whether it booted under Podman or a microVM.
+const BOX_CAPTURE_SPOOL: &str = "/.h5i/spool";
+const BOX_INBOX_MOUNT: &str = "/.h5i/inbox";
 /// Inbox subdir under the env admin dir; mounted read-only into the box.
 const ENV_INBOX_DIR: &str = "inbox";
 #[cfg(unix)] // only the unix-gated RunLock references this
@@ -1919,7 +1921,7 @@ fn grant_box_git(
                 }
             }
         }
-        IsolationClaim::Container => {
+        claim if claim.image_backed() => {
             let mut mounts = box_git_plumbing(repo, m)?;
             mounts.push(BoxGitPath {
                 host: work.to_path_buf(),
@@ -1934,8 +1936,8 @@ fn grant_box_git(
                     });
                 }
             }
-            // Podman errors on a missing bind source (unlike Landlock, which
-            // skips) — keep only what exists on the host.
+            // A bind-mounting runtime errors on a missing source (unlike
+            // Landlock, which skips) — keep only what exists on the host.
             mounts.retain(|b| b.host.exists());
             policy.box_git = mounts;
         }
@@ -1958,6 +1960,22 @@ fn prepare_cargo_env(
         "CARGO_TARGET_DIR".to_string(),
         target_dir.display().to_string(),
     )])
+}
+
+/// The character an image-backed tier's mount **spec string** reserves, and
+/// which a host path therefore cannot contain: `,` for Podman's
+/// `type=bind,source=…,target=…`, `:` for microsandbox's `SOURCE:DEST:OPTIONS`.
+/// `None` for the kernel tiers, which pass paths as arguments rather than as
+/// fields of a delimited string and so have no such hazard.
+///
+/// Callers use this to refuse a path they could not mount, instead of emitting a
+/// spec that would mount something else.
+fn mount_spec_separator(claim: IsolationClaim) -> Option<char> {
+    match claim {
+        IsolationClaim::Container => Some(','),
+        IsolationClaim::Microvm => Some(':'),
+        _ => None,
+    }
 }
 
 /// Materialize per-env private paths (Idea 3): give each declared path its own
@@ -1995,17 +2013,21 @@ fn prepare_private_paths(
         // The mountpoint must exist inside the worktree.
         let target = work.join(&rel);
         std::fs::create_dir_all(&target).map_err(|e| H5iError::with_path(e, &target))?;
-        // Container tier carries the backing dir as a Podman `--mount` whose
-        // syntax can't include a comma — fail closed if the env's host path has
-        // one, rather than silently dropping the (policy-required) isolation.
-        if policy.claim == IsolationClaim::Container && backing.display().to_string().contains(',')
-        {
-            return Err(H5iError::Metadata(format!(
-                "private_paths '{rel}': the env's backing path '{}' contains a ',' which the \
-                 container mount syntax cannot carry — move the repo out of a comma'd path \
-                 (fail-closed)",
-                backing.display()
-            )));
+        // The image-backed tiers carry the backing dir as a mount *spec string*,
+        // and each runtime's syntax reserves a separator its paths cannot
+        // contain: Podman's `--mount` splits on ',', microsandbox's
+        // `SOURCE:DEST` on ':'. Fail closed if the env's host path holds one,
+        // rather than silently dropping the (policy-required) isolation.
+        if let Some(sep) = mount_spec_separator(policy.claim) {
+            if backing.display().to_string().contains(sep) {
+                return Err(H5iError::Metadata(format!(
+                    "private_paths '{rel}': the env's backing path '{}' contains a '{sep}' which \
+                     the {} tier's mount syntax cannot carry — move the repo out of that path \
+                     (fail-closed)",
+                    backing.display(),
+                    policy.claim.as_str()
+                )));
+            }
         }
         if kernel {
             policy.profile.fs_write.push(backing.display().to_string());
@@ -2302,9 +2324,9 @@ fn prepare_env_inbox(
     let inbox = env_inbox_dir(h5i_root, m);
     std::fs::create_dir_all(&inbox).map_err(|e| H5iError::with_path(e, &inbox))?;
     let inside = match policy.claim {
-        IsolationClaim::Container => {
+        claim if claim.image_backed() => {
             policy.env_inbox = Some(inbox);
-            CONTAINER_INBOX_MOUNT.to_string()
+            BOX_INBOX_MOUNT.to_string()
         }
         IsolationClaim::Process | IsolationClaim::Supervised => {
             // Read-only: the box may read its inbox, never write it.
@@ -2393,9 +2415,9 @@ fn prepare_env_capture_spool(
     let spool = m.dir(h5i_root).join("spool");
     std::fs::create_dir_all(&spool).map_err(|e| H5iError::with_path(e, &spool))?;
     let spool_inside = match policy.claim {
-        IsolationClaim::Container => {
+        claim if claim.image_backed() => {
             policy.env_capture_spool = Some(spool);
-            CONTAINER_CAPTURE_SPOOL.to_string()
+            BOX_CAPTURE_SPOOL.to_string()
         }
         IsolationClaim::Process | IsolationClaim::Supervised => {
             policy.profile.fs_write.push(spool.display().to_string());
@@ -2843,7 +2865,7 @@ fn push_protected_hook_config(
     let original = std::fs::read(&path).ok();
     let mut sentinel_created = false;
     let mut parent_created = false;
-    if claim == IsolationClaim::Container
+    if claim.image_backed()
         && matches!(scope, ProtectedHookScope::Worktree)
         && original.is_none()
     {
@@ -3057,8 +3079,8 @@ fn write_user_allow(path: &Path, rules: &[String]) -> Result<(), H5iError> {
 /// `403 Blocked by network policy` is self-diagnosing.
 fn apply_user_egress(policy: &mut sandbox::ResolvedPolicy) {
     let user = user_allow_list();
-    let enforced = matches!(policy.claim, IsolationClaim::Container)
-        && !policy.profile.net_egress.is_empty();
+    let enforced =
+        policy.claim.enforces_egress_allowlist() && !policy.profile.net_egress.is_empty();
     if enforced {
         policy.user_egress_allow = user
             .into_iter()
@@ -3071,7 +3093,7 @@ fn apply_user_egress(policy: &mut sandbox::ResolvedPolicy) {
             })
             .collect();
         announce_egress(policy);
-    } else if matches!(policy.claim, IsolationClaim::Container) && !user.is_empty() {
+    } else if policy.claim.enforces_egress_allowlist() && !user.is_empty() {
         eprintln!(
             "note: {} `h5i dev allow` rule(s) ignored — profile '{}' sets no net.egress \
              (a deny-all profile is never widened from outside the policy)",
@@ -3081,7 +3103,11 @@ fn apply_user_egress(policy: &mut sandbox::ResolvedPolicy) {
     }
 }
 
-/// One line at session start explaining the enforced egress scope.
+/// One line at session start explaining the enforced egress scope — and, since
+/// the two tiers that enforce it do so by different mechanisms with different
+/// holes, *how* it is enforced. A `403` from a proxy and a dropped packet are
+/// diagnosed differently, and the line is the only place the box's operator is
+/// told which one to expect.
 fn announce_egress(policy: &sandbox::ResolvedPolicy) {
     const SHOW: usize = 8;
     let profile = &policy.profile.net_egress;
@@ -3103,7 +3129,11 @@ fn announce_egress(policy: &sandbox::ResolvedPolicy) {
             policy.user_egress_allow.join(", ")
         )
     };
-    eprintln!("⦿ egress (proxy-enforced, everything else 403): {line}{user_part}");
+    let how = match policy.claim {
+        IsolationClaim::Microvm => "address-enforced in the VM netstack, everything else dropped",
+        _ => "proxy-enforced, everything else 403",
+    };
+    eprintln!("⦿ egress ({how}): {line}{user_part}");
 }
 
 /// Run `argv` inside the env's worktree under its pinned policy, and record
@@ -3858,11 +3888,12 @@ fn default_shell_argv(
     // The container shell + its rc come from the image, not the host — the host
     // `~/.bashrc` is never sourced there, so there is nothing to neutralize and
     // a host-path rcfile would not resolve in-box. Honor neither default here.
-    if policy.claim == IsolationClaim::Container {
+    if policy.claim.image_backed() {
         if policy.profile.shell_rcfile.is_some() {
             eprintln!(
-                "   note: [shell] rcfile is ignored at isolation=container \
-                 (the shell rc comes from the image)"
+                "   note: [shell] rcfile is ignored at isolation={} \
+                 (the shell rc comes from the image)",
+                policy.claim.as_str()
             );
         }
         return Ok(bare);
@@ -4504,7 +4535,7 @@ pub fn status_report(repo: &Repository, h5i_root: &Path, m: &EnvManifest) -> Str
         }
         if !p.net_egress.is_empty() {
             out.push_str(&format!("  egress   : {}", p.net_egress.join(", ")));
-            if matches!(policy.claim, IsolationClaim::Container) {
+            if policy.claim.enforces_egress_allowlist() {
                 let extras: Vec<String> = user_allow_list()
                     .into_iter()
                     .filter(|u| !p.net_egress.iter().any(|e| e.trim().eq_ignore_ascii_case(u)))
@@ -4620,9 +4651,23 @@ pub fn doctor(repo: &Repository, h5i_root: &Path, m: &EnvManifest) -> DoctorRepo
                     false,
                     "workspace tier needs no kernel confinement".into()
                 ),
-                IsolationClaim::Container
-                | IsolationClaim::HardenedContainer
-                | IsolationClaim::Microvm => {
+                IsolationClaim::Microvm => match caps.microvm_runtime.as_deref() {
+                    Some(rt) => chk!(
+                        "enforcement",
+                        true,
+                        false,
+                        format!("microVM runtime present ({rt}) and the host can virtualize")
+                    ),
+                    // Name the missing half. "Install msb" and "enable nested
+                    // virtualization" are different problems with different fixes.
+                    None => chk!(
+                        "enforcement",
+                        false,
+                        false,
+                        sandbox::microvm_unavailable_detail()
+                    ),
+                },
+                IsolationClaim::Container | IsolationClaim::HardenedContainer => {
                     if let Some(rt) = caps.container_runtime.as_deref() {
                         chk!(
                             "enforcement",

--- a/crates/h5i-sandbox/src/lib.rs
+++ b/crates/h5i-sandbox/src/lib.rs
@@ -3,7 +3,8 @@
 //! The policy model (`sandbox_policy`) plus the confinement machinery and
 //! runtime backends: kernel-tier Landlock/seccomp/namespaces (`sandbox`,
 //! `supervisor`, `seccomp_notify`, `cgroup`), the rootless-Podman container
-//! backend (`container`), the egress allowlist proxy and secrets handling
+//! backend (`container`), the microsandbox microVM backend (`microvm`), the
+//! egress allowlist proxy and secrets handling
 //! (`auth_proxy`, `secrets`, `secrets_broker`). Extracted from `h5i-core` as an
 //! internal workspace crate so it compiles independently of the domain layer
 //! and could back other tools; it depends only on `h5i-error`.
@@ -17,6 +18,7 @@ pub mod sandbox_policy;
 pub mod auth_proxy;
 pub mod cgroup;
 pub mod container;
+pub mod microvm;
 pub mod sandbox;
 /// macOS Seatbelt backend. Compiled on every Unix target (so its profile
 /// generator is typechecked and unit-tested by the Linux job), but

--- a/crates/h5i-sandbox/src/microvm.rs
+++ b/crates/h5i-sandbox/src/microvm.rs
@@ -1,0 +1,1286 @@
+//! The `isolation=microvm` backend: run an environment's command inside a
+//! **hardware-isolated microVM** via the [microsandbox](https://microsandbox.dev)
+//! runtime (`msb`), and enforce the `net.egress` domain allowlist *in the VM's
+//! own network stack* rather than in a host-side HTTP proxy.
+//!
+//! ### Why this tier exists
+//!
+//! `container.rs` says it plainly: its `net.egress` enforcement is **L7**. It
+//! blocks the dominant exfiltration path (`curl`/`pip`/`npm` honouring
+//! `HTTP(S)_PROXY`) and nothing stops a process that ignores the proxy env and
+//! opens a raw socket to an arbitrary IP the rootless NAT permits. The same
+//! module names the fix: *"airtight L3/L4 egress filtering is the
+//! `hardened-container`/`microvm` tier"*. This module is that tier.
+//!
+//! Two things change relative to `container`:
+//!
+//! 1. **The boundary is a virtual machine.** The guest runs its own kernel on
+//!    KVM (Linux) or Hypervisor.framework (Apple Silicon). A kernel exploit in
+//!    the box is contained by the hypervisor rather than by the host kernel it
+//!    just subverted, which is the property neither the kernel tiers nor a
+//!    shared-kernel container can offer.
+//! 2. **Egress is filtered by address, not by proxy etiquette.** The allowlist
+//!    becomes `--net-default-egress deny` plus one `--net-rule` per allowed
+//!    destination, evaluated by the VM's virtual network stack. A raw socket to
+//!    an unlisted IP is dropped; there is no `HTTP_PROXY` to ignore. DNS-rebind
+//!    protection is on by default and we never disable it.
+//!
+//! ### What it costs, stated rather than hidden
+//!
+//! - **The host must support virtualization.** `/dev/kvm` on Linux, Apple
+//!   Silicon on macOS. No nested virtualization (a plain WSL2 kernel, most CI
+//!   runners) means no microvm tier, and [`resolve`] refuses rather than
+//!   downgrading.
+//! - **No per-request egress tally.** The container tier's proxy sees every
+//!   CONNECT and reports allow/deny counts into the capture manifest. A VM
+//!   netstack filter drops packets without telling us which, so
+//!   [`ExecOutcome::egress`] is `None` here. Stronger enforcement, weaker
+//!   evidence — we report the tier's rules at session start instead of
+//!   pretending to a tally we do not have.
+//! - **No in-box tee shim.** The container tier self-mounts its own image at
+//!   `/.h5i/orig` so a shadowed `/bin/sh` still has a real shell to exec. A VM
+//!   has no image to self-mount, so that trick has no analogue. The *primary*
+//!   in-box observation path — the read-only managed-settings mount carrying the
+//!   unkillable `wrap-bash` hook — works here exactly as it does under
+//!   `container`, and the capture spool is mounted the same way.
+//!
+//! ### Secrets never enter the host argv
+//!
+//! `msb` has no name-only env forwarding (`podman --env NAME` reads the value
+//! from its own environment; `msb --env` takes `KEY=VALUE`). Putting a brokered
+//! credential in `msb run`'s argv would publish it to every local user through
+//! `/proc/<pid>/cmdline`, which is exactly the leak `container.rs` goes out of
+//! its way to avoid. So this backend passes **no** environment on the command
+//! line at all: it writes a `0600` preload script host-side, registers it with
+//! `--script-path` (whose *contents* travel to the runtime over a config fd, not
+//! argv), and runs the command through it. See [`preload_script`].
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::error::H5iError;
+use crate::sandbox_policy::{ExecOutcome, InteractiveOutcome, NetMode, Profile, ResolvedPolicy};
+
+/// Minimum `msb` version this adapter targets. Below it, `--net-rule`,
+/// `--net-default-egress`, `--script-path` and the explicit `--mount-dir` /
+/// `--mount-file` forms are absent or spelled differently, and a run would fail
+/// with a confusing clap error instead of an actionable one.
+pub const MIN_MSB_VERSION: (u64, u64) = (0, 6);
+
+/// Where the guest keeps `--script-path` scripts. `msb`'s guest agent creates
+/// the directory, marks the entries executable, and puts it first on `PATH`
+/// (`microsandbox_protocol::SCRIPTS_PATH`).
+const GUEST_SCRIPTS_DIR: &str = "/.msb/scripts";
+
+/// Script name for the environment preload wrapper. Registered with
+/// `--script-path`, so it lands at `{GUEST_SCRIPTS_DIR}/{PRELOAD_SCRIPT_NAME}`.
+const PRELOAD_SCRIPT_NAME: &str = "h5i-env";
+
+/// The workspace mountpoint inside the guest. Same as the container tier, so a
+/// profile, a hook, and a persona file all mean the same path on both.
+const WORK_MOUNT: &str = "/work";
+
+/// Capture spool for in-box `h5i capture run` — identical to the container
+/// tier's `/.h5i/spool`, so the in-box side needs no per-tier knowledge.
+const SPOOL_MOUNT: &str = "/.h5i/spool";
+
+/// Per-env inbound mailbox, mounted READ-ONLY (the host fans messages in).
+const INBOX_MOUNT: &str = "/.h5i/inbox";
+
+// ─── runtime detection ──────────────────────────────────────────────────────
+
+/// A detected microVM runtime.
+#[derive(Debug, Clone)]
+pub struct Runtime {
+    /// The binary to invoke (`msb`).
+    pub bin: String,
+    /// Parsed `(major, minor)` of `msb --version`, checked against
+    /// [`MIN_MSB_VERSION`].
+    pub version: (u64, u64),
+}
+
+/// Cheap presence check: is the `msb` binary on PATH at all? Used for
+/// discoverability hints that need "is microsandbox installed?" and not "can
+/// this host actually boot a microVM?" — the latter is [`probe`].
+pub fn msb_present() -> bool {
+    msb_version().is_some()
+}
+
+/// Detect a usable microVM runtime: an `msb` new enough for this adapter's flag
+/// set **and** a host that can actually run a VM. Returns `None` when either
+/// half is missing — this tier is never approximated.
+///
+/// Memoized in-process (both halves are cheap: one `msb --version` exec and a
+/// `stat`, so unlike the container tier's ~1.3s `podman info` there is nothing
+/// worth a cross-invocation cache). `H5I_NO_PROBE_CACHE=1` bypasses the memo so
+/// `env probe` always reports a live verdict.
+pub fn probe() -> Option<Runtime> {
+    if std::env::var_os("H5I_NO_PROBE_CACHE").is_some() {
+        return probe_uncached();
+    }
+    static PROBE: std::sync::OnceLock<Option<Runtime>> = std::sync::OnceLock::new();
+    PROBE.get_or_init(probe_uncached).clone()
+}
+
+fn probe_uncached() -> Option<Runtime> {
+    let version = msb_version()?;
+    if version < MIN_MSB_VERSION {
+        return None;
+    }
+    if virtualization_detail().is_some() {
+        return None;
+    }
+    Some(Runtime {
+        bin: "msb".into(),
+        version,
+    })
+}
+
+/// `(major, minor)` from `msb --version`, or `None` when the binary is absent
+/// or its output is unparseable. Clap prints `msb <semver>`; we scan for the
+/// first dotted-numeric token so a future banner change doesn't break detection.
+fn msb_version() -> Option<(u64, u64)> {
+    let out = std::process::Command::new("msb")
+        .arg("--version")
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_version(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Pull `(major, minor)` out of a version banner. Pure, so the parsing rule is
+/// testable without an `msb` on PATH.
+pub fn parse_version(text: &str) -> Option<(u64, u64)> {
+    for token in text.split(|c: char| c.is_whitespace() || c == 'v') {
+        let mut parts = token.split('.');
+        let (Some(major), Some(minor)) = (parts.next(), parts.next()) else {
+            continue;
+        };
+        if let (Ok(major), Ok(minor)) = (major.parse::<u64>(), minor.parse::<u64>()) {
+            return Some((major, minor));
+        }
+    }
+    None
+}
+
+/// Why this host cannot run a microVM, or `None` when it can. Separated from
+/// [`probe`] so `env probe`/`doctor` can say *what* is missing instead of a bare
+/// "microvm unavailable" — the difference between "install msb" and "enable
+/// nested virtualization", which are very different afternoons.
+pub fn virtualization_detail() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        // The gate is not "does the file exist" but "can this user open it":
+        // a host with KVM compiled in but the caller outside the `kvm` group
+        // fails at boot, and finding that out here yields the actionable message.
+        match std::fs::OpenOptions::new().read(true).write(true).open("/dev/kvm") {
+            Ok(_) => None,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Some(
+                "/dev/kvm is absent — this kernel has no KVM (common on WSL2 without nested \
+                 virtualization, and on most cloud CI runners)"
+                    .into(),
+            ),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Some(
+                "/dev/kvm exists but is not openable by this user — add yourself to the `kvm` \
+                 group (`sudo usermod -aG kvm $USER`) and re-login"
+                    .into(),
+            ),
+            Err(e) => Some(format!("/dev/kvm is not usable: {e}")),
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // Hypervisor.framework is present on every supported macOS, but
+        // microsandbox's guest kernel (libkrun) ships for Apple Silicon only.
+        if cfg!(target_arch = "aarch64") {
+            None
+        } else {
+            Some(
+                "microsandbox's microVM guest requires Apple Silicon; this Mac is Intel \
+                 (x86_64)"
+                    .into(),
+            )
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Some("the microvm tier supports Linux (KVM) and macOS (Apple Silicon) only".into())
+    }
+}
+
+// ─── egress allowlist → netstack rules ──────────────────────────────────────
+
+/// How networking is wired for a microVM run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetPlan {
+    /// No network at all (`net.mode = deny`, no egress allowlist).
+    None,
+    /// Unfiltered outbound (`net.mode = host`).
+    Host,
+    /// Default-deny egress plus these `--net-rule` tokens — the real allowlist.
+    Allow(Vec<String>),
+}
+
+/// Translate h5i's `net.egress` entries into microsandbox `--net-rule` tokens.
+///
+/// h5i spells an allowlist entry `host`, `host:port`, `.suffix` or `*.suffix`;
+/// microsandbox spells a rule `<action>[:<direction>]@<target>[:<proto>[:<ports>]]`.
+/// The mapping is deliberately conservative — an entry we cannot translate
+/// *exactly* is an error, never a rule that quietly allows more (or less) than
+/// the policy says:
+///
+/// - `example.com`      → `allow@example.com`                (any proto, any port)
+/// - `example.com:443`  → `allow@example.com:tcp:443`
+/// - `.example.com`     → `allow@domain=example.com` **and** `allow@suffix=example.com`
+///   — h5i's wildcard matches the apex as well as subdomains, and microsandbox's
+///   `suffix=` target covers only the subdomain half, so both tokens are emitted.
+/// - a bare IP or CIDR passes through as its own target.
+///
+/// Every rule set gets a leading `allow@dns` so name resolution works against
+/// the gateway resolver; without it a default-deny box cannot resolve the very
+/// hosts it is allowed to reach.
+///
+/// Fail-closed rejections: an entry carrying `,` or `@` (which would split or
+/// re-target the token), and a single-label wildcard such as `.com` (which
+/// microsandbox refuses, and which is not an allowlist anybody meant to write).
+pub fn egress_rule_tokens(egress: &[String]) -> Result<Vec<String>, H5iError> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut push = |token: String, tokens: &mut Vec<String>| {
+        if seen.insert(token.clone()) {
+            tokens.push(token);
+        }
+    };
+
+    for raw in egress {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        if raw.contains(',') || raw.contains('@') {
+            return Err(H5iError::Metadata(format!(
+                "net.egress entry '{raw}' contains ',' or '@', which the microvm tier's rule \
+                 grammar reserves — refusing rather than emitting a rule that means something \
+                 else (fail-closed). Split it into separate entries."
+            )));
+        }
+        // Only a trailing all-digit segment is a port; IPv6 literals are full of colons.
+        let (host_part, port) = match raw.rsplit_once(':') {
+            Some((h, p)) if !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()) => {
+                (h, p.parse::<u16>().ok())
+            }
+            _ => (raw, None),
+        };
+        let lower = host_part.to_ascii_lowercase();
+        let (host, wildcard) = match lower.strip_prefix("*.").or_else(|| lower.strip_prefix('.')) {
+            Some(rest) => (rest.to_string(), true),
+            None => (lower, false),
+        };
+        if host.is_empty() {
+            continue;
+        }
+        let qualifier = match port {
+            Some(p) => format!(":tcp:{p}"),
+            None => String::new(),
+        };
+        if wildcard {
+            if host.split('.').filter(|l| !l.is_empty()).count() < 2 {
+                return Err(H5iError::Metadata(format!(
+                    "net.egress wildcard '{raw}' covers a single label — a suffix rule must name \
+                     at least two (e.g. '*.example.com', not '*.com'). Refusing (fail-closed)."
+                )));
+            }
+            push(format!("allow@domain={host}{qualifier}"), &mut tokens);
+            push(format!("allow@suffix={host}{qualifier}"), &mut tokens);
+        } else {
+            push(format!("allow@{host}{qualifier}"), &mut tokens);
+        }
+    }
+
+    if !tokens.is_empty() {
+        tokens.insert(0, "allow@dns".to_string());
+    }
+    Ok(tokens)
+}
+
+// ─── environment preload (keeping values out of argv) ───────────────────────
+
+/// A generated preload script and the host path it lives at. Dropping the guard
+/// removes the file — the values inside outlive neither the run nor a crash any
+/// longer than they must.
+pub struct PreloadScript {
+    pub path: PathBuf,
+}
+
+impl Drop for PreloadScript {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Render the preload script: `export` one line per variable, then `exec "$@"`
+/// so argv, stdin, the TTY and the exit code all pass through untouched.
+///
+/// Values are single-quoted with the POSIX `'\''` escape, which is total — there
+/// is no byte a shell single-quoted string cannot carry — so a credential
+/// containing quotes, `$`, backticks or newlines survives verbatim and cannot
+/// break out into command position. Pure, so the quoting rule is unit-tested.
+pub fn preload_script(env: &[(String, String)]) -> String {
+    let mut s = String::from(
+        "#!/bin/sh\n\
+         # h5i microvm env preload — generated per run, never checked in.\n\
+         # Values live here rather than in `msb run`'s argv, which /proc publishes.\n",
+    );
+    for (key, value) in env {
+        s.push_str(&format!("export {key}='{}'\n", value.replace('\'', r"'\''")));
+    }
+    s.push_str("exec \"$@\"\n");
+    s
+}
+
+/// Write the preload script for this run under the env directory with `0600`
+/// permissions.
+///
+/// Unlike the container tier's shim this is **not** best-effort: it carries the
+/// profile's `env.pass` allowlist and every brokered secret, so a box that
+/// silently ran without it would be a box missing its credentials and its
+/// `H5I_ENV_*` wiring. Any failure is an error.
+fn write_preload(work: &Path, env: &[(String, String)]) -> Result<PreloadScript, H5iError> {
+    let env_dir = work.parent().ok_or_else(|| {
+        H5iError::Metadata(format!(
+            "workspace '{}' has no parent env directory to stage the preload script in",
+            work.display()
+        ))
+    })?;
+    let dir = env_dir.join("microvm");
+    std::fs::create_dir_all(&dir).map_err(|e| H5iError::with_path(e, &dir))?;
+    let path = dir.join(format!("preload-{}.sh", std::process::id()));
+    std::fs::write(&path, preload_script(env)).map_err(|e| H5iError::with_path(e, &path))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| H5iError::with_path(e, &path))?;
+    }
+    check_spec_path(&path, "preload script")?;
+    Ok(PreloadScript { path })
+}
+
+/// microsandbox's `--mount-*` and `--script-path` specs are colon-separated, so
+/// a host path containing `:` cannot be represented unambiguously. Fail closed:
+/// a dropped mount is a policy the box does not actually run under.
+fn check_spec_path(path: &Path, what: &str) -> Result<(), H5iError> {
+    if path.display().to_string().contains(':') {
+        return Err(H5iError::Metadata(format!(
+            "microvm {what} path contains ':' and cannot be represented in microsandbox's \
+             SOURCE:DEST spec syntax: {} — move the repo out of a colon'd path (fail-closed)",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+// ─── argv construction ──────────────────────────────────────────────────────
+
+/// Everything the argv builder needs beyond the policy itself. A struct rather
+/// than a dozen positional parameters: this one is security-critical and read
+/// far more often than it is written.
+pub struct RunPlan<'a> {
+    /// Resolved base image (`container.image` in the profile).
+    pub image: &'a str,
+    /// Unique sandbox name, used for cleanup after a wall-clock kill.
+    pub name: &'a str,
+    /// Networking for this run.
+    pub net: &'a NetPlan,
+    /// The command to run inside the guest.
+    pub argv: &'a [String],
+    /// Host path of the generated env preload script.
+    pub preload: &'a Path,
+    /// `None` → captured run (no stdin, wall-clock enforced). `Some(tty)` →
+    /// interactive session, allocating a pseudo-TTY when the caller has one.
+    pub tty: Option<bool>,
+    /// Managed-settings.json (the unkillable `wrap-bash` hook) to mount
+    /// read-only at Claude's managed-settings path. `None` → no injection.
+    pub managed_settings: Option<&'a Path>,
+}
+
+/// Build the `msb run` argv for `plan` under `policy`. Pure — no process is
+/// spawned and no file is written, so the security-critical flag set is
+/// unit-tested directly.
+///
+/// Every host path reaching a `SOURCE:DEST` spec has already been checked for
+/// `:` by [`run`]/[`run_interactive`]; this function assumes that and emits the
+/// mounts unconditionally, because silently dropping one would weaken the box
+/// exactly where the caller believes it was hardened.
+pub fn build_run_argv(rt: &Runtime, policy: &ResolvedPolicy, work: &Path, plan: &RunPlan) -> Vec<String> {
+    let p = &policy.profile;
+    let mut a: Vec<String> = vec![
+        rt.bin.clone(),
+        "run".into(),
+        "--quiet".into(),
+        "--name".into(),
+        plan.name.into(),
+        // A stale sandbox of the same name is this process's own leftover
+        // (the name carries our pid); replace it rather than fail the run.
+        "--replace".into(),
+        // The image must already be in msb's local cache. A run is not the
+        // place to discover the network is down, and an implicit pull would
+        // make the box's contents depend on when it happened to boot.
+        "--pull".into(),
+        "never".into(),
+        // The guest rootfs is the image; only the mounts below are shared with
+        // the host, and the workspace is the only one writable by default.
+        "--mount-dir".into(),
+        format!("{}:{WORK_MOUNT}:rw", work.display()),
+        "--workdir".into(),
+        WORK_MOUNT.into(),
+    ];
+
+    // Warm dependency caches, read-only at the package manager's own path — a
+    // cache a box could write is a mutable surface shared between boxes.
+    for b in &policy.ro_binds {
+        a.push("--mount-dir".into());
+        a.push(format!("{}:{}:ro", b.backing.display(), b.target.display()));
+    }
+    if let Some(b) = &policy.cache_write {
+        a.push("--mount-dir".into());
+        a.push(format!("{}:{}:rw", b.backing.display(), b.target.display()));
+    }
+
+    // Interactive config lockdown: the agent's own hook config, mounted read-only
+    // over its place in the workspace. `$WORK` is writable, so without this the
+    // in-box agent could rewrite the file that defines the observation hook and
+    // then be unobserved. `ProtectedHookConfigGuard` has already made each file
+    // exist host-side (an image-backed tier writes a sentinel when there is no
+    // real config), so a missing source here means the guard deliberately left
+    // it out, not that we should mount something else.
+    for rel in [".claude/settings.json", ".codex/config.toml"] {
+        let source = work.join(rel);
+        if source.is_file() {
+            a.push("--mount-file".into());
+            a.push(format!("{}:{WORK_MOUNT}/{rel}:ro", source.display()));
+        }
+    }
+
+    // In-box git plumbing: each host path mounted at its IDENTICAL guest path,
+    // because the worktree's `gitdir`/`commondir` pointer files contain
+    // host-absolute paths and must resolve unchanged inside the box.
+    for b in &policy.box_git {
+        let flag = if b.host.is_dir() { "--mount-dir" } else { "--mount-file" };
+        a.push(flag.into());
+        a.push(format!(
+            "{p}:{p}:{mode}",
+            p = b.host.display(),
+            mode = if b.rw { "rw" } else { "ro" },
+        ));
+    }
+
+    // Managed-settings injection: the box's own root cannot rewrite a read-only
+    // mount, and Claude will not let a session disable a *managed* hook from
+    // user config — so in-box observation cannot be silenced from inside.
+    // microsandbox's guest init creates the parent directory and the bind
+    // target, so the path need not exist in the image.
+    if let Some(ms) = plan.managed_settings {
+        a.push("--mount-file".into());
+        a.push(format!(
+            "{}:{}:ro",
+            ms.display(),
+            crate::sandbox_policy::CLAUDE_MANAGED_SETTINGS_PATH
+        ));
+    }
+
+    // Capture spool for in-box `h5i capture run`. Everything the box writes here
+    // is untrusted; the host ingest caps and sanitizes it.
+    if let Some(spool) = &policy.env_capture_spool {
+        a.push("--mount-dir".into());
+        a.push(format!("{}:{SPOOL_MOUNT}:rw", spool.display()));
+    }
+    // Inbound mailbox, read-only: the box receives cross-agent messages without
+    // any write access to the shared coordination store.
+    if let Some(inbox) = &policy.env_inbox {
+        a.push("--mount-dir".into());
+        a.push(format!("{}:{INBOX_MOUNT}:ro", inbox.display()));
+    }
+    // Per-env private paths: a distinct backing inode per env, mounted over the
+    // workspace path inside the box so concurrent envs of one repo don't share
+    // build-cache locks.
+    for b in &policy.private_binds {
+        a.push("--mount-dir".into());
+        a.push(format!(
+            "{}:{WORK_MOUNT}/{}:rw",
+            b.backing.display(),
+            b.rel.trim_matches('/')
+        ));
+    }
+
+    // Resource limits. Memory is the VM's, so it is a hard ceiling rather than
+    // a cgroup the guest can pressure its way around.
+    if let Some(bytes) = p.mem_bytes {
+        a.push("--memory".into());
+        a.push(format!("{}M", (bytes / (1024 * 1024)).max(1)));
+    }
+    if let Some(n) = p.max_procs {
+        a.push("--rlimit".into());
+        a.push(format!("nproc={n}"));
+    }
+    if let Some(secs) = p.cpu_secs {
+        a.push("--rlimit".into());
+        a.push(format!("cpu={secs}"));
+    }
+    // Wall clock, captured runs only — an interactive session is bounded by the
+    // operator, not a timer (same rule as every other tier).
+    if plan.tty.is_none() {
+        a.push("--timeout".into());
+        a.push(format!("{}s", p.wall().as_secs()));
+    }
+
+    // Network. The allowlist is the whole reason this tier exists: default-deny
+    // in both directions, then exactly the rules the policy asked for.
+    match plan.net {
+        NetPlan::None => a.push("--no-net".into()),
+        NetPlan::Host => {
+            a.push("--net".into());
+            a.push("public".into());
+        }
+        NetPlan::Allow(rules) => {
+            a.push("--net-default-egress".into());
+            a.push("deny".into());
+            a.push("--net-default-ingress".into());
+            a.push("deny".into());
+            for rule in rules {
+                a.push("--net-rule".into());
+                a.push(rule.clone());
+            }
+        }
+    }
+
+    // The env preload. Its *contents* (the allowlist values and every brokered
+    // secret) reach the runtime over a config fd; only this path is in argv.
+    a.push("--script-path".into());
+    a.push(format!("{PRELOAD_SCRIPT_NAME}:{}", plan.preload.display()));
+
+    match plan.tty {
+        Some(true) => a.push("--tty".into()),
+        // A piped or CI invocation must not ask for a pseudo-TTY, and a captured
+        // run never wants one.
+        Some(false) | None => a.push("--no-tty".into()),
+    }
+
+    a.push(plan.image.to_string());
+    a.push("--".into());
+    a.push(format!("{GUEST_SCRIPTS_DIR}/{PRELOAD_SCRIPT_NAME}"));
+    a.extend(plan.argv.iter().cloned());
+    a
+}
+
+// ─── execution ──────────────────────────────────────────────────────────────
+
+static RUN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Why the microvm tier is unavailable here, naming the *specific* missing
+/// half. "Install microsandbox", "update it", and "enable nested virtualization"
+/// are three different afternoons; a tier that refuses without saying which one
+/// is a tier nobody can adopt. Empty-ish callers get the generic line only when
+/// every check unexpectedly passes.
+pub fn unavailable_detail() -> String {
+    match msb_version() {
+        None => "microsandbox's `msb` is not on PATH — install it from \
+                 https://install.microsandbox.dev"
+            .to_string(),
+        Some(v) if v < MIN_MSB_VERSION => format!(
+            "msb {}.{} is older than the {}.{} this adapter targets — run `msb self update`",
+            v.0, v.1, MIN_MSB_VERSION.0, MIN_MSB_VERSION.1
+        ),
+        Some(_) => virtualization_detail()
+            .unwrap_or_else(|| "the microVM runtime is unavailable".to_string()),
+    }
+}
+
+fn runtime_or_refuse() -> Result<Runtime, H5iError> {
+    probe().ok_or_else(|| {
+        H5iError::Metadata(format!(
+            "isolation claim 'microvm' cannot be satisfied on this host — refusing (h5i never \
+             silently downgrades):\n  - {}\nRe-request a weaker claim (--isolation \
+             container|supervised|process), or run on a host with virtualization enabled.",
+            unavailable_detail()
+        ))
+    })
+}
+
+fn image_or_refuse(p: &Profile) -> Result<String, H5iError> {
+    p.image.clone().ok_or_else(|| {
+        H5iError::Metadata(format!(
+            "profile '{}' uses isolation=microvm but sets no image — pass `--image` at env \
+             create, or set `container.image = \"…\"` in the profile / a repo-level \
+             `[container] image` in .h5i/env.toml (the microvm tier boots the same OCI images)",
+            p.name
+        ))
+    })
+}
+
+/// Resolve the network plan for a run: the enforced rule set is the digested
+/// profile allowlist plus the host-side user extras (`h5i env allow`), and a
+/// deny-all profile ignores the extras (it can never be widened from outside the
+/// digested policy).
+fn net_plan(policy: &ResolvedPolicy) -> Result<NetPlan, H5iError> {
+    let rules = crate::container::effective_egress(
+        &policy.profile.net_egress,
+        &policy.user_egress_allow,
+    );
+    if !rules.is_empty() {
+        return Ok(NetPlan::Allow(egress_rule_tokens(&rules)?));
+    }
+    Ok(if policy.profile.net_mode == NetMode::Host {
+        NetPlan::Host
+    } else {
+        NetPlan::None
+    })
+}
+
+/// Check every host path that will become part of a `SOURCE:DEST` spec.
+fn check_mount_paths(policy: &ResolvedPolicy, work: &Path) -> Result<(), H5iError> {
+    check_spec_path(work, "workspace")?;
+    for b in &policy.ro_binds {
+        check_spec_path(&b.backing, "cache mount")?;
+    }
+    if let Some(b) = &policy.cache_write {
+        check_spec_path(&b.backing, "writable cache mount")?;
+    }
+    for b in &policy.box_git {
+        check_spec_path(&b.host, "in-box git mount")?;
+    }
+    for b in &policy.private_binds {
+        check_spec_path(&b.backing, "private-path mount")?;
+    }
+    if let Some(spool) = &policy.env_capture_spool {
+        check_spec_path(spool, "capture spool mount")?;
+    }
+    if let Some(inbox) = &policy.env_inbox {
+        check_spec_path(inbox, "inbox mount")?;
+    }
+    Ok(())
+}
+
+/// A named `msb` sandbox whose persisted state is removed when the run ends —
+/// on success, on error, and on a wall-clock kill alike.
+///
+/// The name is what makes cleanup possible at all (it is how a hung run gets
+/// force-stopped), but `msb` keeps *named* sandboxes around to be inspected,
+/// while an unnamed one is ephemeral. h5i wants both properties, so it names the
+/// sandbox and takes responsibility for reaping it. Best-effort by design: a
+/// failed cleanup must never turn a successful run into an error, and the name
+/// carries our pid so nothing else can be reaped by mistake.
+struct SandboxGuard {
+    bin: String,
+    name: String,
+}
+
+impl SandboxGuard {
+    fn new(bin: &str) -> Self {
+        SandboxGuard {
+            bin: bin.to_string(),
+            name: format!(
+                "h5i-{}-{}",
+                std::process::id(),
+                RUN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ),
+        }
+    }
+
+    fn remove(&self) {
+        let _ = std::process::Command::new(&self.bin)
+            .args(["remove", "--force", &self.name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+}
+
+impl Drop for SandboxGuard {
+    fn drop(&mut self) {
+        self.remove();
+    }
+}
+
+/// Write the managed-settings.json (carrying the unkillable `wrap-bash`
+/// observation hook) under the env dir, to be mounted read-only into the guest.
+/// Best-effort: `None` (injection skipped, session otherwise unaffected) on any
+/// I/O failure or a path the spec syntax cannot carry — an unobserved session is
+/// still a correctly *confined* session.
+fn prepare_managed_settings(work: &Path, content: &str) -> Option<PathBuf> {
+    let dir = work.parent()?.join("managed");
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join("managed-settings.json");
+    std::fs::write(&path, content).ok()?;
+    check_spec_path(&path, "managed settings").ok()?;
+    Some(path)
+}
+
+/// Run `argv` inside a microVM under `policy`, capturing stdout/stderr and
+/// enforcing the profile's wall clock.
+///
+/// [`ExecOutcome::egress`] is always `None`: the allowlist is enforced by the
+/// VM's network stack, which drops packets rather than reporting them. See the
+/// module docs — stronger enforcement, and no tally to pretend otherwise with.
+pub fn run(
+    policy: &ResolvedPolicy,
+    work: &Path,
+    argv: &[String],
+    injected_env: &[(String, String)],
+) -> Result<ExecOutcome, H5iError> {
+    let rt = runtime_or_refuse()?;
+    let image = image_or_refuse(&policy.profile)?;
+    check_mount_paths(policy, work)?;
+
+    let net = net_plan(policy)?;
+    let preload = write_preload(work, &guest_env(policy, injected_env))?;
+    let sandbox = SandboxGuard::new(&rt.bin);
+    let full = build_run_argv(
+        &rt,
+        policy,
+        work,
+        &RunPlan {
+            image: &image,
+            name: &sandbox.name,
+            net: &net,
+            argv,
+            preload: &preload.path,
+            tty: None,
+            managed_settings: None,
+        },
+    );
+
+    let started = std::time::Instant::now();
+    let mut cmd = std::process::Command::new(&full[0]);
+    cmd.args(&full[1..]);
+    let outcome = wait_vm(cmd, &sandbox, policy.profile.wall(), &full)?;
+    Ok(ExecOutcome {
+        wall_ms: started.elapsed().as_millis(),
+        ..outcome
+    })
+}
+
+/// The **agent-in-box** path: run `argv` (a shell or a coding agent) inside the
+/// microVM with stdio inherited — a real interactive session whose every command
+/// is confined by the VM boundary and the netstack allowlist. Captures nothing
+/// and applies no wall clock; the operator owns the session.
+pub fn run_interactive(
+    policy: &ResolvedPolicy,
+    work: &Path,
+    argv: &[String],
+    injected_env: &[(String, String)],
+    managed_settings_content: Option<&str>,
+) -> Result<InteractiveOutcome, H5iError> {
+    use std::io::IsTerminal;
+    let rt = runtime_or_refuse()?;
+    let image = image_or_refuse(&policy.profile)?;
+    check_mount_paths(policy, work)?;
+
+    let net = net_plan(policy)?;
+    let preload = write_preload(work, &guest_env(policy, injected_env))?;
+    // Managed-settings injection is Claude's managed scope and inert for Codex,
+    // whose hook hardening is separate; `default`/custom profiles may run Claude,
+    // so they get it too.
+    let is_codex = crate::sandbox_policy::AgentRuntime::from_profile_name(&policy.profile.name)
+        == Some(crate::sandbox_policy::AgentRuntime::Codex);
+    let managed_settings = match (is_codex, managed_settings_content) {
+        (false, Some(content)) => prepare_managed_settings(work, content),
+        _ => None,
+    };
+    // Only ask for a pseudo-TTY when we have one on both ends — msb rejects
+    // `--tty` under a pipe, which would turn a CI `env shell` into a hard error.
+    let tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+    let sandbox = SandboxGuard::new(&rt.bin);
+    let full = build_run_argv(
+        &rt,
+        policy,
+        work,
+        &RunPlan {
+            image: &image,
+            name: &sandbox.name,
+            net: &net,
+            argv,
+            preload: &preload.path,
+            tty: Some(tty),
+            managed_settings: managed_settings.as_deref(),
+        },
+    );
+
+    let mut cmd = std::process::Command::new(&full[0]);
+    cmd.args(&full[1..]);
+    let status = cmd
+        .status()
+        .map_err(|e| H5iError::Metadata(format!("failed to start microvm session: {e}")))?;
+    Ok(InteractiveOutcome {
+        exit_code: status.code().unwrap_or(130),
+        egress: None,
+    })
+}
+
+/// The environment the guest command runs with: the profile's `env.pass`
+/// allowlist resolved against *this* process's environment, then the brokered
+/// grants (which win, since a broker-minted credential is the one the policy
+/// actually authorized). Nothing is inherited wholesale.
+fn guest_env(policy: &ResolvedPolicy, injected_env: &[(String, String)]) -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = Vec::new();
+    for key in &policy.profile.env_pass {
+        if let Some(value) = std::env::var_os(key) {
+            env.push((key.clone(), value.to_string_lossy().into_owned()));
+        }
+    }
+    for (k, v) in injected_env {
+        env.retain(|(existing, _)| existing != k);
+        env.push((k.clone(), v.clone()));
+    }
+    env
+}
+
+/// Spawn `msb`, stream output, and enforce the wall clock. On timeout, stop the
+/// sandbox itself (the client dying does not stop a detached VM) then kill the
+/// client. Resource accounting belongs to the guest kernel, not to `msb`, so we
+/// report wall time only.
+fn wait_vm(
+    mut cmd: std::process::Command,
+    sandbox: &SandboxGuard,
+    wall: Duration,
+    full: &[String],
+) -> Result<ExecOutcome, H5iError> {
+    use std::io::Read;
+    use std::process::Stdio;
+    cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| H5iError::Metadata(format!("failed to run `{}`: {e}", full.join(" "))))?;
+
+    let mut out_pipe = child.stdout.take().expect("piped stdout");
+    let mut err_pipe = child.stderr.take().expect("piped stderr");
+    let out_h = std::thread::spawn(move || {
+        let mut b = Vec::new();
+        let _ = out_pipe.read_to_end(&mut b);
+        b
+    });
+    let err_h = std::thread::spawn(move || {
+        let mut b = Vec::new();
+        let _ = err_pipe.read_to_end(&mut b);
+        b
+    });
+
+    // `--timeout` already caps the guest command; this is the host-side backstop
+    // for an `msb` that hangs before or after the guest ever runs. The grace
+    // keeps the two from racing to report the same timeout.
+    let deadline = std::time::Instant::now() + wall + Duration::from_secs(10);
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait().map_err(H5iError::Io)? {
+            Some(s) => break s,
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    timed_out = true;
+                    // Stop the guest first: killing the client does not stop a
+                    // VM it has already handed off to the host runtime.
+                    sandbox.remove();
+                    let _ = child.kill();
+                    break child.wait().map_err(H5iError::Io)?;
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+
+    Ok(ExecOutcome {
+        stdout: out_h.join().unwrap_or_default(),
+        stderr: err_h.join().unwrap_or_default(),
+        exit_code: status.code(),
+        timed_out,
+        wall_ms: 0,
+        cpu_ms: 0,
+        max_rss_kb: None,
+        egress: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox_policy::{IsolationClaim, PrivateBind, RoBind};
+
+    fn rt() -> Runtime {
+        Runtime {
+            bin: "msb".into(),
+            version: (0, 6),
+        }
+    }
+
+    fn policy() -> ResolvedPolicy {
+        let mut p = Profile::builtin("default", IsolationClaim::Microvm);
+        p.image = Some("alpine".into());
+        ResolvedPolicy::new(IsolationClaim::Microvm, p)
+    }
+
+    fn argv_for(policy: &ResolvedPolicy, net: &NetPlan, tty: Option<bool>) -> Vec<String> {
+        build_run_argv(
+            &rt(),
+            policy,
+            Path::new("/h5i/envs/e1/work"),
+            &RunPlan {
+                image: "alpine",
+                name: "h5i-1-0",
+                net,
+                argv: &["sh".into(), "-c".into(), "true".into()],
+                preload: Path::new("/h5i/envs/e1/microvm/preload-1.sh"),
+                tty,
+                managed_settings: None,
+            },
+        )
+    }
+
+    fn window<'a>(a: &'a [String], flag: &str) -> Vec<&'a str> {
+        a.iter()
+            .zip(a.iter().skip(1))
+            .filter(|(f, _)| f.as_str() == flag)
+            .map(|(_, v)| v.as_str())
+            .collect()
+    }
+
+    // ─── version parsing ────────────────────────────────────────────────────
+
+    #[test]
+    fn version_is_parsed_from_the_banner_shapes_msb_prints() {
+        assert_eq!(parse_version("msb 0.6.8\n"), Some((0, 6)));
+        assert_eq!(parse_version("Microsandbox CLI v1.12.0"), Some((1, 12)));
+        assert_eq!(parse_version("msb"), None);
+        assert_eq!(parse_version(""), None);
+    }
+
+    // ─── egress translation ─────────────────────────────────────────────────
+
+    #[test]
+    fn plain_host_becomes_an_any_port_rule_and_dns_is_always_allowed() {
+        let tokens = egress_rule_tokens(&["pypi.org".into()]).unwrap();
+        assert_eq!(tokens, vec!["allow@dns", "allow@pypi.org"]);
+    }
+
+    #[test]
+    fn a_port_scoped_entry_narrows_to_tcp_on_that_port() {
+        let tokens = egress_rule_tokens(&["github.com:443".into()]).unwrap();
+        assert_eq!(tokens, vec!["allow@dns", "allow@github.com:tcp:443"]);
+    }
+
+    #[test]
+    fn a_wildcard_covers_the_apex_as_well_as_subdomains() {
+        // h5i's `.suffix` matches `suffix` itself, so a `suffix=` token alone
+        // would silently *narrow* the policy the profile declared.
+        let tokens = egress_rule_tokens(&[".githubusercontent.com".into()]).unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                "allow@dns",
+                "allow@domain=githubusercontent.com",
+                "allow@suffix=githubusercontent.com",
+            ]
+        );
+        assert_eq!(
+            egress_rule_tokens(&["*.githubusercontent.com".into()]).unwrap(),
+            tokens,
+            "both wildcard spellings mean the same allowlist"
+        );
+    }
+
+    #[test]
+    fn an_empty_allowlist_emits_no_rules_at_all() {
+        // Not even `allow@dns`: an empty list is deny-all, and a box that can
+        // resolve names it may not reach is a box leaking queries.
+        assert!(egress_rule_tokens(&[]).unwrap().is_empty());
+        assert!(egress_rule_tokens(&["  ".into()]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn duplicate_entries_collapse_and_order_is_stable() {
+        let tokens =
+            egress_rule_tokens(&["pypi.org".into(), "PyPI.org".into(), "crates.io".into()]).unwrap();
+        assert_eq!(tokens, vec!["allow@dns", "allow@pypi.org", "allow@crates.io"]);
+    }
+
+    #[test]
+    fn entries_that_would_break_the_token_grammar_are_refused() {
+        for bad in ["a.com,b.com", "user@a.com"] {
+            let err = egress_rule_tokens(&[bad.into()]).unwrap_err().to_string();
+            assert!(err.contains("fail-closed"), "{bad}: {err}");
+        }
+    }
+
+    #[test]
+    fn a_single_label_wildcard_is_refused_rather_than_allowing_a_whole_tld() {
+        let err = egress_rule_tokens(&["*.com".into()]).unwrap_err().to_string();
+        assert!(err.contains("at least two"), "{err}");
+    }
+
+    #[test]
+    fn an_ip_entry_passes_through_as_its_own_target() {
+        assert_eq!(
+            egress_rule_tokens(&["198.51.100.5:8080".into()]).unwrap(),
+            vec!["allow@dns", "allow@198.51.100.5:tcp:8080"]
+        );
+    }
+
+    // ─── preload script ─────────────────────────────────────────────────────
+
+    #[test]
+    fn preload_execs_the_real_command_so_argv_and_exit_code_pass_through() {
+        let s = preload_script(&[("TERM".into(), "xterm".into())]);
+        assert!(s.starts_with("#!/bin/sh\n"));
+        assert!(s.contains("export TERM='xterm'\n"));
+        assert!(s.trim_end().ends_with("exec \"$@\""));
+    }
+
+    #[test]
+    fn a_value_containing_quotes_cannot_break_out_of_the_assignment() {
+        // The POSIX '\'' escape is total: no byte can end the quoted string and
+        // start a command. A credential with a quote in it must not become code.
+        let s = preload_script(&[("T".into(), "a'; rm -rf /; echo '".into())]);
+        assert!(s.contains(r"export T='a'\''; rm -rf /; echo '\'''"), "{s}");
+        assert!(!s.contains("\nrm -rf"), "value escaped into command position: {s}");
+    }
+
+    #[test]
+    fn newlines_and_dollar_signs_survive_verbatim() {
+        let s = preload_script(&[("K".into(), "line1\nline2 $HOME `id`".into())]);
+        assert!(s.contains("export K='line1\nline2 $HOME `id`'\n"), "{s}");
+    }
+
+    // ─── argv: the security-critical flag set ───────────────────────────────
+
+    #[test]
+    fn the_workspace_is_the_only_writable_mount_by_default() {
+        let a = argv_for(&policy(), &NetPlan::None, None);
+        let dirs = window(&a, "--mount-dir");
+        assert_eq!(dirs, vec!["/h5i/envs/e1/work:/work:rw"]);
+        assert!(window(&a, "--workdir").contains(&"/work"));
+        assert!(a.contains(&"--no-net".to_string()));
+    }
+
+    #[test]
+    fn no_environment_value_ever_reaches_argv() {
+        // The whole point of the preload script. A `--env` flag here would
+        // publish brokered credentials through /proc/<pid>/cmdline.
+        let a = argv_for(&policy(), &NetPlan::None, None);
+        assert!(!a.iter().any(|x| x == "--env" || x == "-e"), "{a:?}");
+        let scripts = window(&a, "--script-path");
+        assert_eq!(scripts, vec!["h5i-env:/h5i/envs/e1/microvm/preload-1.sh"]);
+        // …and the command actually runs through it.
+        let sep = a.iter().position(|x| x == "--").expect("`--` separator");
+        assert_eq!(a[sep + 1], "/.msb/scripts/h5i-env");
+        assert_eq!(&a[sep + 2..], &["sh", "-c", "true"]);
+    }
+
+    #[test]
+    fn the_image_is_positional_and_never_pulled_at_run_time() {
+        let a = argv_for(&policy(), &NetPlan::None, None);
+        assert!(window(&a, "--pull").contains(&"never"));
+        let sep = a.iter().position(|x| x == "--").unwrap();
+        assert_eq!(a[sep - 1], "alpine", "image sits just before the `--`");
+    }
+
+    #[test]
+    fn an_allowlist_is_default_deny_in_both_directions_plus_its_rules() {
+        let net = NetPlan::Allow(egress_rule_tokens(&["pypi.org".into()]).unwrap());
+        let a = argv_for(&policy(), &net, None);
+        assert!(window(&a, "--net-default-egress").contains(&"deny"));
+        assert!(window(&a, "--net-default-ingress").contains(&"deny"));
+        assert_eq!(window(&a, "--net-rule"), vec!["allow@dns", "allow@pypi.org"]);
+        // Never the container tier's proxy env — there is no proxy here, and a
+        // stale HTTP_PROXY would make the box look filtered when it is not.
+        assert!(!a.iter().any(|x| x.contains("HTTP_PROXY")), "{a:?}");
+        // And never microsandbox's rebind-protection escape hatch.
+        assert!(!a.iter().any(|x| x == "--no-dns-rebind-protection"), "{a:?}");
+    }
+
+    #[test]
+    fn host_net_mode_asks_for_the_public_profile_and_no_rules() {
+        let a = argv_for(&policy(), &NetPlan::Host, None);
+        assert!(window(&a, "--net").contains(&"public"));
+        assert!(window(&a, "--net-rule").is_empty());
+        assert!(!a.contains(&"--no-net".to_string()));
+    }
+
+    #[test]
+    fn resource_limits_come_from_the_profile() {
+        let mut pol = policy();
+        pol.profile.mem_bytes = Some(2 * 1024 * 1024 * 1024);
+        pol.profile.max_procs = Some(64);
+        pol.profile.cpu_secs = Some(600);
+        let a = argv_for(&pol, &NetPlan::None, None);
+        assert!(window(&a, "--memory").contains(&"2048M"));
+        let rlimits = window(&a, "--rlimit");
+        assert!(rlimits.contains(&"nproc=64"), "{rlimits:?}");
+        assert!(rlimits.contains(&"cpu=600"), "{rlimits:?}");
+    }
+
+    #[test]
+    fn the_wall_clock_applies_to_captured_runs_and_not_to_sessions() {
+        let mut pol = policy();
+        pol.profile.wall_secs = 900;
+        assert!(window(&argv_for(&pol, &NetPlan::None, None), "--timeout").contains(&"900s"));
+        // An interactive session is bounded by the operator, not a timer.
+        assert!(window(&argv_for(&pol, &NetPlan::None, Some(true)), "--timeout").is_empty());
+    }
+
+    #[test]
+    fn a_pseudo_tty_is_requested_only_for_an_interactive_session_that_has_one() {
+        assert!(argv_for(&policy(), &NetPlan::None, Some(true)).contains(&"--tty".to_string()));
+        for tty in [Some(false), None] {
+            let a = argv_for(&policy(), &NetPlan::None, tty);
+            assert!(a.contains(&"--no-tty".to_string()), "{tty:?}");
+            assert!(!a.contains(&"--tty".to_string()), "{tty:?}");
+        }
+    }
+
+    #[test]
+    fn caches_mount_read_only_and_the_one_writable_cache_is_explicit() {
+        let mut pol = policy();
+        pol.ro_binds = vec![RoBind {
+            backing: PathBuf::from("/host/cache/cargo"),
+            target: PathBuf::from("/root/.cargo/registry"),
+        }];
+        pol.cache_write = Some(RoBind {
+            backing: PathBuf::from("/host/cache/npm"),
+            target: PathBuf::from("/root/.npm"),
+        });
+        let a = argv_for(&pol, &NetPlan::None, None);
+        let dirs = window(&a, "--mount-dir");
+        assert!(dirs.contains(&"/host/cache/cargo:/root/.cargo/registry:ro"), "{dirs:?}");
+        assert!(dirs.contains(&"/host/cache/npm:/root/.npm:rw"), "{dirs:?}");
+    }
+
+    #[test]
+    fn spool_is_writable_and_the_inbox_is_not() {
+        let mut pol = policy();
+        pol.env_capture_spool = Some(PathBuf::from("/h5i/envs/e1/spool"));
+        pol.env_inbox = Some(PathBuf::from("/h5i/envs/e1/inbox"));
+        let a = argv_for(&pol, &NetPlan::None, None);
+        let dirs = window(&a, "--mount-dir");
+        assert!(dirs.contains(&"/h5i/envs/e1/spool:/.h5i/spool:rw"), "{dirs:?}");
+        assert!(dirs.contains(&"/h5i/envs/e1/inbox:/.h5i/inbox:ro"), "{dirs:?}");
+    }
+
+    #[test]
+    fn private_paths_shadow_their_workspace_path_inside_the_box() {
+        let mut pol = policy();
+        pol.private_binds = vec![PrivateBind {
+            backing: PathBuf::from("/h5i/envs/e1/private/target"),
+            rel: "target".into(),
+        }];
+        let a = argv_for(&pol, &NetPlan::None, None);
+        let dirs = window(&a, "--mount-dir");
+        assert!(
+            dirs.contains(&"/h5i/envs/e1/private/target:/work/target:rw"),
+            "{dirs:?}"
+        );
+    }
+
+    #[test]
+    fn the_agents_own_hook_config_is_pinned_read_only_inside_the_writable_workspace() {
+        // $WORK is rw, so without this mount an in-box agent could rewrite the
+        // file that defines its observation hook and go dark.
+        let dir = std::env::temp_dir().join(format!("h5i-microvm-cfg-{}", std::process::id()));
+        let work = dir.join("work");
+        std::fs::create_dir_all(work.join(".claude")).unwrap();
+        std::fs::write(work.join(".claude/settings.json"), "{}").unwrap();
+        let a = build_run_argv(
+            &rt(),
+            &policy(),
+            &work,
+            &RunPlan {
+                image: "alpine",
+                name: "h5i-1-0",
+                net: &NetPlan::None,
+                argv: &["bash".into()],
+                preload: Path::new("/tmp/preload.sh"),
+                tty: Some(true),
+                managed_settings: None,
+            },
+        );
+        let files = window(&a, "--mount-file");
+        assert!(
+            files.contains(
+                &format!("{}:/work/.claude/settings.json:ro", work.join(".claude/settings.json").display())
+                    .as_str()
+            ),
+            "{files:?}"
+        );
+        // The config that is not there is not invented.
+        assert!(!files.iter().any(|f| f.contains(".codex/config.toml")), "{files:?}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn managed_settings_mount_is_read_only_so_the_hook_cannot_be_silenced() {
+        let a = build_run_argv(
+            &rt(),
+            &policy(),
+            Path::new("/h5i/envs/e1/work"),
+            &RunPlan {
+                image: "alpine",
+                name: "h5i-1-0",
+                net: &NetPlan::None,
+                argv: &["bash".into()],
+                preload: Path::new("/h5i/envs/e1/microvm/preload-1.sh"),
+                tty: Some(true),
+                managed_settings: Some(Path::new("/h5i/envs/e1/managed/managed-settings.json")),
+            },
+        );
+        let files = window(&a, "--mount-file");
+        assert!(
+            files.contains(
+                &"/h5i/envs/e1/managed/managed-settings.json:/etc/claude-code/managed-settings.json:ro"
+            ),
+            "{files:?}"
+        );
+    }
+
+    // ─── fail-closed path handling ──────────────────────────────────────────
+
+    #[test]
+    fn a_colon_in_a_host_path_is_refused_rather_than_silently_dropped() {
+        let mut pol = policy();
+        pol.private_binds = vec![PrivateBind {
+            backing: PathBuf::from("/h5i/weird:dir/target"),
+            rel: "target".into(),
+        }];
+        let err = check_mount_paths(&pol, Path::new("/h5i/envs/e1/work"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("fail-closed"), "{err}");
+    }
+
+    #[test]
+    fn a_deny_all_profile_is_never_widened_by_the_host_side_user_allowlist() {
+        let mut pol = policy();
+        pol.user_egress_allow = vec!["evil.example".into()];
+        assert_eq!(net_plan(&pol).unwrap(), NetPlan::None);
+        // …but a profile that already opted into egress does take the extras.
+        pol.profile.net_egress = vec!["pypi.org".into()];
+        let NetPlan::Allow(rules) = net_plan(&pol).unwrap() else {
+            panic!("expected an allowlist plan");
+        };
+        assert!(rules.contains(&"allow@pypi.org".to_string()), "{rules:?}");
+        assert!(rules.contains(&"allow@evil.example".to_string()), "{rules:?}");
+    }
+
+    #[test]
+    fn brokered_grants_win_over_the_env_pass_allowlist() {
+        let mut pol = policy();
+        pol.profile.env_pass = vec!["H5I_MICROVM_TEST_VAR".into()];
+        std::env::set_var("H5I_MICROVM_TEST_VAR", "from-host");
+        let env = guest_env(&pol, &[("H5I_MICROVM_TEST_VAR".into(), "brokered".into())]);
+        std::env::remove_var("H5I_MICROVM_TEST_VAR");
+        assert_eq!(
+            env,
+            vec![("H5I_MICROVM_TEST_VAR".to_string(), "brokered".to_string())]
+        );
+    }
+}

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -500,28 +500,24 @@ pub fn effective_auto(
             }
         }
     }
-    // Strongest first. `container` is only picked when the profile sets an
-    // image (resolve refuses it otherwise), so the bare default lands on the
-    // strongest *kernel* confinement instead.
-    for tier in [
-        IsolationClaim::Container,
-        IsolationClaim::Supervised,
-        IsolationClaim::Process,
-    ] {
+    // Strongest first ([`AUTO_TIERS`]).
+    for tier in AUTO_TIERS {
         let Ok(mut profile) = load_profile(repo_workdir, name, Some(tier)) else {
             continue;
         };
         if let Some(img) = image_override {
             profile.image = Some(img.to_string());
         }
-        // Container needs a declared image; without one `resolve` refuses it
-        // regardless of the host, so skip the candidate before paying the ~1s
-        // Podman probe that `probe_host_for(Container)` would trigger.
-        if tier == IsolationClaim::Container && profile.image.is_none() {
+        // The image-backed tiers need a declared image; without one `resolve`
+        // refuses them regardless of the host, so skip the candidate before
+        // paying the runtime probe that `probe_host_for` would trigger (~1s for
+        // `podman info`).
+        if tier.image_backed() && profile.image.is_none() {
             continue;
         }
-        // Probe only what this tier consults: container resolves against the
-        // Podman-aware caps, every other tier against the cheap kernel-only probe.
+        // Probe only what this tier consults: the image-backed tiers resolve
+        // against the runtime-aware caps, every other tier against the cheap
+        // kernel-only probe.
         let caps = probe_host_for(tier);
         let runnable = resolve(&profile, &caps).and_then(|pol| verify_exec(&pol)).is_ok();
         if runnable {
@@ -757,6 +753,12 @@ pub struct HostCaps {
     /// Detected rootless Podman binary for `isolation=container`; `None` when
     /// Podman is absent, broken, or rootful.
     pub container_runtime: Option<String>,
+    /// Detected microVM runtime binary for `isolation=microvm` (microsandbox's
+    /// `msb`); `None` when it is absent, too old, or the host cannot virtualize.
+    /// Kept separate from `container_runtime` because the two answer different
+    /// questions: a host can have Podman and no KVM, or KVM and no Podman.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub microvm_runtime: Option<String>,
 }
 
 impl HostCaps {
@@ -805,17 +807,18 @@ pub fn probe_host() -> HostCaps {
         .get_or_init(|| {
             let mut caps = probe_host_kernel();
             caps.container_runtime = crate::container::probe().map(|r| r.bin);
+            caps.microvm_runtime = crate::microvm::probe().map(|r| r.bin);
             caps
         })
         .clone()
 }
 
 /// Kernel-only probe: Landlock/userns/seccomp, but **not** the ~1s Podman
-/// shell-out (`container_runtime` is left `None`). `resolve` only reads
-/// `container_runtime` inside the container arm (after the image check), and
-/// `supervisor::probe` only reads the kernel bits — so every non-container claim
-/// can probe with this and skip `podman info` entirely. Memoized separately from
-/// the full probe so the two never cross-trigger.
+/// shell-out (`container_runtime` and `microvm_runtime` are left `None`).
+/// `resolve` only reads those inside the container/microvm arms (after the image
+/// check), and `supervisor::probe` only reads the kernel bits — so every
+/// non-image-backed claim can probe with this and skip `podman info` entirely.
+/// Memoized separately from the full probe so the two never cross-trigger.
 pub fn probe_host_kernel() -> HostCaps {
     HOST_CAPS_KERNEL.get_or_init(probe_host_kernel_uncached).clone()
 }
@@ -828,8 +831,24 @@ pub fn podman_present() -> bool {
     crate::container::podman_present()
 }
 
-/// Capability probe scoped to what `claim` actually needs: the container family
-/// gets the full (Podman-aware) probe; every other claim gets the cheap
+/// Cheap "is microsandbox installed?" check for discoverability hints — runs
+/// only `msb --version`, not the virtualization check. Use when a hint just
+/// needs binary presence, not full microvm-tier readiness (that's
+/// [`probe_host`]'s `microvm_runtime`).
+pub fn msb_present() -> bool {
+    crate::microvm::msb_present()
+}
+
+/// Why the `microvm` tier is unavailable on this host, naming the specific
+/// missing half (no `msb`, an `msb` too old, or no virtualization). For
+/// diagnostics — `env doctor`/`env probe` — that must be actionable rather than
+/// merely negative.
+pub fn microvm_unavailable_detail() -> String {
+    crate::microvm::unavailable_detail()
+}
+
+/// Capability probe scoped to what `claim` actually needs: the image-backed
+/// family gets the full (runtime-aware) probe; every other claim gets the cheap
 /// kernel-only probe. This is the choke point that keeps a default supervised/
 /// process `env create` from ever shelling out to `podman info`.
 pub fn probe_host_for(claim: IsolationClaim) -> HostCaps {
@@ -841,6 +860,20 @@ pub fn probe_host_for(claim: IsolationClaim) -> HostCaps {
     }
 }
 
+/// The tiers `--isolation auto` will consider, strongest first.
+///
+/// `microvm` leads: when a host can virtualize and the profile names an image,
+/// it is the strongest boundary h5i can build, and its egress allowlist is the
+/// only one enforced by address rather than by proxy etiquette. Both image-backed
+/// tiers are skipped without an image, so a bare default still lands on the
+/// strongest *kernel* confinement rather than refusing.
+const AUTO_TIERS: [IsolationClaim; 4] = [
+    IsolationClaim::Microvm,
+    IsolationClaim::Container,
+    IsolationClaim::Supervised,
+    IsolationClaim::Process,
+];
+
 /// Support for one isolation claim on this host: can its policy be *resolved*
 /// (`satisfiable`), and — for the kernel tiers — does a confined command
 /// actually *exec* here (`runnable`, the functional `verify_exec` self-test)?
@@ -849,8 +882,9 @@ pub struct ClaimSupport {
     pub claim: &'static str,
     pub satisfiable: bool,
     /// Functional exec self-test for the kernel tiers (`Some`); `None` for tiers
-    /// not exec-tested here (container needs an image; hardened/microvm aren't
-    /// built in).
+    /// not exec-tested here (container and microvm both need a profile image, so
+    /// their readiness is a runtime check rather than a boot; hardened-container
+    /// has no adapter in this build).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runnable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -883,10 +917,21 @@ pub struct CapabilitiesReport {
     /// (see `seatbelt::RESOURCE_NOTE`).
     pub memory_limit: bool,
     pub container_runtime: Option<String>,
-    /// A **domain allowlist** for egress can be *enforced* here. Only the
-    /// container tier's DNS-pinned proxy enforces it; the kernel tiers can
-    /// deny-all but never allowlist, so this tracks the container runtime.
+    /// Detected microVM runtime (microsandbox's `msb`) for `isolation=microvm`;
+    /// `None` when it is absent, too old, or the host cannot virtualize.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub microvm_runtime: Option<String>,
+    /// A **domain allowlist** for egress can be *enforced* here. The container
+    /// tier's DNS-pinned proxy enforces it at L7 and the microvm tier's netstack
+    /// rules enforce it by address; the kernel tiers can deny-all but never
+    /// allowlist, so this tracks whether either of those runtimes is present.
     pub egress_enforced: bool,
+    /// The allowlist above is enforced **by address** (L3/L4), not by a proxy the
+    /// box could decline to use. True only for the microvm tier. Distinguished
+    /// from `egress_enforced` because it is exactly the difference a caller
+    /// running genuinely untrusted code needs to know about: an L7 proxy stops
+    /// `curl` and does not stop a raw socket.
+    pub egress_enforced_l3: bool,
     /// Resource limits (mem / procs / wall / cpu) can be enforced — true when
     /// any confined tier beyond `workspace` runs here (kernel rlimits or the
     /// container runtime's cgroup limits).
@@ -956,30 +1001,43 @@ pub fn capabilities_report() -> CapabilitiesReport {
         runnable: None,
         note: Some("needs rootless Podman + profile container.image"),
     });
-    for claim in [IsolationClaim::HardenedContainer, IsolationClaim::Microvm] {
-        claims.push(ClaimSupport {
-            claim: claim.as_str(),
-            satisfiable: false,
-            runnable: None,
-            note: Some("external backend (not in this build)"),
-        });
+    claims.push(ClaimSupport {
+        claim: IsolationClaim::HardenedContainer.as_str(),
+        satisfiable: false,
+        runnable: None,
+        note: Some("external backend (not in this build)"),
+    });
+    // microVM tier: gated by microsandbox's `msb` **and** host virtualization;
+    // like container, a concrete run also needs a profile image, so it isn't
+    // exec-tested here.
+    let microvm_ok = caps.microvm_runtime.is_some();
+    if microvm_ok && IsolationClaim::Microvm > strongest {
+        strongest = IsolationClaim::Microvm;
     }
+    claims.push(ClaimSupport {
+        claim: IsolationClaim::Microvm.as_str(),
+        satisfiable: microvm_ok,
+        runnable: None,
+        note: Some("needs microsandbox `msb` + host virtualization + profile container.image"),
+    });
 
     let confined_tier_runs = claims
         .iter()
         .any(|c| c.claim != "workspace" && c.runnable == Some(true));
-    let resource_limits = container_ok || confined_tier_runs;
+    let resource_limits = container_ok || microvm_ok || confined_tier_runs;
     // Darwin has no cgroups and does not enforce RLIMIT_AS against mmap, so a
     // memory cap at the kernel tiers there would be a limit in name only. Say
-    // so rather than let `resource_limits` imply it.
-    let memory_limit = container_ok || (caps.os != "macos" && confined_tier_runs);
-    // A domain allowlist is enforced by the container tier's DNS-pinned proxy
-    // and — on macOS — by the supervised tier, whose Seatbelt profile leaves the
-    // box no outbound route except that same proxy on loopback.
+    // so rather than let `resource_limits` imply it. A microVM's memory is the
+    // guest's whole address space, so it is a hard cap on every host.
+    let memory_limit = container_ok || microvm_ok || (caps.os != "macos" && confined_tier_runs);
+    // A domain allowlist is enforced by the container tier's DNS-pinned proxy,
+    // by the microvm tier's netstack rules, and — on macOS — by the supervised
+    // tier, whose Seatbelt profile leaves the box no outbound route except that
+    // same proxy on loopback.
     let supervised_runs = claims
         .iter()
         .any(|c| c.claim == "supervised" && c.runnable == Some(true));
-    let egress_enforced = container_ok || (caps.os == "macos" && supervised_runs);
+    let egress_enforced = container_ok || microvm_ok || (caps.os == "macos" && supervised_runs);
 
     CapabilitiesReport {
         mechanism: caps.confinement_mechanism(),
@@ -991,7 +1049,9 @@ pub fn capabilities_report() -> CapabilitiesReport {
         seatbelt: caps.seatbelt,
         memory_limit,
         container_runtime: caps.container_runtime,
+        microvm_runtime: caps.microvm_runtime,
         egress_enforced,
+        egress_enforced_l3: microvm_ok,
         resource_limits,
         claims,
         strongest_tier: strongest.as_str(),
@@ -1007,6 +1067,7 @@ fn probe_host_kernel_uncached() -> HostCaps {
         seccomp: probe_seccomp(),
         seatbelt: false,
         container_runtime: None,
+        microvm_runtime: None,
     }
 }
 
@@ -1022,6 +1083,7 @@ fn probe_host_kernel_uncached() -> HostCaps {
         seccomp: false,
         seatbelt: crate::seatbelt::probe().usable(),
         container_runtime: None,
+        microvm_runtime: None,
     }
 }
 
@@ -1034,6 +1096,7 @@ fn probe_host_kernel_uncached() -> HostCaps {
         seccomp: false,
         seatbelt: false,
         container_runtime: None,
+        microvm_runtime: None,
     }
 }
 
@@ -1185,6 +1248,61 @@ pub fn resolve(profile: &Profile, caps: &HostCaps) -> Result<ResolvedPolicy, H5i
                 ));
             }
         }
+        IsolationClaim::Microvm => {
+            // Same ordering rule as the container arm: validate the declared
+            // config (image) BEFORE probing host capability, so the error a box
+            // or a CI runner sees is the host-independent one it can act on.
+            if profile.image.is_none() {
+                return Err(H5iError::Metadata(format!(
+                    "isolation claim 'microvm' requires a base image — pass `--image <img>`, \
+                     set a repo default `[container] image = \"…\"` in .h5i/env.toml, or set \
+                     `container.image` in profile '{}' (the microvm tier boots the same OCI \
+                     images the container tier runs)",
+                    profile.name
+                )));
+            }
+            if caps.microvm_runtime.is_none() {
+                // Say which half is missing. "Install microsandbox" and "enable
+                // nested virtualization in your hypervisor" are very different
+                // afternoons, and a tier that refuses without saying which one
+                // is a tier nobody can adopt.
+                let detail = crate::microvm::unavailable_detail();
+                return Err(H5iError::Metadata(format!(
+                    "isolation claim 'microvm' cannot be satisfied on this host — refusing \
+                     (h5i never silently downgrades):\n  - {detail}\nRe-request a weaker claim \
+                     (--isolation container|supervised|process), or run on a host with \
+                     virtualization enabled."
+                )));
+            }
+            // Reject an untranslatable allowlist here, at policy-resolve time,
+            // rather than at first run: a `net.egress` entry the rule grammar
+            // cannot carry exactly is a policy this tier cannot enforce, and the
+            // place to find that out is `env create`.
+            crate::microvm::egress_rule_tokens(&profile.net_egress)?;
+            // Authenticated egress (5.5) hands the box a base URL pointing at a
+            // proxy on the *host's* loopback. A container reaches that through a
+            // known slirp gateway; a microVM's guest has its own loopback and its
+            // own per-sandbox subnet, so the same URL resolves to nothing inside
+            // it. Refuse the combination rather than hand the box an origin it
+            // cannot dial — a grant that silently fails to authenticate is worse
+            // than one that never started.
+            if !profile.auth.is_empty() {
+                return Err(H5iError::Metadata(format!(
+                    "profile '{}' declares authenticated-egress grants ({}), which the microvm \
+                     tier cannot route yet: the credential proxy listens on the host's loopback \
+                     and a microVM has its own. Use --isolation container|supervised for this \
+                     profile, or drop the `[[profile.{}.auth]]` grants (fail-closed).",
+                    profile.name,
+                    profile
+                        .auth
+                        .iter()
+                        .map(|g| g.host.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    profile.name
+                )));
+            }
+        }
         IsolationClaim::Supervised => {
             // The keystone safety property: refuse unless the ENTIRE mediation
             // stack probes green on this host. Never downgrade to a weaker tier
@@ -1266,6 +1384,7 @@ pub fn run_with_env(
         IsolationClaim::Process => run_confined(policy, work, argv, injected_env),
         IsolationClaim::Supervised => crate::supervisor::run(policy, work, argv, injected_env),
         IsolationClaim::Container => crate::container::run(policy, work, argv, injected_env),
+        IsolationClaim::Microvm => crate::microvm::run(policy, work, argv, injected_env),
         claim => Err(H5iError::Metadata(format!(
             "no backend for isolation claim '{}'",
             claim.as_str()
@@ -1440,6 +1559,15 @@ pub fn run_interactive(
         }
         IsolationClaim::Container => {
             crate::container::run_interactive(
+                policy,
+                work,
+                argv,
+                injected_env,
+                managed_settings_content,
+            )
+        }
+        IsolationClaim::Microvm => {
+            crate::microvm::run_interactive(
                 policy,
                 work,
                 argv,
@@ -3435,7 +3563,15 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
     }
 
     fn caps(landlock: Option<i32>, userns: bool, seccomp: bool) -> HostCaps {
-        HostCaps { os: "linux".into(), landlock_abi: landlock, userns, seccomp, seatbelt: false, container_runtime: None }
+        HostCaps {
+            os: "linux".into(),
+            landlock_abi: landlock,
+            userns,
+            seccomp,
+            seatbelt: false,
+            container_runtime: None,
+            microvm_runtime: None,
+        }
     }
 
     #[test]
@@ -3463,11 +3599,11 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
 
     #[test]
     fn resolve_refuses_unimplemented_backends() {
-        for claim in [IsolationClaim::HardenedContainer, IsolationClaim::Microvm] {
-            let p = Profile::builtin("default", claim);
-            let err = resolve(&p, &caps(Some(5), true, true)).unwrap_err();
-            assert!(err.to_string().contains("backend"), "{err}");
-        }
+        // `hardened-container` (gVisor/Kata) still has no adapter. `microvm`
+        // does — see `resolve_microvm_requires_image_and_runtime`.
+        let p = Profile::builtin("default", IsolationClaim::HardenedContainer);
+        let err = resolve(&p, &caps(Some(5), true, true)).unwrap_err();
+        assert!(err.to_string().contains("backend"), "{err}");
     }
 
     fn caps_with_container(runtime: Option<&str>) -> HostCaps {
@@ -3478,7 +3614,49 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
             seccomp: true,
             seatbelt: false,
             container_runtime: runtime.map(str::to_owned),
+            microvm_runtime: None,
         }
+    }
+
+    fn caps_with_microvm(runtime: Option<&str>) -> HostCaps {
+        HostCaps {
+            microvm_runtime: runtime.map(str::to_owned),
+            ..caps_with_container(None)
+        }
+    }
+
+    #[test]
+    fn resolve_microvm_requires_image_and_runtime() {
+        // A missing image is a *static* profile error — true on every host — so
+        // it is reported before the host probe, and a box or a CI runner with no
+        // virtualization still gets the message it can act on.
+        let bare = Profile::builtin("default", IsolationClaim::Microvm);
+        let err = resolve(&bare, &caps_with_microvm(Some("msb"))).unwrap_err();
+        assert!(err.to_string().contains("requires a base image"), "{err}");
+
+        // Image declared, no runtime → refuse, never downgrade.
+        let mut imaged = bare.clone();
+        imaged.image = Some("alpine".into());
+        let err = resolve(&imaged, &caps_with_microvm(None)).unwrap_err();
+        let text = err.to_string();
+        assert!(text.contains("never silently downgrades"), "{text}");
+        assert!(text.contains("microvm"), "{text}");
+
+        // Both halves present → satisfiable.
+        let policy = resolve(&imaged, &caps_with_microvm(Some("msb"))).unwrap();
+        assert_eq!(policy.claim, IsolationClaim::Microvm);
+    }
+
+    #[test]
+    fn resolve_microvm_rejects_an_untranslatable_egress_entry_at_create_time() {
+        // A `net.egress` entry this tier's rule grammar cannot carry exactly is
+        // a policy it cannot enforce. Finding that out at `env create` beats
+        // finding it out on the first run inside the box.
+        let mut p = Profile::builtin("default", IsolationClaim::Microvm);
+        p.image = Some("alpine".into());
+        p.net_egress = vec!["*.com".into()];
+        let err = resolve(&p, &caps_with_microvm(Some("msb"))).unwrap_err();
+        assert!(err.to_string().contains("at least two"), "{err}");
     }
 
     #[test]
@@ -3529,6 +3707,7 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
             seccomp: false,
             seatbelt,
             container_runtime: None,
+            microvm_runtime: None,
         }
     }
 
@@ -3557,6 +3736,7 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
             seccomp: false,
             seatbelt: false,
             container_runtime: None,
+            microvm_runtime: None,
         };
         let err = resolve(&p, &win).unwrap_err();
         assert!(err.to_string().contains("windows"), "{err}");
@@ -3656,24 +3836,36 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
         // Workspace is the floor: no confinement needed, so always usable.
         let ws = r.claims.iter().find(|c| c.claim == "workspace").unwrap();
         assert!(ws.satisfiable && ws.runnable == Some(true));
-        // Not-in-this-build backends are always unsatisfiable.
-        for name in ["hardened-container", "microvm"] {
-            let c = r.claims.iter().find(|c| c.claim == name).unwrap();
-            assert!(!c.satisfiable && c.runnable.is_none());
-        }
+        // The one remaining not-in-this-build backend is always unsatisfiable.
+        let hc = r.claims.iter().find(|c| c.claim == "hardened-container").unwrap();
+        assert!(!hc.satisfiable && hc.runnable.is_none());
+        // The image-backed tiers are never exec-tested (a run needs an image),
+        // and each tracks its own runtime.
+        let mv = r.claims.iter().find(|c| c.claim == "microvm").unwrap();
+        assert!(mv.runnable.is_none());
+        assert_eq!(mv.satisfiable, r.microvm_runtime.is_some());
+        let ct = r.claims.iter().find(|c| c.claim == "container").unwrap();
+        assert!(ct.runnable.is_none());
+        assert_eq!(ct.satisfiable, r.container_runtime.is_some());
         // A domain allowlist is enforced by the container tier's DNS-pinned
-        // proxy, and on macOS also by the supervised tier — whose Seatbelt
-        // profile leaves the box no outbound route except that same proxy. The
-        // Linux kernel tiers can deny all but never allowlist, so they do not
-        // count towards this.
+        // proxy, by the microvm tier's netstack rules, and on macOS also by the
+        // supervised tier — whose Seatbelt profile leaves the box no outbound
+        // route except that same proxy. The Linux kernel tiers can deny all but
+        // never allowlist, so they do not count towards this.
         let supervised_runs = r
             .claims
             .iter()
             .any(|c| c.claim == "supervised" && c.runnable == Some(true));
         assert_eq!(
             r.egress_enforced,
-            r.container_runtime.is_some() || (r.os == "macos" && supervised_runs)
+            r.container_runtime.is_some()
+                || r.microvm_runtime.is_some()
+                || (r.os == "macos" && supervised_runs)
         );
+        // L3 enforcement is the microvm tier's alone: an L7 proxy stops `curl`
+        // and does not stop a raw socket, and the report must not blur the two.
+        assert_eq!(r.egress_enforced_l3, r.microvm_runtime.is_some());
+        assert!(!r.egress_enforced_l3 || r.egress_enforced);
         // The two honesty flags, which exist so a caller never infers a
         // guarantee from a tier name that means different things per platform.
         assert!(
@@ -3681,8 +3873,11 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
             "only Linux has a syscall deny-list; macOS must never claim one"
         );
         assert!(
-            !(r.memory_limit && r.os == "macos" && r.container_runtime.is_none()),
-            "Darwin cannot cap memory without the container tier"
+            !(r.memory_limit
+                && r.os == "macos"
+                && r.container_runtime.is_none()
+                && r.microvm_runtime.is_none()),
+            "Darwin cannot cap memory without an image-backed tier"
         );
         assert!(
             !r.memory_limit || r.resource_limits,

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -53,7 +53,12 @@ pub enum IsolationClaim {
     Container,
     /// gVisor / Kata adapter (not in this build).
     HardenedContainer,
-    /// Firecracker adapter (not in this build).
+    /// **microVM** adapter (opt-in shell-out to microsandbox's `msb`). A
+    /// hardware-isolated guest with its own kernel, and the first tier whose
+    /// `net.egress` allowlist is enforced by address in the VM's network stack
+    /// rather than by an HTTP proxy the box could decline to use. Requires
+    /// virtualization on the host (KVM / Apple Silicon); refused, never
+    /// downgraded, when it is absent (`microvm.rs`).
     Microvm,
 }
 
@@ -81,6 +86,31 @@ impl IsolationClaim {
             Self::HardenedContainer => "hardened-container",
             Self::Microvm => "microvm",
         }
+    }
+
+    /// Does this tier run the command inside a **base image** with the workspace
+    /// mounted in, rather than against the host filesystem under a kernel
+    /// policy? True for `container` and `microvm`.
+    ///
+    /// Ask this instead of testing `== Container` wherever the reason is
+    /// structural — the box needs its git plumbing mounted, its spool and inbox
+    /// mounted, its shell rc coming from the image, its host paths free of the
+    /// mount syntax's separator. Those facts follow from "the box is an image",
+    /// not from which runtime boots it, and a tier added later should inherit
+    /// them by construction rather than by someone remembering to grep.
+    ///
+    /// `hardened-container` is deliberately **not** included: it has no adapter
+    /// in this build, so claiming its structural shape would be claiming a
+    /// backend that does not exist.
+    pub fn image_backed(&self) -> bool {
+        matches!(self, Self::Container | Self::Microvm)
+    }
+
+    /// Does this tier enforce a `net.egress` **domain allowlist**? The kernel
+    /// tiers can deny all outbound or allow all of it and nothing in between,
+    /// so a non-empty allowlist there fails closed.
+    pub fn enforces_egress_allowlist(&self) -> bool {
+        matches!(self, Self::Container | Self::Microvm)
     }
 }
 
@@ -373,8 +403,11 @@ pub struct Profile {
     /// Tools allowlist — when non-empty, only these programs (argv[0] basename)
     /// may run; enforced fail-closed (see `check_tool_allowlist`).
     pub tools: Vec<String>,
-    /// Container image for `isolation=container` (required at that tier). The
-    /// command runs inside it with the workspace bind-mounted at `/work`.
+    /// Base OCI image for the image-backed tiers — `isolation=container` and
+    /// `isolation=microvm`, both of which require it. The command runs inside it
+    /// with the workspace mounted at `/work`. Named `container.image` in
+    /// `.h5i/env.toml` for compatibility; the microvm tier boots the same
+    /// images.
     pub image: Option<String>,
     /// Environment-variable allowlist — the child gets *only* these (plus
     /// nothing else; secrets are never inherited wholesale).

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -370,7 +370,7 @@ unsatisfiable request fails closed rather than leaving half a box behind.</p>
 </tr>
 <tr>
 <td><code>--image &lt;img&gt;</code></td>
-<td>Container base image for <code>isolation=container</code>.</td>
+<td>Base image for <code>isolation=container</code> and <code>isolation=microvm</code>. Pre-pulled; runs never pull.</td>
 </tr>
 </tbody>
 </table>
@@ -729,6 +729,11 @@ wall  = &quot;30m&quot;
 <td>Rootless Podman: a portable image, with a CONNECT-proxy egress allowlist.</td>
 <td>L7</td>
 </tr>
+<tr>
+<td><code>microvm</code></td>
+<td>A hardware-isolated guest with its own kernel, booted by <a href="https://microsandbox.dev">microsandbox</a> (<code>msb</code>) from the same OCI images. Egress rules are evaluated by the VM's network stack.</td>
+<td><strong>L3/L4</strong></td>
+</tr>
 </tbody>
 </table>
 <p><code>auto</code> (the default) picks the strongest tier the host can actually run. An
@@ -738,6 +743,38 @@ silently downgrades.</p>
 container tier buys <strong>portability</strong>, not tighter network control. Its allowlist
 is a proxy, so it binds proxy-respecting tooling only. <code>supervised</code> enforces at
 L3/L4 and does not have that hole.</p>
+<h4 id="the-microvm-tier">The microvm tier</h4>
+<p><code>microvm</code> is the one tier where the boundary is a virtual machine rather than a
+policy applied to a host process. A kernel exploit inside the box meets the
+hypervisor, not the host kernel it just subverted. Its <code>net.egress</code> allowlist
+becomes default-deny plus one address rule per allowed destination, so a raw
+socket to an unlisted IP is dropped rather than merely un-proxied.</p>
+<p>Requirements, all three, or the tier refuses:</p>
+<ul>
+<li>microsandbox's <code>msb</code> on <code>PATH</code>, version 0.6 or newer.</li>
+<li>Host virtualization: <code>/dev/kvm</code> openable on Linux, Apple Silicon on macOS.
+  A stock WSL2 kernel and most cloud CI runners have neither.</li>
+<li>A base image, from <code>--image</code>, the profile's <code>container.image</code>, or the
+  repo-level <code>[container] image</code> — the same images the container tier runs,
+  pre-pulled with <code>msb pull</code>.</li>
+</ul>
+<p><code>h5i box probe</code> reports which of the three is missing, since "install a package"
+and "enable nested virtualization" are different problems.</p>
+<p>Two things it does <strong>not</strong> do yet, stated rather than left to be discovered:</p>
+<ul>
+<li><strong>No per-request egress tally.</strong> The container tier's proxy sees every CONNECT
+  and records allow/deny counts in the capture manifest. A netstack filter drops
+  packets without reporting them, so a microvm receipt carries no egress
+  summary. Stronger enforcement, thinner evidence.</li>
+<li><strong>No authenticated-egress grants.</strong> <code>[[profile.X.auth]]</code> hands the box a base
+  URL pointing at a credential proxy on the <em>host's</em> loopback, which a microVM
+  guest cannot dial. A profile that declares grants is refused at this tier
+  rather than handed an origin that resolves to nothing.</li>
+</ul>
+<p>In-box observation works as it does under <code>container</code>: the read-only
+managed-settings mount carrying the <code>wrap-bash</code> hook, and the capture spool at
+<code>/.h5i/spool</code>. The container tier's tee shim has no analogue here (it depends on
+self-mounting the image, which a VM has nothing to do).</p>
 <h3 id="af_unix-sockets">AF_UNIX sockets</h3>
 <p><code>[profile.X.net] unix = true</code> lets the box create <code>AF_UNIX</code> sockets. Off by
 default, because <code>SCM_RIGHTS</code> passes file descriptors, which is authority

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -109,10 +109,10 @@ Remote to fetch the PR head from (with \-\-pr)
 Policy profile from .h5i/env.toml. Built\-ins need no file: `agent` (agent\-in\-box, scoped to $H5I_AGENT\*(Aqs runtime), `agent\-claude` / `agent\-codex` (pin one runtime: only that agent\*(Aqs HOME state + API egress), `browser` (the agent profile plus headless Chrome and the agent\-browser daemon, so the agent can drive a real browser against the dev server it just started), and `default` (fail\-closed build/test confinement). Unset auto\-picks the creating runtime\*(Aqs agent profile when this host can enforce it, else `default`
 .TP
 \fB\-\-isolation\fR \fI<ISOLATION>\fR
-Isolation: auto (default) | workspace | process | supervised | container | hardened\-container | microvm. `auto` (or unset) picks the strongest tier the host can run; an explicit tier fails closed if the host cannot satisfy it (never silently downgrades)
+Isolation: auto (default) | workspace | process | supervised | container | microvm. `auto` (or unset) picks the strongest tier the host can run; an explicit tier fails closed if the host cannot satisfy it (never silently downgrades). `microvm` boots a hardware\-isolated guest via microsandbox (`msb`) and is the only tier whose net.egress allowlist is enforced by address rather than by an HTTP proxy; it needs an image and host virtualization
 .TP
 \fB\-\-image\fR \fI<IMAGE>\fR
-Container base image for isolation=container (pre\-pulled; runs use \-\-pull=never). Overrides the profile\*(Aqs `container.image` and the repo\-level `[container] image` default in .h5i/env.toml. Passing it makes the container tier a candidate for the isolation auto\-pick
+Base image for isolation=container and isolation=microvm (pre\-pulled; runs never pull). Overrides the profile\*(Aqs `container.image` and the repo\-level `[container] image` default in .h5i/env.toml. Passing it makes both image\-backed tiers candidates for the isolation auto\-pick
 .TP
 \fB\-\-backend\fR \fI<BACKEND>\fR [default: auto]
 Workspace backend (auto|worktree)
@@ -171,7 +171,7 @@ Environment name (slug, `agent/slug`, or full `env/agent/slug`)
 [\fICOMMAND\fR]
 Command to run inside the box (after `\-\-`); default: an interactive shell
 .SH "H5I BOX ALLOW"
-Manage the persistent user-level egress allowlist: extra hosts merged into every container-tier env whose profile already sets net.egress (a deny-all profile is never widened). Stored host-side under ~/.config/h5i/, outside every box-granted path; takes effect at the next `env run`/`env shell`. With no rule, lists the current entries
+Manage the persistent user-level egress allowlist: extra hosts merged into every container- or microvm-tier env whose profile already sets net.egress (a deny-all profile is never widened). Stored host-side under ~/.config/h5i/, outside every box-granted path; takes effect at the next `env run`/`env shell`. With no rule, lists the current entries
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -51,15 +51,18 @@ pub enum BoxCommands {
         /// agent profile when this host can enforce it, else `default`.
         #[arg(long)]
         profile: Option<String>,
-        /// Isolation: auto (default) | workspace | process | supervised | container | hardened-container | microvm.
+        /// Isolation: auto (default) | workspace | process | supervised | container | microvm.
         /// `auto` (or unset) picks the strongest tier the host can run; an explicit
         /// tier fails closed if the host cannot satisfy it (never silently downgrades).
+        /// `microvm` boots a hardware-isolated guest via microsandbox (`msb`) and is
+        /// the only tier whose net.egress allowlist is enforced by address rather
+        /// than by an HTTP proxy; it needs an image and host virtualization.
         #[arg(long)]
         isolation: Option<String>,
-        /// Container base image for isolation=container (pre-pulled; runs use
-        /// --pull=never). Overrides the profile's `container.image` and the
+        /// Base image for isolation=container and isolation=microvm (pre-pulled;
+        /// runs never pull). Overrides the profile's `container.image` and the
         /// repo-level `[container] image` default in .h5i/env.toml. Passing it
-        /// makes the container tier a candidate for the isolation auto-pick.
+        /// makes both image-backed tiers candidates for the isolation auto-pick.
         #[arg(long)]
         image: Option<String>,
         /// Workspace backend (auto|worktree)
@@ -113,8 +116,8 @@ pub enum BoxCommands {
     },
 
     /// Manage the persistent user-level egress allowlist: extra hosts merged
-    /// into every container-tier env whose profile already sets net.egress
-    /// (a deny-all profile is never widened). Stored host-side under
+    /// into every container- or microvm-tier env whose profile already sets
+    /// net.egress (a deny-all profile is never widened). Stored host-side under
     /// ~/.config/h5i/, outside every box-granted path; takes effect at the
     /// next `env run`/`env shell`. With no rule, lists the current entries.
     Allow {
@@ -990,6 +993,10 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                         "  container    = {}",
                         caps.container_runtime.as_deref().unwrap_or("none")
                     );
+                    println!(
+                        "  microvm      = {}",
+                        caps.microvm_runtime.as_deref().unwrap_or("none")
+                    );
                     println!();
                     for (claim, profile_net_deny) in [
                         (h5i_core::sandbox::IsolationClaim::Workspace, false),
@@ -1010,16 +1017,30 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                             }
                         );
                     }
-                    // Container claim: needs rootless Podman + a profile image;
-                    // show whether the runtime half is satisfiable.
+                    // Image-backed claims: each needs its own runtime plus a
+                    // profile image; show whether the runtime half is there.
                     let container_ok = caps.container_runtime.is_some();
                     println!(
                         "  claim {:<10} satisfiable = {} (needs rootless Podman + profile container.image)",
                         "container",
                         if container_ok { style("yes").green() } else { style("no").red() }
                     );
+                    let microvm_ok = caps.microvm_runtime.is_some();
                     println!(
-                        "  claim hardened-container/microvm: external backends (not in this build)"
+                        "  claim {:<10} satisfiable = {} (needs microsandbox `msb` + host virtualization + profile container.image)",
+                        "microvm",
+                        if microvm_ok { style("yes").green() } else { style("no").red() }
+                    );
+                    if !microvm_ok {
+                        // Which half is missing decides what the reader does
+                        // next: install a package, or turn on nested virt.
+                        println!(
+                            "    {}",
+                            style(h5i_core::sandbox::microvm_unavailable_detail()).dim()
+                        );
+                    }
+                    println!(
+                        "  claim hardened-container: external backend (not in this build)"
                     );
                     // Functional self-test: bits can be present while a hardened
                     // kernel still denies exec under the full confinement stack.
@@ -1070,7 +1091,25 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                             "  container        = {}",
                             report.container_runtime.as_deref().unwrap_or("none")
                         );
+                        println!(
+                            "  microvm          = {}",
+                            report.microvm_runtime.as_deref().unwrap_or("none")
+                        );
                         println!("  egress_enforced  = {}", yn(report.egress_enforced));
+                        // The distinction that matters for untrusted code: an
+                        // L7 proxy stops `curl`, an L3 filter stops a raw socket.
+                        println!(
+                            "  egress_l3        = {} {}",
+                            yn(report.egress_enforced_l3),
+                            style(if report.egress_enforced_l3 {
+                                "(by address, microvm netstack)"
+                            } else if report.egress_enforced {
+                                "(allowlist is L7 proxy only)"
+                            } else {
+                                ""
+                            })
+                            .dim()
+                        );
                         println!("  syscall_filter   = {}", yn(report.syscall_filter));
                         println!("  resource_limits  = {}", yn(report.resource_limits));
                         println!("  memory_limit     = {}", yn(report.memory_limit));

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -1667,19 +1667,58 @@ fn auto_isolation_picks_a_runnable_tier() {
 #[test]
 fn unimplemented_backends_refuse_at_create() {
     let r = Repo::new();
-    // hardened-container/microvm have no adapter in this build → refuse.
-    for claim in ["hardened-container", "microvm"] {
-        let out = r.h5i(&["env", "create", "boxed", "--isolation", claim]);
-        assert!(!out.status.success(), "claim {claim} must refuse");
-        assert!(out_str(&out).contains("backend"), "{}", out_str(&out));
-        assert!(
-            !r.env_dir("boxed").exists(),
-            "no state left behind on refusal"
-        );
-    }
+    // hardened-container (gVisor/Kata) still has no adapter in this build.
+    let out = r.h5i(&["env", "create", "boxed", "--isolation", "hardened-container"]);
+    assert!(!out.status.success(), "hardened-container must refuse");
+    assert!(out_str(&out).contains("backend"), "{}", out_str(&out));
+    assert!(
+        !r.env_dir("boxed").exists(),
+        "no state left behind on refusal"
+    );
     // An unknown claim name is rejected outright.
     let out = r.h5i(&["env", "create", "boxed", "--isolation", "docker"]);
     assert!(!out.status.success(), "unknown claim must refuse");
+}
+
+/// The microvm tier has an adapter, so it refuses for *substantive* reasons —
+/// a missing image or a host that cannot virtualize — and never by silently
+/// downgrading to a weaker tier.
+#[test]
+fn microvm_claim_fails_closed_with_an_actionable_reason() {
+    let r = Repo::new();
+    // No image: a static profile error, true on every host, so it is reported
+    // regardless of whether this machine has `msb` or KVM.
+    let out = r.h5i(&["env", "create", "boxed", "--isolation", "microvm"]);
+    assert!(!out.status.success(), "microvm without an image must refuse");
+    let text = out_str(&out);
+    assert!(text.contains("requires a base image"), "{text}");
+    assert!(
+        !r.env_dir("boxed").exists(),
+        "no state left behind on refusal"
+    );
+
+    // With an image the verdict depends on the host. Either it resolves to the
+    // microvm tier, or it refuses saying so — never a quiet downgrade to a
+    // weaker claim, which is the failure mode this whole design exists to avoid.
+    let out = r.h5i(&[
+        "env",
+        "create",
+        "vmbox",
+        "--isolation",
+        "microvm",
+        "--image",
+        "alpine",
+    ]);
+    let text = out_str(&out);
+    if out.status.success() {
+        assert_eq!(r.manifest("vmbox")["isolation_claim"], "microvm");
+    } else {
+        assert!(
+            text.contains("never silently downgrades"),
+            "a refusal must say why and must not downgrade: {text}"
+        );
+        assert!(!r.env_dir("vmbox").exists(), "no state left behind: {text}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
`isolation=microvm` has been an enum variant that refuses since the tier model landed. It is now a real backend: a shell-out adapter to [microsandbox](https://microsandbox.dev)'s `msb`, structured like `container.rs` — probe, egress translation, a pure argv builder, `run` and `run_interactive`.

## Why

`container.rs` already names both of this tier's advantages as its own gaps:

- **The boundary is a VM with its own kernel.** A kernel exploit in the box meets the hypervisor rather than the host kernel it just subverted. `container.rs` calls this out: *"airtight L3/L4 egress filtering is the `hardened-container`/`microvm` tier."*
- **Egress is filtered by address, not by proxy etiquette.** `net.egress` becomes `--net-default-egress deny` plus one `--net-rule` per allowed destination, evaluated by the guest netstack. A raw socket to an unlisted IP is dropped; there is no `HTTP_PROXY` to decline to use.

## Three points worth a reviewer's attention

**No environment value reaches the host argv.** `msb --env` takes `KEY=VALUE`, unlike `podman --env NAME` — so the obvious wiring would publish brokered credentials through `/proc/<pid>/cmdline`, the exact leak `container.rs` goes out of its way to avoid. The adapter instead writes a `0600` preload script and registers it with `--script-path`, whose *contents* travel to the runtime over a config fd. No `--env` flag is emitted at all, and a test asserts that. Values are single-quoted with the total POSIX `'\''` escape, so a credential containing quotes cannot reach command position.

**Egress translation is fail-closed.** A `.suffix` entry emits both `domain=` and `suffix=` tokens, because h5i's wildcard matches the apex and microsandbox's `suffix=` does not — one token alone would silently *narrow* the declared policy. An entry the grammar cannot carry exactly (`*.com`, a comma, an `@`) is refused at `env create` rather than at first run.

**Authenticated-egress grants are refused at this tier.** `[[profile.X.auth]]` hands the box a base URL for a credential proxy on the *host's* loopback, which a microVM guest cannot dial. Refusing beats handing over an origin that resolves to nothing.

## Integration

`IsolationClaim::image_backed()` and `enforces_egress_allowlist()` replace the scattered `== Container` checks in `env.rs` (git plumbing, capture spool, inbox, hook lockdown, shell rc, mount-separator guard), so a tier added later inherits the structural facts by construction rather than by someone remembering to grep. Plus `HostCaps.microvm_runtime`, microvm leading the auto-pick, and a new `egress_l3` flag in the capability report so an L7 proxy and an address filter are never reported as the same guarantee.

## What is *not* demonstrated

**No guest has ever booted under this adapter.** The development host has no `/dev/kvm` and no `msb` installed, so the argv builder and rule translation are unit-tested (30 tests) and the refusal paths are exercised end to end, but the live path is unproven. ROADMAP.md §9 says so rather than let the tier read as finished. **A reviewer with virtualization available should boot a box before this merges.**

Deliberate v1 gaps, documented in MANUAL.md:

- **No per-request egress tally.** The container tier's proxy sees every CONNECT and records allow/deny counts in the capture manifest. A netstack filter drops packets without reporting them, so a microvm receipt carries no egress summary. Stronger enforcement, thinner evidence.
- **No tee shim.** It depends on self-mounting the image, which a VM has nothing to do. The read-only managed-settings mount carrying the `wrap-bash` hook — the primary observation path — works here exactly as under `container`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean, with and without default features.
- 241 sandbox + 188 core unit tests pass; `env_integration` 112 pass.
- Three `env_integration` tests fail (`process_tier_confines_fs_and_network`, `box_git_status_and_commit_work_inside_process_tier`, `box_git_grants_stay_fail_closed_outside_env_namespace`). Confirmed by stashing that they fail identically on the unmodified base — known process-tier host drift, not this change.
- `man/man1/h5i.1` and `docs/manual/index.html` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
