### PR TITLE
fix(sandbox): let a Claude box reach its own OAuth host

### DIFF
--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -3525,6 +3525,31 @@ resources = { mem = "2G", fsize = "100M", cpu = "5s" }
     }
 
     #[test]
+    fn agent_profiles_reach_their_own_auth_host() {
+        // Without the auth host an agent box is a one-session box: the seeded
+        // credential copy expires, the silent refresh has nowhere to go, and the
+        // in-box login that should repopulate it cannot complete either (the
+        // paste comes back "invalid token"). Regression guard — the API host
+        // alone looks sufficient right up until a session outlives its token.
+        let dir = tempfile::tempdir().unwrap();
+        for (name, auth_host, foreign) in [
+            ("agent-claude", "platform.claude.com", "auth.openai.com"),
+            ("agent-codex", "auth.openai.com", "platform.claude.com"),
+        ] {
+            let p = load_profile(dir.path(), name, Some(IsolationClaim::Supervised)).unwrap();
+            assert!(
+                p.net_egress.iter().any(|s| s == auth_host),
+                "{name} cannot refresh or log in without {auth_host}: {:?}",
+                p.net_egress
+            );
+            assert!(
+                !p.net_egress.iter().any(|s| s == foreign),
+                "{name} must not reach the other runtime's auth host"
+            );
+        }
+    }
+
+    #[test]
     fn agent_runtime_from_identity_maps_codex_else_claude() {
         assert_eq!(AgentRuntime::from_identity("codex"), AgentRuntime::Codex);
         assert_eq!(AgentRuntime::from_identity("Codex-2"), AgentRuntime::Codex);

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -258,9 +258,25 @@ impl AgentRuntime {
     /// The API endpoints this runtime is allowed to reach. Scoped per-runtime so
     /// a Claude box cannot egress to OpenAI (and so a stolen cross-runtime token
     /// would have nowhere allowlisted to go).
+    ///
+    /// Each runtime needs its **auth** host as well as its API host, or the box
+    /// is a one-session box: the credential copy `prepare_home_state` seeds it
+    /// with expires, the silent refresh has nowhere to go, and the in-box login
+    /// the credential-proxy design falls back to cannot complete either — the
+    /// paste is reported as an invalid token. Claude exchanges and refreshes at
+    /// `platform.claude.com/v1/oauth/token`; Codex at `auth.openai.com`.
+    ///
+    /// Granting the auth host is not a new capability class: the box already
+    /// holds the OAuth token, and `api.anthropic.com` already serves
+    /// `/api/oauth/claude_cli/create_api_key`. Where a host-side credential
+    /// exists the broker is still the better answer — `auth_proxy::engage`
+    /// scrubs the box copy and locks egress to the proxy alone, so none of these
+    /// hosts are reachable at all.
     pub(crate) fn egress(self) -> &'static [&'static str] {
         match self {
-            AgentRuntime::Claude => &["api.anthropic.com", "statsig.anthropic.com"],
+            AgentRuntime::Claude => {
+                &["api.anthropic.com", "platform.claude.com", "statsig.anthropic.com"]
+            }
             AgentRuntime::Codex => &["api.openai.com", "auth.openai.com", "chatgpt.com"],
         }
     }


### PR DESCRIPTION
## The bug

An agent box is a one-session box. `AgentRuntime::Claude.egress()` allowed `api.anthropic.com` and `statsig.anthropic.com`, but not the host Claude Code actually exchanges and refreshes OAuth tokens at.

`prepare_home_state` seeds the per-env `~/.claude` copy from the real HOME, expiry included. When that access token expires mid-session:

1. the silent refresh posts to `platform.claude.com/v1/oauth/token` and has nowhere to go,
2. Claude Code falls back to `/login`,
3. the pasted code is exchanged at the same unreachable host,
4. the user sees "invalid token" and reasonably concludes the box cannot find where credentials are stored.

It can. Storage was never the problem.

## Evidence

From inside a real supervised box (`profile = browser`):

```
api.anthropic.com   -> 404          (reachable)
platform.claude.com -> CURL_FAIL(6) (host does not resolve)
claude.ai           -> CURL_FAIL(6)
```

curl exit 6 is "couldn't resolve host". Supervised pins DNS with a hosts file, so a host outside the allowlist has no entry and no route.

Claude Code 2.1.223 does the exchange at `platform.claude.com/v1/oauth/token` and authorizes at `platform.claude.com/oauth/authorize`. `console.anthropic.com` has zero hits in the bundle, so this is not a host that moved recently under us; the OAuth host was never on the list.

## The change

`crates/h5i-sandbox/src/sandbox_policy.rs` adds `platform.claude.com` to the Claude allowlist. Codex has carried `auth.openai.com` all along, so this is the missing half of an existing pair, not a new grant shape.

It is also not a new capability class. The box already holds the OAuth token, and `api.anthropic.com` already serves `/api/oauth/claude_cli/create_api_key`. Where a host-side credential exists, `auth_proxy::engage` remains the better answer and is unaffected: it scrubs the box copy and locks egress to the proxy alone, so none of these hosts are reachable from that box at all.

`docs/credential-proxy-design.md` already documents the in-box login as the fallback when there is no host credential to broker. This makes that documented path actually reachable.

## Test

`agent_profiles_reach_their_own_auth_host`, table-driven over both runtimes: each reaches its own auth host, neither reaches the other's. The existing cross-runtime tests all use `.any(...)`, so nothing else needed touching.

`cargo test -p h5i-sandbox --lib`: 264 passed, 0 failed. `cargo clippy --workspace --all-targets`: clean. No generated manual to regenerate, since no `.md` lists the allowlist hosts and the CLI surface is unchanged.

## Rollout note for reviewers

`net_egress` feeds the resolved-policy TOML that `ResolvedPolicy::digest` hashes, so existing boxes stay pinned to their old digest and report drift rather than silently widening. Picking this up means a fresh box.

## Not covered

The interactive login was not driven end to end; that needs a paste in a live box. If it still fails after this, the next suspect is whether the CLI fetches `claude.ai/oauth/claude-code-client-metadata` itself rather than the server dereferencing it. That host remains blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)