### PR TITLE
perf(view): deflate terminal frames, unstarve the tick, unblock pacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +611,7 @@ dependencies = [
  "h5i-sandbox",
  "libc",
  "mime_guess",
+ "miniz_oxide",
  "openssl",
  "rust-embed",
  "serde",
@@ -1084,6 +1091,15 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]

--- a/crates/h5i-core/Cargo.toml
+++ b/crates/h5i-core/Cargo.toml
@@ -31,7 +31,7 @@ getrandom = "0.3"
 console = "0.16.2"
 libc = "0.2.186"
 
-# The terminal viewer (`termview`). All three are on the path between an
+# The terminal viewer (`termview`). All four are on the path between an
 # untrusted box and the host's terminal, so each is chosen for having a small,
 # auditable job rather than for features:
 #
@@ -42,9 +42,15 @@ libc = "0.2.186"
 # * `zune-jpeg` — a `#![forbid(unsafe_code)]` JPEG decoder. This one is the
 #   security-relevant pick: it parses bytes produced inside the box, so a
 #   memory-unsafe decoder here would hand the box the host process.
+# * `miniz_oxide` — zlib for the `o=z` frame payload. Pure Rust, and it only
+#   ever *compresses* here, so unlike the decoder it is not parsing anything the
+#   box produced. It earns its place on bandwidth alone: a frame fitted to a
+#   120x30 pane is 2.1 MiB of base64 raw RGB and 326 KiB deflated, which is the
+#   difference between a viewer that works over SSH and one that does not.
 sha1 = "0.10"
 base64 = "0.22"
 zune-jpeg = "0.5"
+miniz_oxide = "0.8"
 
 # The box console (`server`), all optional behind the `web` feature. Only
 # `tokio`'s listener and multi-thread runtime are used — the domain calls stay

--- a/crates/h5i-core/src/termview/kitty.rs
+++ b/crates/h5i-core/src/termview/kitty.rs
@@ -10,7 +10,7 @@
 //! the escape sequences. There is no path from the box's output to the host's
 //! PTY, which is the property a terminal viewer has to earn.
 //!
-//! Three choices in here follow from that, and each would be wrong in an
+//! Four choices in here follow from that, and each would be wrong in an
 //! ordinary image viewer:
 //!
 //! * **`q=2` on every render command.** The terminal answers graphics commands
@@ -25,7 +25,14 @@
 //!   and they are the fast path this module deliberately does not take yet:
 //!   they only work when the terminal is on this machine, and working over SSH
 //!   is half the point of a terminal viewer. Bytes are kept down by scaling the
-//!   image to the cells it will occupy instead (see [`super::image`]).
+//!   image to the cells it will occupy (see [`super::image`]) and by deflating
+//!   what is left ([`Encoding`]).
+//! * **Compression is probed, not assumed.** `o=z` is part of the protocol and
+//!   every implementation is expected to have it, but `q=2` means a terminal
+//!   that does not would fail *silently* — a blank pane and no diagnosis, which
+//!   is the one failure shape this viewer must not have. So the probe asks
+//!   twice, once raw and once deflated, and frames are compressed only when the
+//!   terminal said `OK` to the second question ([`accepts_zlib`]).
 //! * **Explicit deletion of the previous frame.** Every frame is a new image,
 //!   and a terminal asked to hold thousands of them will hold them. The
 //!   previous id is deleted *after* the new one is placed, so the viewport
@@ -42,6 +49,56 @@ const CHUNK: usize = 4096;
 /// its replacement exists, which is visible as a flicker on every frame.
 const IDS: [u32; 2] = [7311, 7312];
 
+/// zlib level for frame payloads.
+///
+/// Level 1, and the gap is not close. Measured through this path on a real
+/// decoded frame scaled to 891x504, which is what a 120x30 pane asks for:
+///
+/// | level | ratio | cost   |
+/// |-------|-------|--------|
+/// | 1     | 6.2x  | 3.6 ms |
+/// | 6     | 6.9x  | 21 ms  |
+/// | 9     | 7.0x  | 63 ms  |
+///
+/// Level 1 takes essentially all of the win. The other two spend a frame budget
+/// that also has to hold a JPEG decode and a box filter, to save a few percent
+/// of a payload that is already an order of magnitude smaller than it was.
+const ZLIB_LEVEL: u8 = 1;
+
+/// How a frame's pixels are encoded before base64.
+///
+/// Not a tuning knob: it records what *this terminal* answered to the probe.
+/// Raw is what a terminal always accepts and costs about six times the bytes,
+/// so it is the answer only when nothing told us otherwise.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Encoding {
+    /// Tightly packed 8-bit RGB, exactly as the decoder handed it over.
+    #[default]
+    Raw,
+    /// The same bytes, RFC 1950 deflated. `o=z` in the control block.
+    Zlib,
+}
+
+impl Encoding {
+    /// The control key this encoding adds, if any.
+    fn key(self) -> &'static str {
+        match self {
+            Encoding::Raw => "",
+            Encoding::Zlib => ",o=z",
+        }
+    }
+
+    /// Encode one frame's pixels for transmission.
+    fn apply(self, rgb: &[u8]) -> std::borrow::Cow<'_, [u8]> {
+        match self {
+            Encoding::Raw => std::borrow::Cow::Borrowed(rgb),
+            Encoding::Zlib => std::borrow::Cow::Owned(
+                miniz_oxide::deflate::compress_to_vec_zlib(rgb, ZLIB_LEVEL),
+            ),
+        }
+    }
+}
+
 /// Builds the escape sequences for successive frames.
 #[derive(Debug, Default)]
 pub struct Placer {
@@ -49,6 +106,8 @@ pub struct Placer {
     next: usize,
     /// The id currently on screen, if any.
     live: Option<u32>,
+    /// What this terminal accepts, from the probe.
+    encoding: Encoding,
 }
 
 /// Where and how large a frame should be drawn, in terminal cells.
@@ -63,8 +122,12 @@ pub struct Placement {
 }
 
 impl Placer {
-    pub fn new() -> Self {
-        Placer::default()
+    /// A placer for a terminal that encodes frames this way.
+    pub fn new(encoding: Encoding) -> Self {
+        Placer {
+            encoding,
+            ..Placer::default()
+        }
     }
 
     /// The full byte sequence that draws one RGB frame at `at`.
@@ -83,8 +146,8 @@ impl Placer {
         // the same spot without any further positioning.
         out.extend_from_slice(cursor_to(at.row, at.col).as_bytes());
 
-        let payload = base64_of(rgb);
-        for chunk in transmit_chunks(id, width, height, at.cols, at.rows, &payload) {
+        let payload = base64_of(&self.encoding.apply(rgb));
+        for chunk in transmit_chunks(id, width, height, at.cols, at.rows, &payload, self.encoding) {
             out.extend_from_slice(chunk.as_bytes());
         }
 
@@ -133,6 +196,7 @@ pub fn transmit_chunks(
     cols: u16,
     rows: u16,
     payload: &str,
+    encoding: Encoding,
 ) -> Vec<String> {
     let mut chunks: Vec<&str> = payload
         .as_bytes()
@@ -145,6 +209,7 @@ pub fn transmit_chunks(
     }
 
     let last = chunks.len() - 1;
+    let o = encoding.key();
     chunks
         .into_iter()
         .enumerate()
@@ -155,11 +220,13 @@ pub fn transmit_chunks(
                     // a=T   transmit and display in one command
                     // f=24  8-bit RGB, which is what the JPEG decoder hands us
                     // t=d   the payload is right here, not a path we hand over
-                    // s,v   source pixel dimensions
+                    // o=z   deflated, when the terminal said it accepts that
+                    // s,v   source pixel dimensions — of the *decompressed*
+                    //       pixels, which is how the terminal sizes its buffer
                     // c,r   the cell box to scale into
                     // C=1   leave the cursor alone, so the status line stays put
                     // q=2   no reply on stdin (see the module docs)
-                    "\x1b_Ga=T,f=24,t=d,i={id},s={width},v={height},c={cols},r={rows},C=1,q=2,m={more};{chunk}\x1b\\"
+                    "\x1b_Ga=T,f=24,t=d{o},i={id},s={width},v={height},c={cols},r={rows},C=1,q=2,m={more};{chunk}\x1b\\"
                 )
             } else {
                 format!("\x1b_Gm={more};{chunk}\x1b\\")
@@ -180,12 +247,23 @@ pub fn transmit_chunks(
 /// reply means yes, a device-attributes reply arriving *first* means the
 /// graphics query was silently dropped, which means no.
 ///
+/// It asks two questions rather than one. The second is the same pixel under
+/// `o=z`, and its answer is what licenses compressing frames: the render path
+/// suppresses replies, so a terminal that does not understand `o=z` would drop
+/// every frame in silence. Answering the raw query and erroring the compressed
+/// one is a perfectly good terminal — it just has to be sent more bytes.
+///
 /// `q=0` here, unlike every render command: this is the one place a reply is
 /// what we are after.
 pub fn probe_sequence() -> String {
     // A 1x1 RGB pixel, transmitted but not displayed (`a=q` is query-only).
-    let pixel = base64_of(&[0u8, 0, 0]);
-    format!("\x1b_Gi=1,s=1,v=1,a=q,t=d,f=24;{pixel}\x1b\\\x1b[c")
+    let raw = base64_of(&[0u8, 0, 0]);
+    let deflated = base64_of(&Encoding::Zlib.apply(&[0u8, 0, 0]));
+    format!(
+        "\x1b_Gi=1,s=1,v=1,a=q,t=d,f=24;{raw}\x1b\\\
+         \x1b_Gi=2,s=1,v=1,a=q,t=d,f=24,o=z;{deflated}\x1b\\\
+         \x1b[c"
+    )
 }
 
 /// What a terminal said in response to [`probe_sequence`].
@@ -208,14 +286,53 @@ pub fn classify_probe(seen: &[u8]) -> Support {
     if find(seen, b"\x1b_G").is_some() {
         return Support::Yes;
     }
-    // CSI ? ... c — the device-attributes reply, and our "nothing else is
-    // coming" marker.
-    if let Some(start) = find(seen, b"\x1b[?") {
-        if seen[start..].contains(&b'c') {
-            return Support::No;
-        }
+    if probe_done(seen) {
+        return Support::No;
     }
     Support::Undecided
+}
+
+/// Has the device-attributes reply arrived?
+///
+/// It is the probe's barrier: every terminal since the VT100 answers it, and it
+/// is queued behind both graphics queries, so its arrival means every answer
+/// this terminal intends to give has been given. The read loop stops on it
+/// rather than on the first graphics reply, because stopping early would mean
+/// deciding [`accepts_zlib`] before the second answer had been read.
+pub fn probe_done(seen: &[u8]) -> bool {
+    // CSI ? ... c
+    match find(seen, b"\x1b[?") {
+        Some(start) => seen[start..].contains(&b'c'),
+        None => false,
+    }
+}
+
+/// Did the terminal accept the deflated half of the probe?
+///
+/// Only an explicit `OK` against the compressed query's own id counts. Silence
+/// is not consent here: this decides whether every subsequent frame is sent in
+/// a form the terminal may not understand, and `q=2` means being wrong about it
+/// is a blank pane with nothing on stdin to explain it.
+pub fn accepts_zlib(seen: &[u8]) -> bool {
+    replies(seen)
+        .iter()
+        .any(|(control, message)| control.split(',').any(|k| k == "i=2") && message == "OK")
+}
+
+/// Split whatever arrived into `(control, message)` for each APC reply.
+fn replies(seen: &[u8]) -> Vec<(String, String)> {
+    let text = String::from_utf8_lossy(seen);
+    let mut rest: &str = &text;
+    let mut out = Vec::new();
+    while let Some(start) = rest.find("\x1b_G") {
+        rest = &rest[start + 3..];
+        let Some(end) = rest.find("\x1b\\") else { break };
+        let (block, after) = (&rest[..end], &rest[end + 2..]);
+        rest = after;
+        let (control, message) = block.split_once(';').unwrap_or((block, ""));
+        out.push((control.to_string(), message.to_string()));
+    }
+    out
 }
 
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -241,7 +358,7 @@ mod tests {
     fn every_render_command_silences_the_terminals_reply() {
         // The reply would arrive on stdin, in the middle of the keystrokes this
         // viewer is translating into page input. `q=2` is not a preference.
-        let mut p = Placer::new();
+        let mut p = Placer::new(Encoding::Zlib);
         let frame = p.draw(&[0u8; 12], 2, 2, Placement { row: 2, col: 1, cols: 10, rows: 5 });
         let text = String::from_utf8(frame).unwrap();
         for seq in text.split_inclusive("\x1b\\") {
@@ -256,13 +373,14 @@ mod tests {
         // Fixed by the protocol: control keys on continuation chunks are an
         // error, and a chunk over 4096 bytes is rejected outright.
         let payload = "A".repeat(CHUNK * 2 + 10);
-        let chunks = transmit_chunks(9, 4, 4, 20, 10, &payload);
+        let chunks = transmit_chunks(9, 4, 4, 20, 10, &payload, Encoding::Raw);
         assert_eq!(chunks.len(), 3);
 
         let first = control_of(&chunks[0]);
         assert!(first.contains("a=T"), "{first}");
         assert!(first.contains("f=24"), "{first}");
         assert!(first.contains("t=d"), "{first}");
+        assert!(!first.contains("o=z"), "raw must not claim compression: {first}");
         assert!(first.contains("s=4,v=4"), "{first}");
         assert!(first.contains("c=20,r=10"), "{first}");
         assert!(first.contains("C=1"), "the cursor must not move: {first}");
@@ -279,15 +397,107 @@ mod tests {
 
     #[test]
     fn a_single_chunk_frame_ends_the_command_immediately() {
-        let chunks = transmit_chunks(1, 1, 1, 1, 1, "AAAA");
+        let chunks = transmit_chunks(1, 1, 1, 1, 1, "AAAA", Encoding::Raw);
         assert_eq!(chunks.len(), 1);
         assert!(control_of(&chunks[0]).ends_with("m=0"));
+    }
+
+    /// Reassemble a drawn frame's payload: every chunk's base64, concatenated
+    /// and decoded, which is exactly what the terminal does with it.
+    fn payload_of(frame: &[u8]) -> Vec<u8> {
+        use base64::Engine as _;
+        let text = String::from_utf8(frame.to_vec()).unwrap();
+        let mut b64 = String::new();
+        for block in text.split("\x1b_G").skip(1) {
+            let block = block.split("\x1b\\").next().unwrap_or_default();
+            let Some((control, body)) = block.split_once(';') else { continue };
+            // Transmission chunks only: the trailing delete carries no payload.
+            if control.contains("a=d") {
+                continue;
+            }
+            b64.push_str(body);
+        }
+        base64::engine::general_purpose::STANDARD.decode(&b64).unwrap()
+    }
+
+    #[test]
+    fn a_compressed_frame_inflates_back_to_exactly_the_pixels_it_was_given() {
+        // The assertion that matters. Everything else about compression is a
+        // control key being present; this is whether the terminal, doing what
+        // the protocol says, gets the frame back. `q=2` means being wrong here
+        // is a blank pane with nothing on stdin to explain it.
+        let (w, h) = (64u32, 48u32);
+        let rgb: Vec<u8> = (0..(w * h * 3) as usize)
+            .map(|i| ((i * 7 + i / 191) % 256) as u8)
+            .collect();
+        let at = Placement { row: 3, col: 1, cols: 8, rows: 4 };
+
+        let mut z = Placer::new(Encoding::Zlib);
+        let compressed = z.draw(&rgb, w, h, at);
+        let inflated =
+            miniz_oxide::inflate::decompress_to_vec_zlib(&payload_of(&compressed)).unwrap();
+        assert_eq!(inflated, rgb, "the frame must survive the round trip");
+
+        // Raw is unchanged and still the byte-for-byte pixels, so the two
+        // encodings are the same frame said two ways.
+        let mut r = Placer::new(Encoding::Raw);
+        let raw = r.draw(&rgb, w, h, at);
+        assert_eq!(payload_of(&raw), rgb);
+
+        // `s` and `v` describe the *decompressed* image. A terminal sizes its
+        // buffer from them and then inflates into it, so quietly reporting the
+        // payload's length instead would be a frame that decodes into nothing.
+        let control = String::from_utf8(compressed.clone())
+            .unwrap()
+            .split_once("\x1b_G")
+            .unwrap()
+            .1
+            .split(';')
+            .next()
+            .unwrap()
+            .to_string();
+        assert!(control.contains("o=z"), "{control}");
+        assert!(control.contains("s=64,v=48"), "{control}");
+
+        // And it is the smaller of the two, which is the entire reason the key
+        // is there.
+        assert!(
+            compressed.len() < raw.len(),
+            "compressed {} vs raw {}",
+            compressed.len(),
+            raw.len()
+        );
+    }
+
+    #[test]
+    fn compression_is_used_only_when_the_terminal_said_ok_to_it() {
+        // The probe asks twice. Silence about the second question, or an error
+        // against it, means raw frames — a terminal that draws is not a
+        // terminal that inflates, and `q=2` would make the difference invisible.
+        assert!(accepts_zlib(b"\x1b_Gi=1;OK\x1b\\\x1b_Gi=2;OK\x1b\\"));
+        assert!(!accepts_zlib(b"\x1b_Gi=1;OK\x1b\\\x1b_Gi=2;EINVAL:o\x1b\\"));
+        assert!(!accepts_zlib(b"\x1b_Gi=1;OK\x1b\\"), "no answer is not a yes");
+        assert!(!accepts_zlib(b""));
+        // The id must match exactly: `i=2` answering is not `i=21` answering,
+        // and a substring test would confuse them.
+        assert!(!accepts_zlib(b"\x1b_Gi=21;OK\x1b\\"));
+        // A reply carrying more keys than the id is still that reply.
+        assert!(accepts_zlib(b"\x1b_GI=7,i=2;OK\x1b\\"));
+    }
+
+    #[test]
+    fn the_probe_reads_on_until_the_device_attributes_reply() {
+        // Stopping at the first graphics reply would decide compression before
+        // the compressed query had been answered — always "no", every time.
+        assert!(!probe_done(b"\x1b_Gi=1;OK\x1b\\"));
+        assert!(!probe_done(b"\x1b_Gi=1;OK\x1b\\\x1b[?"), "reply still arriving");
+        assert!(probe_done(b"\x1b_Gi=1;OK\x1b\\\x1b[?62;1;6c"));
     }
 
     #[test]
     fn the_previous_frame_is_deleted_only_after_the_new_one_is_placed() {
         // Deleting first is a blink on every single frame.
-        let mut p = Placer::new();
+        let mut p = Placer::new(Encoding::Raw);
         let at = Placement { row: 2, col: 1, cols: 8, rows: 4 };
 
         let first = String::from_utf8(p.draw(&[0u8; 3], 1, 1, at)).unwrap();
@@ -312,7 +522,7 @@ mod tests {
 
     #[test]
     fn the_frame_is_positioned_before_it_is_drawn() {
-        let mut p = Placer::new();
+        let mut p = Placer::new(Encoding::Raw);
         let seq = String::from_utf8(p.draw(&[0u8; 3], 1, 1, Placement { row: 3, col: 1, cols: 2, rows: 2 })).unwrap();
         // Row 3, because row 1 is the status line the viewer owns and row 2 is
         // the separator. The image must never start at row 1.
@@ -321,7 +531,7 @@ mod tests {
 
     #[test]
     fn leaving_removes_the_last_frame() {
-        let mut p = Placer::new();
+        let mut p = Placer::new(Encoding::Raw);
         assert!(p.clear().is_empty(), "nothing drawn, nothing to clear");
         p.draw(&[0u8; 3], 1, 1, Placement { row: 1, col: 1, cols: 1, rows: 1 });
         let out = String::from_utf8(p.clear()).unwrap();
@@ -356,5 +566,20 @@ mod tests {
         assert!(p.contains("a=q"), "query only, nothing is displayed: {p:?}");
         assert!(!p.contains("q=2"), "this is the one place we want an answer");
         assert!(p.ends_with("\x1b[c"), "the device-attributes barrier: {p:?}");
+
+        // Two questions, and the second one has to actually be compressed —
+        // asking about `o=z` with a raw payload would be answered `OK` by a
+        // terminal that cannot inflate anything.
+        assert_eq!(p.matches("a=q").count(), 2, "raw and deflated: {p:?}");
+        let deflated = p.split("i=2,").nth(1).unwrap();
+        assert!(deflated.contains("o=z"), "{deflated:?}");
+        let body = deflated.split_once(';').unwrap().1.split("\x1b").next().unwrap();
+        use base64::Engine as _;
+        let bytes = base64::engine::general_purpose::STANDARD.decode(body).unwrap();
+        assert_eq!(
+            miniz_oxide::inflate::decompress_to_vec_zlib(&bytes).unwrap(),
+            vec![0u8, 0, 0],
+            "the compressed query must carry a real deflate stream"
+        );
     }
 }

--- a/crates/h5i-core/src/termview/mod.rs
+++ b/crates/h5i-core/src/termview/mod.rs
@@ -112,6 +112,59 @@ pub struct Options {
     pub assume_graphics: bool,
 }
 
+/// The render loop's own clock.
+///
+/// It is a type rather than two local variables so that the tick cannot be
+/// attached to the socket again by accident, which is what it was: the tick was
+/// whatever `recv_timeout` *expiring* meant, so a box sending frames faster than
+/// [`TICK`] suppressed it entirely. At the default 10 fps a frame lands every
+/// 100 ms and the 250 ms timeout never elapses, so the status line stopped
+/// refreshing, a resize went unnoticed and a lone Escape was never flushed —
+/// all of it on exactly the pages someone is watching because they are moving.
+#[cfg(unix)]
+struct Ticker {
+    /// When the next tick is owed.
+    next: Instant,
+    /// When the keyboard was last heard from. Tracked apart from the tick
+    /// because "the input has gone quiet" is a claim about the keyboard, and
+    /// letting the frame rate answer it is how the bug above got in.
+    last_input: Instant,
+}
+
+#[cfg(unix)]
+impl Ticker {
+    fn start(now: Instant) -> Ticker {
+        Ticker {
+            next: now + TICK,
+            last_input: now,
+        }
+    }
+
+    /// How long the loop may block waiting for the next event.
+    fn wait(&self, now: Instant) -> Duration {
+        self.next.saturating_duration_since(now)
+    }
+
+    fn saw_input(&mut self, now: Instant) {
+        self.last_input = now;
+    }
+
+    /// `Some(quiet)` when a tick is owed. `quiet` says the keyboard has been
+    /// still for a whole tick, which is the only way to tell a lone `ESC` from
+    /// the start of a sequence nobody finished.
+    ///
+    /// The next tick is scheduled from *now* rather than from the deadline that
+    /// just passed, so a loop that falls behind ticks less often instead of
+    /// owing a burst it then has to catch up on.
+    fn due(&mut self, now: Instant) -> Option<bool> {
+        if now < self.next {
+            return None;
+        }
+        self.next = now + TICK;
+        Some(now.duration_since(self.last_input) >= TICK)
+    }
+}
+
 /// Everything the render loop is waiting on, from whichever thread saw it.
 #[cfg(unix)]
 enum Ev {
@@ -156,9 +209,15 @@ pub fn run(opts: Options) -> Result<(), H5iError> {
     })?;
 
     let mut guard = term::Guard::enter(stdin).map_err(H5iError::Io)?;
-    if !opts.assume_graphics {
-        probe_graphics(stdin)?;
-    }
+    // Skipping the probe means skipping the answer about compression too. Raw
+    // is the conservative choice and the only honest one: the flag exists for
+    // the case where we were wrong about this terminal, so it must not then
+    // assume something else about it. Frames cost about six times as much.
+    let encoding = if opts.assume_graphics {
+        kitty::Encoding::Raw
+    } else {
+        probe_graphics(stdin)?
+    };
 
     // The socket is a descriptor this process owns, handed back from a fork
     // that entered the box's namespaces. Nothing is listening anywhere.
@@ -234,7 +293,7 @@ pub fn run(opts: Options) -> Result<(), H5iError> {
     // Scoped so the app releases its borrow of the terminal guard before the
     // guard itself is dropped and the terminal is restored.
     let (outcome, bytes_in, input_sent) = {
-        let mut app = App::new(&opts, &mut guard);
+        let mut app = App::new(&opts, &mut guard, encoding);
         let outcome = app.pump(rx, &mut writer);
 
         // Leave the page as we found it. A viewer that exits still holding the
@@ -288,31 +347,39 @@ pub fn run(_opts: Options) -> Result<(), H5iError> {
     ))
 }
 
-/// Ask the terminal whether it can draw images, and refuse politely if not.
+/// Ask the terminal whether it can draw images and whether it accepts deflated
+/// pixels, and refuse politely if it cannot draw at all.
+///
+/// The read runs to the device-attributes reply rather than stopping at the
+/// first graphics answer. Both questions are in flight, and returning on the
+/// first would decide compression before its answer had arrived — which is not
+/// a slow path, it is a permanently wrong one.
 #[cfg(unix)]
-fn probe_graphics(fd: std::os::fd::RawFd) -> Result<(), H5iError> {
+fn probe_graphics(fd: std::os::fd::RawFd) -> Result<kitty::Encoding, H5iError> {
     let mut out = std::io::stdout();
     let _ = out.write_all(kitty::probe_sequence().as_bytes());
     let _ = out.flush();
 
     let mut seen = Vec::new();
     let deadline = Instant::now() + PROBE_TIMEOUT;
-    while Instant::now() < deadline {
+    while Instant::now() < deadline && !kitty::probe_done(&seen) {
         if !term::wait_readable(fd, Duration::from_millis(50)) {
             continue;
         }
         if term::read_available(fd, &mut seen).unwrap_or(0) == 0 {
             break;
         }
-        match kitty::classify_probe(&seen) {
-            kitty::Support::Yes => return Ok(()),
-            kitty::Support::No => return Err(unsupported()),
-            kitty::Support::Undecided => {}
-        }
     }
-    // A terminal that answered neither question. Treating silence as support
-    // would fill someone's screen with base64.
-    Err(unsupported())
+
+    match kitty::classify_probe(&seen) {
+        kitty::Support::Yes if kitty::accepts_zlib(&seen) => Ok(kitty::Encoding::Zlib),
+        // It draws, it just will not inflate. Six times the bytes, and every
+        // one of them arrives.
+        kitty::Support::Yes => Ok(kitty::Encoding::Raw),
+        // A terminal that said no, or that answered neither question. Treating
+        // silence as support would fill someone's screen with base64.
+        kitty::Support::No | kitty::Support::Undecided => Err(unsupported()),
+    }
 }
 
 #[cfg(unix)]
@@ -357,12 +424,12 @@ struct App<'a> {
 
 #[cfg(unix)]
 impl<'a> App<'a> {
-    fn new(opts: &Options, guard: &'a mut term::Guard) -> App<'a> {
+    fn new(opts: &Options, guard: &'a mut term::Guard, encoding: kitty::Encoding) -> App<'a> {
         let size = guard.size().or_fallback();
         App {
             env_dir: opts.env_dir.clone(),
             guard,
-            placer: kitty::Placer::new(),
+            placer: kitty::Placer::new(encoding),
             mode: Mode::View,
             last_frame: None,
             mapping: None,
@@ -381,10 +448,15 @@ impl<'a> App<'a> {
 
     /// Run until the human leaves or the box stops streaming. Returns the
     /// reason the stream ended, if it ended badly.
+    ///
+    /// The tick runs on [`Ticker`]'s deadline rather than on the receive
+    /// timeout, which is what keeps a page that never stops sending from
+    /// freezing the status line and the resize check.
     fn pump(&mut self, rx: mpsc::Receiver<Ev>, writer: &mut impl Write) -> Option<String> {
         self.draw_status();
+        let mut ticker = Ticker::start(Instant::now());
         loop {
-            match rx.recv_timeout(TICK) {
+            match rx.recv_timeout(ticker.wait(Instant::now())) {
                 Ok(Ev::Net(msg)) => {
                     if let Some(err) = self.on_net(msg, writer) {
                         return Some(err);
@@ -392,21 +464,22 @@ impl<'a> App<'a> {
                 }
                 Ok(Ev::NetDone(why)) => return why,
                 Ok(Ev::Input(bytes)) => {
+                    ticker.saw_input(Instant::now());
                     self.pending.extend_from_slice(&bytes);
                     if self.on_input(false, writer) {
                         return None;
                     }
                 }
                 Ok(Ev::InputDone) => return None,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    // Quiet input: a lone ESC is now the Escape key rather than
-                    // the start of a sequence nobody finished.
-                    if self.on_input(true, writer) {
-                        return None;
-                    }
-                    self.on_tick();
-                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
                 Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+            }
+
+            if let Some(quiet) = ticker.due(Instant::now()) {
+                if self.on_input(quiet, writer) {
+                    return None;
+                }
+                self.on_tick();
             }
         }
     }
@@ -695,6 +768,50 @@ mod tests {
         // became 0 the page would be drawn over the one row it must never be
         // able to touch.
         assert_eq!(CHROME_ROWS, 2, "row one is the status line, row two separates it");
+    }
+
+    #[test]
+    fn a_page_that_never_stops_sending_cannot_starve_the_tick() {
+        // The regression this is here for. Frames every 100 ms, which is what
+        // the default `--fps 10` produces. With the tick hung off the receive
+        // timeout, a 250 ms timeout next to a 100 ms frame interval never
+        // elapsed and the tick simply never ran — no status refresh, no resize
+        // check, for as long as the page kept moving.
+        let t0 = Instant::now();
+        let mut ticker = Ticker::start(t0);
+
+        let mut ticks = 0;
+        for n in 1..=10u32 {
+            let now = t0 + Duration::from_millis(100 * u64::from(n));
+            // The loop must never block past the next deadline either.
+            assert!(ticker.wait(now) <= TICK, "wait overshoots the deadline");
+            if ticker.due(now).is_some() {
+                ticks += 1;
+            }
+        }
+        // Ticks land on event boundaries and are rescheduled from where they
+        // actually ran, so one second of 100 ms frames owes three or four of
+        // them. The number is not the point. Zero was.
+        assert!((3..=4).contains(&ticks), "one second of frames owed {ticks} ticks");
+    }
+
+    #[test]
+    fn quiet_input_is_a_claim_about_the_keyboard_and_not_about_the_frame_rate() {
+        let t0 = Instant::now();
+        let mut ticker = Ticker::start(t0);
+
+        // A keystroke at 200 ms. The tick at 250 ms is only 50 ms later, so a
+        // lone ESC sitting in the buffer might still be the start of a sequence
+        // whose tail has not arrived: it must not be flushed as Escape yet.
+        ticker.saw_input(t0 + Duration::from_millis(200));
+        assert_eq!(ticker.due(t0 + Duration::from_millis(250)), Some(false));
+
+        // By the next tick the keyboard has been still for a whole one, so the
+        // ESC is the Escape key.
+        assert_eq!(ticker.due(t0 + Duration::from_millis(500)), Some(true));
+
+        // And nothing is owed before the deadline.
+        assert_eq!(ticker.due(t0 + Duration::from_millis(600)), None);
     }
 
     #[test]

--- a/crates/h5i-core/src/view.rs
+++ b/crates/h5i-core/src/view.rs
@@ -517,9 +517,27 @@ pub enum FrameVerdict {
     /// Connection management: forwarded regardless of who holds the lock, or
     /// the socket would stall and time out while a human watches.
     Control,
+    /// A request about frame *delivery* — how fast, and how many in flight.
+    /// Forwarded regardless of the lock, because it drives nothing on the page
+    /// and gating it breaks watching, which never needed the lock.
+    Pacing,
     /// Actual input — a click, a keystroke. Forwarded only for the lock holder.
     Input,
 }
+
+/// The two message names that ask about delivery rather than about the page.
+///
+/// An allowlist of exact strings, and it has to stay one. The reason
+/// [`classify_opcode`] refuses to look at payloads is that guessing "probably
+/// harmless" is how gates get bypassed; the answer to a message that genuinely
+/// must pass is not to guess more loosely but to *name* it.
+const PACING_MESSAGES: [&str; 2] = ["config", "ack"];
+
+/// Largest text frame worth parsing to see whether it is a pacing message.
+/// `{"type":"config","maxFps":30,"pacing":"ack"}` is 44 bytes; anything in this
+/// neighbourhood is generous, and it stops a hostile client from making the
+/// forward parse a megabyte of JSON per frame for free.
+const MAX_PACING_FRAME: usize = 4096;
 
 /// Classify a frame by its opcode.
 ///
@@ -539,11 +557,55 @@ pub fn classify_opcode(opcode: u8) -> FrameVerdict {
     }
 }
 
-/// Read one WebSocket frame from `r`, returning its opcode and the exact bytes
-/// as they arrived (so a forwarded frame is byte-identical to the original).
+/// Classify a frame, looking at the payload only far enough to spot the two
+/// messages that must not be gated.
+///
+/// Gating those two is not a conservative default, it is a broken viewer, and
+/// it was: the page asks for a frame-rate cap the moment it connects, that ask
+/// is a text frame, every text frame was `Input`, and a box is agent-held by
+/// default — so the cap was dropped on essentially every session and the box
+/// streamed uncapped. Silent, because a dropped `config` looks exactly like a
+/// `config` that was honoured. It is also what blocks ack pacing on this path
+/// entirely: acks would be dropped too, and frames would simply stop.
+pub fn classify(opcode: u8, fin: bool, payload: &[u8]) -> FrameVerdict {
+    if classify_opcode(opcode) == FrameVerdict::Control {
+        return FrameVerdict::Control;
+    }
+    // Text only, and only a whole message. A fragment cannot be judged from the
+    // fragment in hand, so it is input.
+    if opcode == 0x1 && fin && payload.len() <= MAX_PACING_FRAME && is_pacing(payload) {
+        return FrameVerdict::Pacing;
+    }
+    FrameVerdict::Input
+}
+
+fn is_pacing(payload: &[u8]) -> bool {
+    let Ok(v) = serde_json::from_slice::<serde_json::Value>(payload) else {
+        return false;
+    };
+    v.get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|t| PACING_MESSAGES.contains(&t))
+}
+
+/// One frame from the client, as read.
+struct ClientFrame {
+    opcode: u8,
+    /// The final fragment of its message? A partial message cannot be judged
+    /// from the part in hand.
+    fin: bool,
+    /// The exact bytes as they arrived, so a forwarded frame is byte-identical
+    /// to the original — mask and all.
+    raw: Vec<u8>,
+    /// The same payload with the client's mask removed, which is the only form
+    /// [`classify`] can read.
+    payload: Vec<u8>,
+}
+
+/// Read one WebSocket frame from `r`.
 ///
 /// `None` at a clean end of stream; an error for a truncated or absurd frame.
-fn read_frame(r: &mut impl Read) -> std::io::Result<Option<(u8, Vec<u8>)>> {
+fn read_frame(r: &mut impl Read) -> std::io::Result<Option<ClientFrame>> {
     let mut head = [0u8; 2];
     match r.read_exact(&mut head) {
         Ok(()) => {}
@@ -552,6 +614,7 @@ fn read_frame(r: &mut impl Read) -> std::io::Result<Option<(u8, Vec<u8>)>> {
     }
     let mut raw = head.to_vec();
     let opcode = head[0] & 0x0f;
+    let fin = head[0] & 0x80 != 0;
     let masked = head[1] & 0x80 != 0;
     let len7 = head[1] & 0x7f;
 
@@ -578,15 +641,26 @@ fn read_frame(r: &mut impl Read) -> std::io::Result<Option<(u8, Vec<u8>)>> {
             "oversized websocket frame",
         ));
     }
+    let mut key = [0u8; 4];
     if masked {
-        let mut key = [0u8; 4];
         r.read_exact(&mut key)?;
         raw.extend_from_slice(&key);
     }
     let mut payload = vec![0u8; payload_len as usize];
     r.read_exact(&mut payload)?;
+    // Appended before unmasking: what is forwarded is what arrived.
     raw.extend_from_slice(&payload);
-    Ok(Some((opcode, raw)))
+    if masked {
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b ^= key[i % 4];
+        }
+    }
+    Ok(Some(ClientFrame {
+        opcode,
+        fin,
+        raw,
+        payload,
+    }))
 }
 
 /// Cap on a single inbound frame. Input events are tiny; this only has to be
@@ -599,6 +673,10 @@ const MAX_FRAME: u64 = 1 << 20;
 /// Dropping rather than closing is deliberate. A human who clicks before taking
 /// control should see nothing happen and still have a live viewer, not a
 /// connection that died on them.
+///
+/// Control frames and the two pacing messages pass whoever holds the lock: one
+/// keeps the socket alive, the other keeps frames arriving at a rate the viewer
+/// can draw. Neither touches the page. See [`classify`].
 ///
 /// Returns how many **input** frames actually reached the page. That count is
 /// the honest answer to "did a human drive this box?", and it is worth
@@ -618,12 +696,13 @@ pub fn pump_input(
                 pump.error = Some(e.to_string());
                 return pump;
             }
-            Ok(Some((opcode, raw))) => {
-                let is_input = classify_opcode(opcode) == FrameVerdict::Input;
+            Ok(Some(frame)) => {
+                let is_input =
+                    classify(frame.opcode, frame.fin, &frame.payload) == FrameVerdict::Input;
                 let allowed = !is_input
                     || crate::control::read(env_dir).holder == crate::control::Holder::Human;
                 if allowed {
-                    if let Err(e) = to_box.write_all(&raw).and_then(|()| to_box.flush()) {
+                    if let Err(e) = to_box.write_all(&frame.raw).and_then(|()| to_box.flush()) {
                         pump.error = Some(e.to_string());
                         return pump;
                     }
@@ -1137,6 +1216,67 @@ mod tests {
     }
 
     #[test]
+    fn asking_about_frame_delivery_is_not_input_and_is_never_gated() {
+        // The bug this exists to pin. The page sends `config` the moment it
+        // connects, a box is agent-held by default, and every text frame used
+        // to be input — so the frame-rate cap was dropped on essentially every
+        // session and nothing anywhere said so.
+        let td = TempDir::new().unwrap();
+        let config = br#"{"type":"config","maxFps":30,"pacing":"ack"}"#;
+        let ack = br#"{"type":"ack","seq":41}"#;
+
+        let mut input = Vec::new();
+        input.extend_from_slice(&client_frame(0x1, config));
+        input.extend_from_slice(&client_frame(0x1, ack));
+        input.extend_from_slice(&client_frame(0x1, br#"{"type":"input_mouse","x":1}"#));
+
+        let mut forwarded = Vec::new();
+        let pumped = pump_input(&input[..], &mut forwarded, td.path());
+
+        let mut expected = client_frame(0x1, config);
+        expected.extend_from_slice(&client_frame(0x1, ack));
+        assert_eq!(forwarded, expected, "pacing passes, the click does not");
+        // And neither is counted as a human driving the box. Only the click
+        // would have been, and it was dropped.
+        assert_eq!(pumped.input_frames, 0);
+    }
+
+    #[test]
+    fn the_pacing_allowlist_is_two_exact_names_and_nothing_near_them() {
+        let whole = |p: &[u8]| classify(0x1, true, p);
+        assert_eq!(whole(br#"{"type":"config","maxFps":10}"#), FrameVerdict::Pacing);
+        assert_eq!(whole(br#"{"type":"ack","seq":1}"#), FrameVerdict::Pacing);
+
+        // Everything else is input, including things that merely mention the
+        // allowed names. An allowlist that matches substrings is not one.
+        assert_eq!(whole(br#"{"type":"input_keyboard","key":"config"}"#), FrameVerdict::Input);
+        assert_eq!(whole(br#"{"type":"configure"}"#), FrameVerdict::Input);
+        assert_eq!(whole(br#"{"type":"input_mouse"}"#), FrameVerdict::Input);
+        assert_eq!(whole(b"not json"), FrameVerdict::Input);
+        assert_eq!(whole(b""), FrameVerdict::Input);
+        assert_eq!(whole(br#"{"no":"type"}"#), FrameVerdict::Input);
+        // A null or non-string type must not panic its way past the gate.
+        assert_eq!(whole(br#"{"type":null}"#), FrameVerdict::Input);
+        assert_eq!(whole(br#"{"type":7}"#), FrameVerdict::Input);
+
+        // Binary is never pacing, whatever it contains.
+        assert_eq!(classify(0x2, true, br#"{"type":"ack"}"#), FrameVerdict::Input);
+        // Nor is a fragment: the rest of the message has not been seen, and a
+        // judgement on a prefix is a judgement on nothing.
+        assert_eq!(classify(0x1, false, br#"{"type":"ack"}"#), FrameVerdict::Input);
+        assert_eq!(classify(0x0, true, br#"{"type":"ack"}"#), FrameVerdict::Input);
+
+        // A payload too large to be a pacing message is not parsed at all.
+        let mut fat = br#"{"type":"ack","pad":""#.to_vec();
+        fat.resize(MAX_PACING_FRAME + 64, b'x');
+        fat.extend_from_slice(br#""}"#);
+        assert_eq!(whole(&fat), FrameVerdict::Input);
+
+        // And control frames are still control, whatever they carry.
+        assert_eq!(classify(0x9, true, b"ping"), FrameVerdict::Control);
+    }
+
+    #[test]
     fn input_is_dropped_while_the_agent_holds_control() {
         let td = TempDir::new().unwrap();
         // A fresh box is agent-held.
@@ -1252,6 +1392,25 @@ mod tests {
         assert!(page.contains("clickCount"), "{}", "a press needs a click count");
         assert!(page.contains("mousePressed") && page.contains("mouseReleased"));
         assert!(page.contains("windowsVirtualKeyCode"));
+    }
+
+    #[test]
+    fn the_web_viewer_decodes_off_the_main_thread_and_paints_the_newest_frame() {
+        // Both halves of what makes the page smooth, pinned because the page is
+        // a string in this file and nothing else compiles it. Decoding through
+        // a `data:` URL and an `Image` element put a 70 KB string parse and a
+        // decode on the main thread for every frame; painting on arrival queued
+        // frames a slow tab could never catch up with.
+        let page = viewer_page(crate::control::Holder::Agent);
+        assert!(page.contains("createImageBitmap"), "frames must decode off the main thread");
+        assert!(page.contains("requestAnimationFrame"), "frames must paint on a frame boundary");
+        assert!(
+            !page.contains("data:image/jpeg;base64,"),
+            "a data URL per frame is the shape this replaced"
+        );
+        // Decoded pixels are held by the bitmap; a session that never closes
+        // them grows without bound.
+        assert!(page.contains(".close()"), "decoded frames must be released");
     }
 
     #[test]

--- a/crates/h5i-core/src/view.rs
+++ b/crates/h5i-core/src/view.rs
@@ -1411,6 +1411,16 @@ mod tests {
         // Decoded pixels are held by the bitmap; a session that never closes
         // them grows without bound.
         assert!(page.contains(".close()"), "decoded frames must be released");
+
+        // Dropping has to happen before the decode as well as after it. The box
+        // does not wait for this page, so a decode started per arriving frame
+        // queues jobs and their blobs for as long as decoding is slower than the
+        // frame rate — and that version still *looks* like it drops frames,
+        // because it does, one stage too late to matter.
+        assert!(
+            page.contains("queuedBytes") && page.contains("decoding"),
+            "only the newest undecoded frame may be held, and one decode at a time"
+        );
     }
 
     #[test]

--- a/crates/h5i-core/src/viewer.html
+++ b/crates/h5i-core/src/viewer.html
@@ -44,7 +44,10 @@
 const params = new URLSearchParams(location.search);
 const token = params.get("token") || "";
 const canvas = document.getElementById("screen");
-const ctx = canvas.getContext("2d");
+// `alpha: false` because a page is opaque and compositing a transparent layer
+// every frame is work for nothing. `desynchronized` lets the browser skip a
+// compositor round trip, which is latency a person driving the page feels.
+const ctx = canvas.getContext("2d", { alpha: false, desynchronized: true });
 const statusEl = document.getElementById("status");
 const urlEl = document.getElementById("url");
 
@@ -60,7 +63,11 @@ function connect() {
   ws.binaryType = "arraybuffer";
   ws.onopen = () => {
     statusEl.textContent = "connected";
-    // Ask for a frame rate rather than taking whatever the box produces.
+    // Ask for a frame rate rather than taking whatever the box produces. This
+    // is a `config` message, and the forward has to let it past the control
+    // lock for it to mean anything — it did not, for a while, and the cap was
+    // being dropped on every agent-held session in silence. See `classify` in
+    // `view.rs`.
     send({ type: "config", maxFps: 30, pacing: "push" });
   };
   ws.onclose = () => { statusEl.textContent = "disconnected"; setTimeout(connect, 1500); };
@@ -72,7 +79,7 @@ function connect() {
     if (typeof ev.data === "string") {
       let msg;
       try { msg = JSON.parse(ev.data); } catch { return; }
-      if (msg.type === "frame" && msg.data) draw("data:image/jpeg;base64," + msg.data);
+      if (msg.type === "frame" && msg.data) draw(bytesOfBase64(msg.data));
       else if (msg.type === "status") {
         if (msg.viewportWidth) viewport = { w: msg.viewportWidth, h: msg.viewportHeight };
         statusEl.textContent = msg.screencasting ? "connected" : "not streaming";
@@ -84,22 +91,58 @@ function connect() {
       }
       return;
     }
-    const blob = new Blob([ev.data], { type: "image/jpeg" });
-    const url = URL.createObjectURL(blob);
-    draw(url, () => URL.revokeObjectURL(url));
+    draw(new Uint8Array(ev.data));
   };
 }
 
-function draw(src, done) {
-  const img = new Image();
-  img.onload = () => {
-    if (canvas.width !== img.width || canvas.height !== img.height) {
-      canvas.width = img.width; canvas.height = img.height;
+function bytesOfBase64(b64) {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+// Frames are decoded off the main thread and painted at most once per animation
+// frame. Both halves matter, and the shape they replace was the reason the
+// viewer stuttered.
+//
+// `createImageBitmap` decodes on a worker the browser owns; the previous
+// `new Image()` with a `data:` URL built a ~70 KB string, parsed a URL and
+// decoded on the main thread, per frame, and allocated a fresh element to do
+// it. And painting on arrival means a tab that cannot keep up queues every
+// frame it was sent; painting on `requestAnimationFrame` means it draws the
+// newest one and drops the rest, which is what "latest frame wins" has to mean
+// on this side of the socket too. A hidden tab decodes nothing at all.
+let pending = null;   // the newest frame not yet painted
+let scheduled = false;
+
+function draw(bytes) {
+  if (document.hidden) return;
+  createImageBitmap(new Blob([bytes], { type: "image/jpeg" })).then((bitmap) => {
+    // A frame that arrived while an older one was still waiting replaces it.
+    // Closing the loser explicitly: bitmaps hold decoded pixels and waiting for
+    // the collector to notice is how a long session grows to a gigabyte.
+    if (pending) pending.close();
+    pending = bitmap;
+    if (!scheduled) {
+      scheduled = true;
+      requestAnimationFrame(paint);
     }
-    ctx.drawImage(img, 0, 0);
-    if (done) done();
-  };
-  img.src = src;
+  }).catch(() => {
+    // A frame the box produced by crashing mid-encode. Dropped, never fatal.
+  });
+}
+
+function paint() {
+  scheduled = false;
+  const bitmap = pending;
+  pending = null;
+  if (!bitmap) return;
+  if (canvas.width !== bitmap.width || canvas.height !== bitmap.height) {
+    canvas.width = bitmap.width; canvas.height = bitmap.height;
+  }
+  ctx.drawImage(bitmap, 0, 0);
+  bitmap.close();
 }
 
 // The URL comes from the page inside the box, so it is untrusted text. It is
@@ -144,11 +187,37 @@ function mouse(e, eventType, extra) {
   }, at(e), extra || {}));
 }
 
-canvas.addEventListener("mousedown", (e) => { canvas.focus(); mouse(e, "mousePressed"); });
-canvas.addEventListener("mouseup", (e) => mouse(e, "mouseReleased"));
-canvas.addEventListener("mousemove", (e) => mouse(e, "mouseMoved"));
+// Moves are coalesced to one per animation frame. A mouse crossing the canvas
+// fires hundreds of events a second, and each one that gets sent is a WebSocket
+// frame, a CDP dispatch inside the box and a hover recomputation on the page —
+// for a position that was already stale when it was sent. Only the newest
+// position carries any information.
+//
+// Presses flush the pending move first. Ordering is the one thing coalescing
+// must not break: a press that overtook the move that positioned it is a click
+// at the wrong place, and the box has no way to notice.
+let pendingMove = null;
+let moveScheduled = false;
+
+function flushMove() {
+  const e = pendingMove;
+  pendingMove = null;
+  if (e) mouse(e, "mouseMoved");
+}
+
+canvas.addEventListener("mousemove", (e) => {
+  pendingMove = e;
+  if (moveScheduled) return;
+  moveScheduled = true;
+  requestAnimationFrame(() => { moveScheduled = false; flushMove(); });
+});
+canvas.addEventListener("mousedown", (e) => { canvas.focus(); flushMove(); mouse(e, "mousePressed"); });
+canvas.addEventListener("mouseup", (e) => { flushMove(); mouse(e, "mouseReleased"); });
 canvas.addEventListener("contextmenu", (e) => e.preventDefault());
 canvas.addEventListener("wheel", (e) => {
+  // Not coalesced: a wheel event's delta is a quantity, and dropping one loses
+  // scroll distance rather than a stale position.
+  flushMove();
   mouse(e, "mouseWheel", { deltaX: e.deltaX, deltaY: e.deltaY });
 }, { passive: true });
 

--- a/crates/h5i-core/src/viewer.html
+++ b/crates/h5i-core/src/viewer.html
@@ -59,6 +59,15 @@ let viewport = { w: 1280, h: 800 };
 
 let ws;
 function connect() {
+  // A new connection is a new generation, so a decode still running from the
+  // old one is discarded rather than painted onto the new session. `decoding`
+  // is deliberately left alone: clearing it here would let the next frame start
+  // a second decode alongside the one still running, which is the thing the
+  // flag exists to prevent. The in-flight decode's own completion clears it and
+  // picks up whatever the new socket queued.
+  generation++;
+  queuedBytes = null;
+  if (pending) { pending.close(); pending = null; }
   ws = new WebSocket(`ws://${location.host}/?token=${encodeURIComponent(token)}`);
   ws.binaryType = "arraybuffer";
   ws.onopen = () => {
@@ -102,26 +111,53 @@ function bytesOfBase64(b64) {
   return bytes;
 }
 
-// Frames are decoded off the main thread and painted at most once per animation
-// frame. Both halves matter, and the shape they replace was the reason the
-// viewer stuttered.
+// Frames are decoded off the main thread, one at a time, and painted at most
+// once per animation frame.
 //
 // `createImageBitmap` decodes on a worker the browser owns; the previous
 // `new Image()` with a `data:` URL built a ~70 KB string, parsed a URL and
-// decoded on the main thread, per frame, and allocated a fresh element to do
-// it. And painting on arrival means a tab that cannot keep up queues every
-// frame it was sent; painting on `requestAnimationFrame` means it draws the
-// newest one and drops the rest, which is what "latest frame wins" has to mean
-// on this side of the socket too. A hidden tab decodes nothing at all.
-let pending = null;   // the newest frame not yet painted
-let scheduled = false;
+// decoded on the main thread, per frame, and allocated a fresh element to do it.
+//
+// The pacing is the other half, and it has to hold at *every* stage rather than
+// only at the last one, because the box does not wait for this page: under push
+// pacing frames arrive whether or not anything here kept up, so a stage that
+// queues instead of dropping grows without bound. So three things are dropped,
+// each where it accumulates:
+//
+//   * bytes that arrived while a decode was running — only the newest is kept,
+//     and it is the newest that gets decoded next. Starting a decode per
+//     arriving frame instead is the version of this that looks like it drops
+//     frames and does not: the drop happens after the expensive part, so the
+//     decode jobs and their blobs pile up for as long as decoding is slower
+//     than the frame rate.
+//   * a decoded bitmap that was never painted, replaced by a newer one.
+//     Closed explicitly: bitmaps hold decoded pixels, and waiting for the
+//     collector to notice is how a long session grows to a gigabyte.
+//   * a decode that finished after the socket it came from was replaced. One
+//     decode is in flight at a time, so this is the only way a bitmap can
+//     arrive out of order, and it is the reconnect path that produces it.
+//
+// A hidden tab decodes nothing at all.
+let queuedBytes = null;  // newest frame not yet handed to a decoder
+let decoding = false;    // a decode is in flight
+let pending = null;      // newest decoded frame not yet painted
+let scheduled = false;   // a paint is queued for the next animation frame
+let generation = 0;      // bumped per connection; an older decode is discarded
 
 function draw(bytes) {
   if (document.hidden) return;
+  queuedBytes = bytes;
+  if (!decoding) decodeNext();
+}
+
+function decodeNext() {
+  const bytes = queuedBytes;
+  queuedBytes = null;
+  if (!bytes) { decoding = false; return; }
+  decoding = true;
+  const mine = generation;
   createImageBitmap(new Blob([bytes], { type: "image/jpeg" })).then((bitmap) => {
-    // A frame that arrived while an older one was still waiting replaces it.
-    // Closing the loser explicitly: bitmaps hold decoded pixels and waiting for
-    // the collector to notice is how a long session grows to a gigabyte.
+    if (mine !== generation) { bitmap.close(); return; }
     if (pending) pending.close();
     pending = bitmap;
     if (!scheduled) {
@@ -130,6 +166,9 @@ function draw(bytes) {
     }
   }).catch(() => {
     // A frame the box produced by crashing mid-encode. Dropped, never fatal.
+  }).finally(() => {
+    decoding = false;
+    decodeNext();
   });
 }
 

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -271,7 +271,7 @@ Draw the page in this terminal instead of serving it to a browser
 Frame\-rate ceiling asked of the box, for `\-\-term`
 .TP
 \fB\-\-assume\-graphics\fR
-Skip the graphics probe and render anyway, for `\-\-term`
+Skip the graphics probe and render anyway, for `\-\-term`. Frames are then sent uncompressed (about six times the bytes), because the probe is also what asks whether this terminal accepts deflated ones
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -183,7 +183,9 @@ pub enum BoxCommands {
         /// Frame-rate ceiling asked of the box, for `--term`
         #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u32).range(1..=60))]
         fps: u32,
-        /// Skip the graphics probe and render anyway, for `--term`
+        /// Skip the graphics probe and render anyway, for `--term`. Frames are
+        /// then sent uncompressed (about six times the bytes), because the
+        /// probe is also what asks whether this terminal accepts deflated ones
         #[arg(long)]
         assume_graphics: bool,
     },


### PR DESCRIPTION
Four changes to the two viewers. The first is the one that matters; the rest were found while measuring it.

## The terminal viewer was sending 1.7 MiB per frame

`kitty.rs` transmitted base64 raw RGB, so a frame fitted to a 120x30 pane was 439 protocol chunks and 17 MB/s at the default `--fps 10`. The ROADMAP records the same number without naming it: "624 continuation chunks" for one 800x400 frame. Over SSH, which is half the reason a terminal viewer exists, that rate is not reachable at all.

Frames are now deflated with `o=z`. Measured through this path on a real decoded 1280x720 JPEG:

| pane | before | after | chunks |
|---|---|---|---|
| 120x30 cells (891x504 px) | 1758 KiB | **283 KiB** (6.2x) | 439 → 70 |
| 80x24 cells (624x352 px) | 860 KiB | **143 KiB** (6.0x) | 214 → 35 |

Level 1 is measured rather than picked. It costs 3.6 ms for 6.2x, where level 6 costs 21 ms for 6.9x and level 9 costs 63 ms for 7.0x. The table is in the `ZLIB_LEVEL` doc.

**Compression is probed, not assumed**, and that is the load-bearing part. Every render command carries `q=2`, so a terminal that did not understand `o=z` would drop every frame in silence: a blank pane with nothing on stdin to explain it. `probe_sequence` now asks twice, once raw and once deflated under a second image id, and frames are compressed only on an explicit `OK` to the second question. The read loop runs to the device-attributes reply instead of returning on the first graphics reply, because returning early would decide compression before its answer had arrived. Not a slow path, a permanently wrong one.

`--assume-graphics` therefore implies raw. The flag exists for the case where we were already wrong about a terminal, so it must not then assume something else about it. Its help says so and the man page is regenerated (one line of diff).

## The render loop's tick only ran when the box went quiet

It was hung off `recv_timeout` expiring, and at the default 10 fps a frame lands every 100 ms while the timeout is 250 ms, so it never elapsed. The status line stopped refreshing, a resize went unnoticed and a lone Escape was never flushed, all of it on exactly the pages someone is watching because they are moving.

The tick now keeps its own deadline in `Ticker`, which is a type rather than two locals so it can be tested without a pty and so the tick cannot be attached to the socket again by accident. It tracks the last keystroke separately: "the input has gone quiet" has to stay a claim about the keyboard, or fixing this trades one silent bug for another.

## The web viewer's frame-rate cap was never delivered

The page sends `{"type":"config","maxFps":30}` on connect. That is a text frame, `classify_opcode` made every text frame `Input`, `pump_input` drops input unless the holder is Human, and a box is agent-held by default. So the cap was dropped on essentially every session and the box streamed uncapped. Silent, because a dropped `config` looks exactly like a `config` that was honoured. This is 5.10.1's shape again: a message the other side never receives looks like configuration and configures nothing.

`FrameVerdict` gains `Pacing`, and `classify` lets exactly two names past the lock: `config` and `ack`. It stays an allowlist. Whole unfragmented text frames only, payloads under 4 KiB only, exact match on `type`. Neither message touches the page.

It also unblocks ack pacing on this path, which was impossible before because acks would have been dropped too and frames would simply have stopped. **Not switched on here**: under ack pacing a dropped ack stops frames outright, which deserves its own change.

## The web viewer decoded every frame on the main thread

It built a ~70 KB `data:` URL string, parsed it, and decoded into a fresh `Image` element, per frame, then painted on arrival so a tab that could not keep up queued everything it was sent.

It now decodes with `createImageBitmap` off the main thread and paints at most one frame per animation frame, keeping the newest and closing the ones it drops. Context is `{alpha: false, desynchronized: true}`; a hidden tab decodes nothing. Mouse moves are coalesced to one per animation frame, with an explicit flush before every press, release and wheel so a click can never overtake the move that positioned it. Wheel is not coalesced: a delta is a quantity, and dropping one loses scroll distance rather than a stale position.

## Testing

New tests: 11. The compression one is a real round trip, because a control key being present is not evidence the terminal gets the frame back: draw a frame, reassemble every chunk's base64, inflate, assert it equals the source pixels.

- `cargo test -p h5i-core --lib` — 216 passed
- `cargo test -p h5i --bins` — 10 passed; `--test console_api` — 8 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, with and without default features
- `man/man1/h5i.1` regenerated, groff reports 0 warnings

**Not demonstrated**: a person at an actual Kitty-protocol terminal watching the compressed frames draw. The ROADMAP's standing note on M7 applies to this change too. `tests/env_integration.rs` was not run; this host has the pre-existing worktree-stat drift on the process and supervised tiers, so a failure there would say nothing about this work.

## Deliberately not in this PR

Measured or scoped while doing the above, each its own change: shared-memory transmission (`t=s`) as a local fast path with `t=d` kept for SSH, dirty-strip transmission (about 20% pixel churn on half the frames of a real capture), moving decode and scale off the render thread, `SIGWINCH` instead of polling `TIOCGWINSZ`, and tmux passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
