### PR TITLE
fix(box): take the interactive shell from the image, not the host $SHELL

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -60,6 +60,10 @@ mounts are all enforced outside the agent, so the inner layer is redundant.
 - **Observation**: the tee-shim records shell commands for any image; the
   baked-in `h5i` additionally powers the unremovable managed-settings
   `wrap-bash` hook (Claude images) and in-box `h5i capture run`.
+- **The shell** for a bare `h5i box shell` comes from the *image*, never from
+  the host `$SHELL` (a `/bin/zsh` host path does not exist in the box): `bash`
+  when the image has it, `/bin/sh` otherwise. Its rc comes from the image too,
+  so a profile's `[shell] rcfile` is ignored here.
 
 ## Extending with your project's toolchain
 

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -4247,10 +4247,14 @@ fn capture_shell_egress(
 
 /// Build the argv for a default (no-command) interactive `env shell` session.
 ///
-/// The host `$SHELL` is used, but for **bash** the host `~/.bashrc` is *not*
-/// sourced by default — under confinement it routinely calls tools the sandbox
-/// blocks (e.g. `~/.local/bin/powerline-shell`), spraying `Permission denied`
-/// noise. Instead bash is pointed at:
+/// On the **kernel tiers** the box runs against the host filesystem, so the host
+/// `$SHELL` is the right binary. On the **image-backed** tiers it is not a
+/// binary that exists at all — see [`box_shell_argv`].
+///
+/// For **bash** the host `~/.bashrc` is *not* sourced by default — under
+/// confinement it routinely calls tools the sandbox blocks (e.g.
+/// `~/.local/bin/powerline-shell`), spraying `Permission denied` noise. Instead
+/// bash is pointed at:
 ///   - a **custom** rcfile when the profile sets `[shell] rcfile` — resolved
 ///     relative to `$WORK` (the worktree), so it is version-controlled and
 ///     reachable in the box on every tier without an extra grant; or
@@ -4258,8 +4262,9 @@ fn capture_shell_egress(
 ///     optional `~/.h5i_envrc` hook), written under the env's private dir and
 ///     Landlock-granted read on the kernel tiers.
 ///
-/// Non-bash shells and the container tier (whose rc comes from the image, not
-/// the host) fall through to a bare `[$SHELL, "-i"]`.
+/// Non-bash shells fall through to a bare `[$SHELL, "-i"]`; the image-backed
+/// tiers (whose shell *and* rc come from the image, not the host) fall through
+/// to [`box_shell_argv`].
 fn default_shell_argv(
     h5i_root: &Path,
     m: &EnvManifest,
@@ -4273,9 +4278,10 @@ fn default_shell_argv(
         .unwrap_or(false);
     let bare = vec![shell.clone(), "-i".to_string()];
 
-    // The container shell + its rc come from the image, not the host — the host
+    // The box's shell + its rc come from the image, not the host — the host
     // `~/.bashrc` is never sourced there, so there is nothing to neutralize and
-    // a host-path rcfile would not resolve in-box. Honor neither default here.
+    // a host-path rcfile would not resolve in-box. Honor neither default here,
+    // and do not carry the host `$SHELL` in either: it names a host binary.
     if policy.claim.image_backed() {
         if policy.profile.shell_rcfile.is_some() {
             eprintln!(
@@ -4284,7 +4290,7 @@ fn default_shell_argv(
                 policy.claim.as_str()
             );
         }
-        return Ok(bare);
+        return Ok(box_shell_argv());
     }
 
     if let Some(rc) = policy.profile.shell_rcfile.clone() {
@@ -4314,6 +4320,30 @@ fn default_shell_argv(
         policy.profile.fs_read.push(rcpath.clone());
     }
     Ok(vec![shell, "--rcfile".into(), rcpath, "-i".into()])
+}
+
+/// The default interactive shell **inside an image-backed box** (container,
+/// microVM).
+///
+/// `$SHELL` names a *host* binary: on a stock macOS it is `/bin/zsh`, which the
+/// box's Linux rootfs does not carry — passing it in ends the session at exec
+/// before the first prompt (`/.msb/scripts/h5i-env: exec: /bin/zsh: not found`).
+/// The shell has to come from the image, exactly like the rc does, and the image
+/// is the only thing that knows which shells it has. So ask it at start-up
+/// rather than guess host-side: prefer `bash` (both shipped agent images carry
+/// it, `containers/entrypoint.sh` falls back to it, and the container tier's
+/// observation shim shadows it), and fall back to the one shell every image is
+/// guaranteed to have — the same `/bin/sh` this probe is already running in.
+///
+/// Both arms `exec`, so the probing `sh` is *replaced* rather than left behind
+/// as a parent: the TTY, the signals and the exit code reach the real shell
+/// exactly as if it had been launched directly.
+fn box_shell_argv() -> Vec<String> {
+    vec![
+        "/bin/sh".into(),
+        "-c".into(),
+        "if command -v bash >/dev/null 2>&1; then exec bash -i; else exec /bin/sh -i; fi".into(),
+    ]
 }
 
 /// Resolve a profile `[shell] rcfile` (relative to `$WORK`) to an absolute path,
@@ -7342,6 +7372,61 @@ mod tests {
         assert!(body.contains("$HOME/.h5i_envrc"));
         assert!(!body.contains(".bashrc\""));
         assert!(path.ends_with("shell/rc.bash"));
+    }
+
+    // A box's rootfs is the image's, so the host `$SHELL` is a path to a binary
+    // that is simply not there: a stock macOS `$SHELL=/bin/zsh` used to end the
+    // session at exec ("/bin/zsh: not found") before the first prompt. The shell
+    // must be resolved inside the box instead — on every image-backed tier, and
+    // regardless of what the profile says about rc files (which are the image's
+    // business too).
+    #[test]
+    fn image_backed_tiers_take_their_shell_from_the_image_not_the_host() {
+        use crate::sandbox::Profile;
+        let h5i_root = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let m = canonical_manifest("claude", "demo");
+        let host_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+
+        for claim in [IsolationClaim::Container, IsolationClaim::Microvm] {
+            for rcfile in [None, Some(".h5i/box.bashrc".to_string())] {
+                let mut pol = ResolvedPolicy::new(claim, Profile::builtin("default", claim));
+                pol.profile.shell_rcfile = rcfile.clone();
+                let argv = default_shell_argv(h5i_root.path(), &m, &mut pol, work.path()).unwrap();
+
+                assert_eq!(argv[0], "/bin/sh", "{claim:?} launches via the image's sh");
+                assert_eq!(argv[1], "-c");
+                // bash when the image has it, the guaranteed /bin/sh otherwise —
+                // and `exec` either way, so the probe leaves no parent behind.
+                assert!(argv[2].contains("exec bash -i"), "{argv:?}");
+                assert!(argv[2].contains("exec /bin/sh -i"), "{argv:?}");
+                // Nothing host-side rides along: no host $SHELL, and no
+                // host-path rcfile (which would not resolve in-box).
+                if host_shell != "/bin/sh" {
+                    assert!(!argv.contains(&host_shell), "host shell leaked: {argv:?}");
+                }
+                assert!(!argv.iter().any(|a| a == "--rcfile"), "{argv:?}");
+            }
+        }
+    }
+
+    // The kernel tiers DO run against the host filesystem, so there the host
+    // shell is the right one — the fix above must not have flattened them.
+    #[test]
+    fn kernel_tiers_keep_the_host_shell() {
+        use crate::sandbox::Profile;
+        let h5i_root = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+        let m = canonical_manifest("claude", "demo");
+        let host_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+
+        let mut pol = ResolvedPolicy::new(
+            IsolationClaim::Process,
+            Profile::builtin("default", IsolationClaim::Process),
+        );
+        let argv = default_shell_argv(h5i_root.path(), &m, &mut pol, work.path()).unwrap();
+        assert_eq!(argv[0], host_shell);
+        assert_eq!(argv.last().unwrap(), "-i");
     }
 
     #[test]


### PR DESCRIPTION
`h5i box shell <name>` on a microvm-tier box died before the first prompt on any host whose login shell is not also in the image:

    /.msb/scripts/h5i-env: exec: line 17: /bin/zsh: not found

`default_shell_argv` builds the no-command argv from the host `$SHELL`, which is right on the kernel tiers — they run against the host filesystem — and meaningless on the image-backed ones, where the rootfs is the image's. A stock macOS `$SHELL` is `/bin/zsh`, so the preload wrapper's `exec "$@"` was handed a path to a binary the box does not have. The image-backed branch already knew the shell *rc* comes from the image and said so in its comment; it just never applied the same reasoning one level down, to the shell binary the rc would belong to.

Which shells exist is a fact only the image holds, so ask it at start-up instead of guessing host-side: prefer `bash` (both shipped agent images carry it, `containers/entrypoint.sh` falls back to it, and the container tier's observation shim shadows it), and fall back to the one shell every image is guaranteed to have. Both arms `exec`, so the probing `sh` is replaced rather than left as a parent and the TTY, the signals and the exit code reach the real shell untouched.

Hardcoding `/bin/bash` would have looked equally correct and fixed nothing here: the box this was reported from runs `alpine:latest`, which has no bash. The fallback arm is the half that makes that box work, so both arms are asserted.

The container tier had the same bug for the same reason and is fixed by the same branch — `image_backed()` is what the check keys on, so a tier added later inherits it rather than needing someone to remember.

One trade-off, taken deliberately: the probe is an `sh -c`, and the container tee-shim keys on a `-c` cluster. A TTY session (every real one) passes straight through on the shim's `[ -t 1 ]` guard, but a *non-TTY* `box shell` with no command would now have the probe recorded and would carry `H5I_SHIM=1` into the session, leaving it unobserved. That case is an interactive shell with no terminal, and image-agnostic correctness is worth more than it.

Verified against the reported box (`env/human/demo-mvm`, microvm, `alpine:latest`): the session enters with no exec error, the guest argv is `-- /.msb/scripts/h5i-env /bin/sh -c if command -v bash …`, and probing the image in-box reports no bash and the fallback selecting `/bin/sh`. Suite: 198 core (2 new) + 4 env_integration shell cases, clippy clean.

Also documents the rule in containers/README.md, next to the rc-comes- from-the-image note it follows from — an image without a shell at all is now a stated requirement rather than a runtime surprise.