### PR TITLE
fix(sandbox): let a box shell drive the terminal it was given

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -718,13 +718,32 @@ Being explicit about these is a feature, since the claim is a security claim.
 - **An interactive session at a kernel tier shares your terminal.** `box shell`
   hands the box the terminal you launched it from, because that is what makes
   job control and every TUI work — a box shell is a nested shell, not a
-  connection to somewhere else. A terminal is a two-way device, so a box that
-  can drive it can in principle push characters into its *input* queue
-  (`TIOCSTI`), which your own shell would then read as typing after the session
-  ends. Both kernel tiers close that particular door — macOS by refusing that
-  one ioctl in the profile, Linux by the kernel's `CONFIG_LEGACY_TIOCSTI`
-  default — but the terminal is still shared. Giving the box its own pty and
-  proxying it is the airtight fix, and it is not built. The container and
+  connection to somewhere else. A terminal is a two-way device, and the box gets
+  both directions of it, so the residual is a list rather than a single door:
+    - **Typing at your shell** (`TIOCSTI` pushes characters into the terminal's
+      *input* queue, which your shell reads as if you had typed them, after the
+      session ends). On macOS the profile subtracts that one ioctl, so it is
+      refused. On Linux it is **your kernel's setting, not ours**: 6.2 made it
+      disableable via `CONFIG_LEGACY_TIOCSTI` and `dev.tty.legacy_tiocsti`, but
+      upstream defaults that *open* — many distros ship it closed, and a kernel
+      older than 6.2 cannot close it at all. h5i does not assume:
+      `h5i box probe` reads the sysctl and prints `tty-injection = blocked` or
+      `possible`, and says how to close it. h5i does no ioctl filtering of its
+      own on Linux.
+    - **Reading what you type next.** The session's read grant on the terminal
+      is not revoked when the shell exits, so a box process that outlives the
+      session — a stray background job — can read the terminal it still holds
+      open. This predates the tty ioctl grant; it is a property of sharing the
+      device.
+    - **Leaving the terminal in a state.** A box can set raw mode, turn echo
+      off, change the line discipline, or take the terminal exclusive so other
+      programs cannot open it. Recoverable (`stty sane`, or a new terminal), not
+      an escape, but it is yours to recover.
+
+  What is *not* reachable, checked rather than assumed: `TIOCCONS` (redirecting
+  console output to the box's terminal) is refused by Darwin for a non-root
+  process with or without a sandbox. Giving the box its own pty and proxying it
+  is the fix that ends the whole list, and it is not built. The container and
   microVM tiers do not share a terminal at all.
 - **Chrome runs with its own sandbox off.** On Linux, h5i's seccomp deny-list
   blocks the namespace syscalls Chrome's sandbox needs, at every tier. h5i's box

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -722,14 +722,25 @@ Being explicit about these is a feature, since the claim is a security claim.
   both directions of it, so the residual is a list rather than a single door:
     - **Typing at your shell** (`TIOCSTI` pushes characters into the terminal's
       *input* queue, which your shell reads as if you had typed them, after the
-      session ends). On macOS the profile subtracts that one ioctl, so it is
-      refused. On Linux it is **your kernel's setting, not ours**: 6.2 made it
-      disableable via `CONFIG_LEGACY_TIOCSTI` and `dev.tty.legacy_tiocsti`, but
-      upstream defaults that *open* — many distros ship it closed, and a kernel
-      older than 6.2 cannot close it at all. h5i does not assume:
-      `h5i box probe` reads the sysctl and prints `tty-injection = blocked` or
-      `possible`, and says how to close it. h5i does no ioctl filtering of its
-      own on Linux.
+      session ends). Whether that is closed is not h5i's to assert, and the two
+      platforms answer from different places. On macOS it is the Seatbelt
+      profile that subtracts the ioctl — so it holds at `process` and
+      `supervised`, and **not** at `isolation=workspace`, which applies no
+      profile by design, nor on a host whose Seatbelt is unusable. On Linux it
+      is **your kernel's setting**, the same at every tier, since h5i does no
+      ioctl filtering of its own there: 6.2 made TIOCSTI disableable via
+      `CONFIG_LEGACY_TIOCSTI` and `dev.tty.legacy_tiocsti`, but upstream
+      defaults that *open* — many distros ship it closed, and a kernel older
+      than 6.2 cannot close it at all. So h5i measures instead of claiming.
+      `h5i box probe` prints one of:
+
+      ```
+        tty-injection= blocked at every tier
+        tty-injection= blocked at the kernel tiers, possible at isolation=workspace
+        tty-injection= possible at every tier
+      ```
+
+      and, when anything is open, how to close it.
     - **Reading what you type next.** The session's read grant on the terminal
       is not revoked when the shell exits, so a box process that outlives the
       session — a stray background job — can read the terminal it still holds

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -715,6 +715,17 @@ Being explicit about these is a feature, since the claim is a security claim.
   not built.
 - **The container tier's egress scoping is L7.** Its allowlist is a proxy, so it
   binds proxy-respecting tooling only.
+- **An interactive session at a kernel tier shares your terminal.** `box shell`
+  hands the box the terminal you launched it from, because that is what makes
+  job control and every TUI work — a box shell is a nested shell, not a
+  connection to somewhere else. A terminal is a two-way device, so a box that
+  can drive it can in principle push characters into its *input* queue
+  (`TIOCSTI`), which your own shell would then read as typing after the session
+  ends. Both kernel tiers close that particular door — macOS by refusing that
+  one ioctl in the profile, Linux by the kernel's `CONFIG_LEGACY_TIOCSTI`
+  default — but the terminal is still shared. Giving the box its own pty and
+  proxying it is the airtight fix, and it is not built. The container and
+  microVM tiers do not share a terminal at all.
 - **Chrome runs with its own sandbox off.** On Linux, h5i's seccomp deny-list
   blocks the namespace syscalls Chrome's sandbox needs, at every tier. h5i's box
   is the boundary; Chrome's is not available inside it. That is one layer fewer

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -4823,6 +4823,10 @@ fn write_plain_zshrc(
          HISTFILE={histfile}\n\
          HISTSIZE=2000\n\
          SAVEHIST=1000\n\
+         # zsh renices background jobs by default and the box cannot call\n\
+         # setpriority(2), so every `cmd &` would answer `zsh: nice(5) failed:\n\
+         # operation not permitted`. The renice buys the session nothing.\n\
+         unsetopt bgnice\n\
          PROMPT='h5i:{id} %~ %# '\n\
          alias ll='ls -alF'\n\
          alias la='ls -A'\n\

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -7957,6 +7957,44 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&out.stdout), "/tmp/o'clock.zshrc");
     }
 
+    /// A box shell must not answer `zsh: nice(5) failed: operation not
+    /// permitted` on every `cmd &`: zsh renices background jobs by default and
+    /// no box can call `setpriority(2)`, so the generated rc turns the renice
+    /// off. Put to zsh itself where there is one — an option name is only right
+    /// if zsh accepts it, and a typo here would be silently inert.
+    #[test]
+    fn the_generated_zshrc_turns_off_the_background_renice() {
+        let h5i_root = tempfile::tempdir().unwrap();
+        let m = canonical_manifest("claude", "demo");
+        let z = write_plain_zshrc(h5i_root.path(), &m, None).unwrap();
+        let rc = Path::new(&z.zdotdir).join(".zshrc");
+        let body = std::fs::read_to_string(&rc).unwrap();
+        assert!(body.contains("\nunsetopt bgnice\n"), "the rc must disable bgnice:\n{body}");
+
+        // `-f` so the host's own zsh startup cannot decide the answer; the rc
+        // under test is sourced explicitly.
+        let out = std::process::Command::new("zsh")
+            .arg("-f")
+            .arg("-c")
+            .arg(format!(
+                "source {}; [[ -o bgnice ]] && print ON || print OFF",
+                sq(&rc.display().to_string())
+            ))
+            .output();
+        match out {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("SKIP the_generated_zshrc_turns_off_the_background_renice: no zsh here");
+            }
+            Err(e) => panic!("run zsh: {e}"),
+            Ok(out) => assert_eq!(
+                String::from_utf8_lossy(&out.stdout).trim(),
+                "OFF",
+                "zsh still renices background jobs after sourcing the rc\nstderr: {}",
+                String::from_utf8_lossy(&out.stderr)
+            ),
+        }
+    }
+
     // zsh has no `--rcfile`, so a profile's `[shell] rcfile` reaches it by being
     // sourced from the generated rc — last, so it wins over the plain defaults.
     #[test]

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -807,38 +807,59 @@ impl HostCaps {
     }
 }
 
-/// Can a box at a kernel tier push characters into the **input** queue of the
-/// terminal it shares with the operator (`TIOCSTI`)? An interactive session
-/// keeps the caller's session and controlling terminal — that is what makes job
-/// control work — so this is a real residual of the shared tty, and it is a
-/// property of the *host*, not of h5i's policy. Hence a probe rather than a
-/// claim: reported by `box probe` and disclosed in the manual's Limits.
+/// Can a box push characters into the **input** queue of the terminal it shares
+/// with the operator (`TIOCSTI`)? An interactive session at a kernel tier keeps
+/// the caller's session and controlling terminal — that is what makes job
+/// control work — so this is a real residual of the shared tty. Reported by
+/// `box probe` and disclosed in the manual's Limits.
 ///
-/// - **macOS**: `false`. The Seatbelt profile subtracts that one ioctl from the
-///   tty grant (`seatbelt::build_profile`), so it is refused by policy — and
-///   Darwin appears to refuse it under any deny-default profile besides.
-/// - **Linux**: `dev.tty.legacy_tiocsti`. Kernel 6.2 made TIOCSTI disableable
+/// The two platforms answer from different places, and that asymmetry is why
+/// this takes both the probed host **and** the tier rather than collapsing to a
+/// constant:
+///
+/// - **Linux**: `dev.tty.legacy_tiocsti`, a kernel-global property that is the
+///   same at every tier — h5i's seccomp policy does not filter `ioctl`, so the
+///   kernel's own setting is the whole answer. 6.2 made TIOCSTI disableable
 ///   (`CONFIG_LEGACY_TIOCSTI`, default **`y`** upstream) and exposed this
-///   sysctl. A missing file means a kernel older than that, where TIOCSTI is
-///   unconditionally available. Fails **open** in its reporting — anything we
-///   cannot read is reported as injectable, because telling an operator a door
-///   is shut when we could not check is worse than telling them to look.
+///   sysctl; a missing file means an older kernel, where it cannot be closed.
+/// - **macOS**: a property of the Seatbelt **profile**, which subtracts that one
+///   ioctl from the tty grant (`seatbelt::build_profile`) — so it holds exactly
+///   where a profile is applied. `isolation=workspace` applies none by design,
+///   and a host whose Seatbelt is unusable applies none either; in both cases
+///   nothing stands between the box and the operator's terminal, and answering
+///   "blocked" from a compile-time `cfg` would assert what this cannot know.
+///
+/// Fails **open** throughout: anything we cannot positively establish is
+/// reported as injectable, because telling an operator a door is shut when we
+/// could not check is worse than telling them to look.
 ///
 /// This never gates a tier. A stock kernel would otherwise stop being able to
 /// run a box at all, and the shared terminal is a disclosed limit, not a
 /// regression — so it informs the operator instead of refusing on their behalf.
-pub fn tty_input_injection() -> bool {
-    if cfg!(target_os = "macos") {
+pub fn tty_input_injection(caps: &HostCaps, claim: IsolationClaim) -> bool {
+    // These tiers give the box a terminal of its own (Podman's `-t`, the guest's
+    // console) rather than the operator's, so its input queue is its own too.
+    if matches!(
+        claim,
+        IsolationClaim::Container | IsolationClaim::HardenedContainer | IsolationClaim::Microvm
+    ) {
         return false;
     }
-    if !cfg!(target_os = "linux") {
-        return true;
+    match caps.os.as_str() {
+        "macos" => {
+            !(caps.seatbelt
+                && matches!(
+                    claim,
+                    IsolationClaim::Process | IsolationClaim::Supervised
+                ))
+        }
+        "linux" => tty_injection_from_sysctl(
+            std::fs::read_to_string("/proc/sys/dev/tty/legacy_tiocsti")
+                .ok()
+                .as_deref(),
+        ),
+        _ => true,
     }
-    tty_injection_from_sysctl(
-        std::fs::read_to_string("/proc/sys/dev/tty/legacy_tiocsti")
-            .ok()
-            .as_deref(),
-    )
 }
 
 /// The reading half of [`tty_input_injection`], split out so the fail-open rule
@@ -4074,10 +4095,44 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
             tty_injection_from_sysctl(Some("banana")),
             "anything we cannot read as a definite 0 must read as open"
         );
-        // macOS answers from the profile, not from a file that is not there.
-        if cfg!(target_os = "macos") {
-            assert!(!tty_input_injection(), "the Seatbelt profile subtracts TIOCSTI");
+    }
+
+    /// macOS answers from the Seatbelt *profile*, so the answer is tier-shaped:
+    /// the subtraction exists only where a profile is applied. Reporting one
+    /// constant for the host would claim the door is shut on exactly the paths
+    /// that apply no profile — the direction the fail-open rule forbids.
+    #[test]
+    fn tty_injection_on_macos_follows_the_profile_not_the_platform() {
+        // A kernel tier on a working Seatbelt: the profile subtracts it.
+        assert!(!tty_input_injection(&mac_caps(true), IsolationClaim::Process));
+        assert!(!tty_input_injection(&mac_caps(true), IsolationClaim::Supervised));
+
+        // `workspace` runs unconfined by design — no profile, no subtraction.
+        assert!(
+            tty_input_injection(&mac_caps(true), IsolationClaim::Workspace),
+            "an unconfined session applies no profile; nothing subtracts TIOCSTI"
+        );
+        // A host whose Seatbelt is unusable applies no profile either. The
+        // kernel tiers refuse there, but the report must not say "blocked".
+        assert!(
+            tty_input_injection(&mac_caps(false), IsolationClaim::Process),
+            "no working Seatbelt means no profile to subtract with"
+        );
+
+        // The image-backed tiers hand the box its own terminal, so its input
+        // queue is its own — true whatever the host underneath.
+        for claim in [
+            IsolationClaim::Container,
+            IsolationClaim::HardenedContainer,
+            IsolationClaim::Microvm,
+        ] {
+            assert!(!tty_input_injection(&mac_caps(false), claim), "{claim:?} has its own tty");
         }
+
+        // An OS with no backend at all: nothing is known, so nothing is claimed.
+        let mut unknown = mac_caps(true);
+        unknown.os = "windows".into();
+        assert!(tty_input_injection(&unknown, IsolationClaim::Process));
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -807,6 +807,50 @@ impl HostCaps {
     }
 }
 
+/// Can a box at a kernel tier push characters into the **input** queue of the
+/// terminal it shares with the operator (`TIOCSTI`)? An interactive session
+/// keeps the caller's session and controlling terminal — that is what makes job
+/// control work — so this is a real residual of the shared tty, and it is a
+/// property of the *host*, not of h5i's policy. Hence a probe rather than a
+/// claim: reported by `box probe` and disclosed in the manual's Limits.
+///
+/// - **macOS**: `false`. The Seatbelt profile subtracts that one ioctl from the
+///   tty grant (`seatbelt::build_profile`), so it is refused by policy — and
+///   Darwin appears to refuse it under any deny-default profile besides.
+/// - **Linux**: `dev.tty.legacy_tiocsti`. Kernel 6.2 made TIOCSTI disableable
+///   (`CONFIG_LEGACY_TIOCSTI`, default **`y`** upstream) and exposed this
+///   sysctl. A missing file means a kernel older than that, where TIOCSTI is
+///   unconditionally available. Fails **open** in its reporting — anything we
+///   cannot read is reported as injectable, because telling an operator a door
+///   is shut when we could not check is worse than telling them to look.
+///
+/// This never gates a tier. A stock kernel would otherwise stop being able to
+/// run a box at all, and the shared terminal is a disclosed limit, not a
+/// regression — so it informs the operator instead of refusing on their behalf.
+pub fn tty_input_injection() -> bool {
+    if cfg!(target_os = "macos") {
+        return false;
+    }
+    if !cfg!(target_os = "linux") {
+        return true;
+    }
+    tty_injection_from_sysctl(
+        std::fs::read_to_string("/proc/sys/dev/tty/legacy_tiocsti")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// The reading half of [`tty_input_injection`], split out so the fail-open rule
+/// is testable on a host whose own answer we do not control (and on macOS, where
+/// the file does not exist at all). `None` is an unreadable or absent sysctl.
+fn tty_injection_from_sysctl(v: Option<&str>) -> bool {
+    match v {
+        Some(s) => s.trim() != "0",
+        None => true,
+    }
+}
+
 /// Process-wide memoization of the host capability probe. Kernel features
 /// (Landlock ABI, unprivileged userns, seccomp) and the rootless-Podman probe
 /// are effectively immutable for the life of a process, yet `probe_host` is
@@ -2228,9 +2272,14 @@ pub(crate) fn build_confined_command(
             //    control and every TUI ("cannot set terminal process group").
             //    They keep the caller's session — exactly how a nested shell
             //    runs — and have no wall-clock kill (operator-bounded), so the
-            //    killpg guarantee isn't needed. (TIOCSTI keystroke injection
-            //    via the shared tty is gated off by default since kernel 6.2,
-            //    CONFIG_LEGACY_TIOCSTI; a PTY-proxy is the airtight follow-up.)
+            //    killpg guarantee isn't needed. The residual is TIOCSTI
+            //    keystroke injection through the shared tty. Kernel 6.2 made it
+            //    *disableable* — CONFIG_LEGACY_TIOCSTI, and the
+            //    `dev.tty.legacy_tiocsti` sysctl — but upstream defaults that
+            //    option to `y`, so whether the door is shut is the host's
+            //    choice, not ours. h5i reads the sysctl and reports it
+            //    (`tty_input_injection`) rather than assuming a hardened
+            //    kernel; a pty proxy is the fix that would not have to ask.
             if !interactive && libc::setsid() == -1 {
                 return Err(Error::last_os_error());
             }
@@ -4006,6 +4055,29 @@ fs.deny = ["~/.ssh", "$REPO/.git/hooks"]
         let err = resolve(&p, &mac_caps(false)).unwrap_err();
         assert!(err.to_string().contains("Seatbelt"), "{err}");
         assert!(!err.to_string().contains("Landlock"), "{err}");
+    }
+
+    /// An interactive box shell shares the operator's terminal, so whether a box
+    /// can type into it is a disclosed limit — and on Linux it is the *host's*
+    /// setting. Report it wrong in the safe direction and an operator trusts a
+    /// door that is open, so the unreadable case must read as injectable.
+    #[test]
+    fn tty_injection_reporting_fails_open() {
+        assert!(tty_injection_from_sysctl(None), "an unreadable sysctl must read as open");
+        assert!(
+            tty_injection_from_sysctl(Some("1\n")),
+            "upstream's default (y → 1) leaves TIOCSTI available"
+        );
+        assert!(!tty_injection_from_sysctl(Some("0\n")), "0 means the kernel refuses TIOCSTI");
+        assert!(!tty_injection_from_sysctl(Some("0")), "no trailing newline is still 0");
+        assert!(
+            tty_injection_from_sysctl(Some("banana")),
+            "anything we cannot read as a definite 0 must read as open"
+        );
+        // macOS answers from the profile, not from a file that is not there.
+        if cfg!(target_os = "macos") {
+            assert!(!tty_input_injection(), "the Seatbelt profile subtracts TIOCSTI");
+        }
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/seatbelt.rs
+++ b/crates/h5i-sandbox/src/seatbelt.rs
@@ -593,6 +593,21 @@ pub fn build_profile(policy: &ResolvedPolicy, work: &Path, opts: &SeatbeltOption
     // session looks alive while `ls` and everything else does nothing. The same
     // EPERM denies `tcsetattr`, so raw mode is gone too and ZLE and every TUI
     // degrade with it.
+    //
+    // The grant names exactly the nodes the two rules above it name, so the
+    // ioctl reach can never exceed the path reach. `/dev/tty` is spelled out
+    // even though `^/dev/tty[a-z0-9]*$` already subsumes it (the `*` matches
+    // empty): it is the node a program actually opens, it is granted by literal
+    // in `MACOS_DEV_NODES`/`MACOS_DEV_WRITE`, and a reader comparing the three
+    // rules should see one node set rather than have to derive it. `/dev/ptmx`
+    // is not optional — `^/dev/pty…$` does not match it (`ptm` ≠ `pty`) — and
+    // without it `posix_openpt`'s `TIOCPTYGRANT`/`TIOCPTYUNLK` fail, so a box
+    // could open a pty master and never unlock its slave.
+    //
+    // This is the only rule the generator emits with more than one filter
+    // clause; `every_sbpl_construct_we_emit_is_accepted` hands it to the real
+    // parser, and `the_generated_profile_is_accepted_by_sandbox_exec` compiles
+    // the interactive profile it lands in.
     if opts.interactive {
         s.push_str("(allow file-write* file-read* (regex #\"^/dev/tty[a-z0-9]*$\"))\n");
         s.push_str("(allow file-write* file-read* (regex #\"^/dev/pty[a-z0-9]*$\"))\n");
@@ -1386,11 +1401,17 @@ mod tests {
         let ioctl = s
             .find("(allow file-ioctl")
             .unwrap_or_else(|| panic!("interactive sessions need tty ioctls\n{s}"));
+        // Every node the interactive session already holds read/write on, and no
+        // other: an ioctl grant wider than the path grant it accompanies would
+        // be reach this rule never intended to add. `/dev/ptmx` is the one that
+        // needs naming — `^/dev/pty…$` does not match it (`ptm` ≠ `pty`), and it
+        // is granted by literal above for the same reason.
         let rule = s[ioctl..].lines().next().unwrap();
         for f in [
             "(literal \"/dev/tty\")",
             "(literal \"/dev/ptmx\")",
             "(regex #\"^/dev/tty[a-z0-9]*$\")",
+            "(regex #\"^/dev/pty[a-z0-9]*$\")",
         ] {
             assert!(rule.contains(f), "tty ioctl grant misses {f}\n{rule}");
         }
@@ -2031,23 +2052,38 @@ mod tests {
             return;
         }
         let (_tmp, work, pol) = functional_env();
-        let plan = plan(&pol, &work, &SeatbeltOptions::default());
-        let file = ProfileFile::write(&plan.profile).unwrap();
-        let out = std::process::Command::new(SANDBOX_EXEC)
-            .arg("-f")
-            .arg(file.path())
-            .arg("/usr/bin/true")
-            .output()
-            .expect("run sandbox-exec");
-        assert!(
-            out.status.success(),
-            "sandbox-exec rejected the generated profile.\n\
-             status: {:?}\nstderr: {}\nstdout: {}\n--- profile ---\n{}",
-            out.status,
-            String::from_utf8_lossy(&out.stderr),
-            String::from_utf8_lossy(&out.stdout),
-            plan.profile
-        );
+        // Both option sets, because they generate *different* profiles: the
+        // interactive one adds the tty grants (including the only rule this
+        // generator emits with more than one filter clause) and the
+        // agent-config lockdown, and a rule the parser rejects takes the whole
+        // profile with it. Checking only the captured shape would leave every
+        // interactive box shell resting on `String::contains`.
+        for opts in [
+            SeatbeltOptions::default(),
+            SeatbeltOptions {
+                interactive: true,
+                ..SeatbeltOptions::default()
+            },
+        ] {
+            let interactive = opts.interactive;
+            let plan = plan(&pol, &work, &opts);
+            let file = ProfileFile::write(&plan.profile).unwrap();
+            let out = std::process::Command::new(SANDBOX_EXEC)
+                .arg("-f")
+                .arg(file.path())
+                .arg("/usr/bin/true")
+                .output()
+                .expect("run sandbox-exec");
+            assert!(
+                out.status.success(),
+                "sandbox-exec rejected the generated profile (interactive={interactive}).\n\
+                 status: {:?}\nstderr: {}\nstdout: {}\n--- profile ---\n{}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr),
+                String::from_utf8_lossy(&out.stdout),
+                plan.profile
+            );
+        }
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/seatbelt.rs
+++ b/crates/h5i-sandbox/src/seatbelt.rs
@@ -2058,15 +2058,48 @@ mod tests {
         // agent-config lockdown, and a rule the parser rejects takes the whole
         // profile with it. Checking only the captured shape would leave every
         // interactive box shell resting on `String::contains`.
+        // The interactive lockdown comes from `config_lock_paths(work, home)`,
+        // which lists only paths that *exist* — so `home: None` (or a home with
+        // nothing in it) yields an empty lockdown and the rules production
+        // actually generates never reach the parser. Create both scopes.
+        let home = work.join("home");
+        std::fs::create_dir_all(work.join(".claude")).unwrap();
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::write(home.join(".claude/settings.json"), "{}").unwrap();
+        let home = Some(home);
         for opts in [
-            SeatbeltOptions::default(),
+            SeatbeltOptions {
+                home: home.clone(),
+                ..SeatbeltOptions::default()
+            },
             SeatbeltOptions {
                 interactive: true,
+                home: home.clone(),
                 ..SeatbeltOptions::default()
             },
         ] {
             let interactive = opts.interactive;
             let plan = plan(&pol, &work, &opts);
+            if interactive {
+                // Guard the setup, not the parser: a profile that quietly lost
+                // the tty grant or the lockdown would still compile, and this
+                // test would pass while covering less than it says it does.
+                for expected in [
+                    "(allow file-ioctl",
+                    "(deny file-ioctl (ioctl-command #x80017472))",
+                    &format!("(subpath \"{}\")", work.join(".claude").display()),
+                    &format!(
+                        "(subpath \"{}\")",
+                        work.join("home/.claude/settings.json").display()
+                    ),
+                ] {
+                    assert!(
+                        plan.profile.contains(expected),
+                        "the interactive profile handed to the parser is missing {expected}\n{}",
+                        plan.profile
+                    );
+                }
+            }
             let file = ProfileFile::write(&plan.profile).unwrap();
             let out = std::process::Command::new(SANDBOX_EXEC)
                 .arg("-f")

--- a/crates/h5i-sandbox/src/seatbelt.rs
+++ b/crates/h5i-sandbox/src/seatbelt.rs
@@ -574,11 +574,32 @@ pub fn build_profile(policy: &ResolvedPolicy, work: &Path, opts: &SeatbeltOption
         s.push_str(&r);
         s.push('\n');
     }
-    // Pseudo-terminals: an interactive session allocates one, and the pty pair
-    // lives outside every path grant.
+    // Terminals: an interactive session inherits the operator's, and a program
+    // in the box may allocate its own pty pair — neither lives under any path
+    // grant. A captured run reaches none of this: it gets `setsid`, so it has no
+    // controlling terminal and `/dev/tty` cannot be opened at all.
+    //
+    // `file-ioctl` is a *separate* SBPL operation: `file-write*` does not imply
+    // it, so without this rule every terminal ioctl returns EPERM under
+    // `(deny default)`. That is not a cosmetic gap. An interactive zsh puts
+    // itself in its own process group and calls `tcsetpgrp` to make that group
+    // the terminal's foreground one; the EPERM surfaces as
+    //
+    //     zsh: can't set tty pgrp: operation not permitted
+    //
+    // and leaves the shell in a *background* process group, where reading the
+    // terminal raises SIGTTIN and no line ever reaches it. The box prompt
+    // renders and keystrokes echo (the tty driver does both regardless), so the
+    // session looks alive while `ls` and everything else does nothing. The same
+    // EPERM denies `tcsetattr`, so raw mode is gone too and ZLE and every TUI
+    // degrade with it.
     if opts.interactive {
         s.push_str("(allow file-write* file-read* (regex #\"^/dev/tty[a-z0-9]*$\"))\n");
         s.push_str("(allow file-write* file-read* (regex #\"^/dev/pty[a-z0-9]*$\"))\n");
+        s.push_str(
+            "(allow file-ioctl (literal \"/dev/tty\") (literal \"/dev/ptmx\") \
+             (regex #\"^/dev/tty[a-z0-9]*$\") (regex #\"^/dev/pty[a-z0-9]*$\"))\n",
+        );
     }
     s.push('\n');
 
@@ -594,6 +615,19 @@ pub fn build_profile(policy: &ResolvedPolicy, work: &Path, opts: &SeatbeltOption
         s.push_str(&format!("(deny sysctl-read (sysctl-name \"{name}\"))\n"));
     }
     s.push_str("(deny process-info* (target others))\n");
+    // TIOCSTI (`_IOW('t', 114, char)` = 0x80017472) pushes a byte into the
+    // terminal's *input* queue rather than reading or writing it. An interactive
+    // session shares the operator's terminal, so a box able to issue it would be
+    // typing at the host shell — a command that runs outside the box, after the
+    // session ends. The tty grant above is what puts that ioctl in reach, so the
+    // subtraction ships with it. (Darwin appears to refuse TIOCSTI under a
+    // deny-default profile even without this rule; containment must not rest on
+    // an observation of undocumented behaviour, and this is the same residual
+    // the Linux tier notes at its own shared-tty comment — there it is the
+    // kernel's CONFIG_LEGACY_TIOCSTI default that closes it. A pty proxy, which
+    // would stop handing the box the operator's terminal at all, is the airtight
+    // fix on both.)
+    s.push_str("(deny file-ioctl (ioctl-command #x80017472))\n");
 
     // Defence in depth, not a new capability: `validate_profile` refuses a
     // policy whose granted parent contains a denied child, so anything left in
@@ -1334,6 +1368,44 @@ mod tests {
         assert!(deny_at > allow_at, "the subtraction must come after");
     }
 
+    /// Job control is what makes a box shell usable, and it rests on one
+    /// operation the write grant does not confer. Without `file-ioctl` the
+    /// session's `tcsetpgrp` fails, zsh warns "can't set tty pgrp" and is left in
+    /// a background process group where no typed line ever reaches it.
+    #[test]
+    fn interactive_session_may_drive_its_terminal() {
+        let p = policy(IsolationClaim::Supervised);
+        let s = build_profile(
+            &p,
+            Path::new("/w"),
+            &SeatbeltOptions {
+                interactive: true,
+                ..opts()
+            },
+        );
+        let ioctl = s
+            .find("(allow file-ioctl")
+            .unwrap_or_else(|| panic!("interactive sessions need tty ioctls\n{s}"));
+        let rule = s[ioctl..].lines().next().unwrap();
+        for f in [
+            "(literal \"/dev/tty\")",
+            "(literal \"/dev/ptmx\")",
+            "(regex #\"^/dev/tty[a-z0-9]*$\")",
+        ] {
+            assert!(rule.contains(f), "tty ioctl grant misses {f}\n{rule}");
+        }
+        // TIOCSTI types at the *host* shell through the shared terminal; the
+        // subtraction must come after the grant, or last-match-wins re-allows it.
+        let deny = s.find("(deny file-ioctl (ioctl-command #x80017472))").unwrap();
+        assert!(deny > ioctl, "the TIOCSTI subtraction must come after\n{s}");
+
+        // A captured run has no terminal to drive (it gets its own session), so
+        // it gets neither the tty paths nor the ioctl.
+        let s = build_profile(&p, Path::new("/w"), &opts());
+        assert!(!s.contains("(allow file-ioctl"), "captured runs get no tty ioctl\n{s}");
+        assert!(!s.contains("/dev/tty[a-z0-9]"), "captured runs get no tty paths\n{s}");
+    }
+
     #[test]
     fn interactive_locks_agent_config() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1727,6 +1799,9 @@ mod tests {
             "(deny file-read* file-write* (subpath \"/Users/nobody/.ssh\"))",
             "(deny file-write* (subpath \"/tmp/x/.claude\"))",
             "(allow file-write* file-read* (regex #\"^/dev/tty[a-z0-9]*$\"))",
+            "(allow file-ioctl (literal \"/dev/tty\") (literal \"/dev/ptmx\") \
+             (regex #\"^/dev/tty[a-z0-9]*$\") (regex #\"^/dev/pty[a-z0-9]*$\"))",
+            "(deny file-ioctl (ioctl-command #x80017472))",
             "(allow process-fork)",
             "(allow process-exec*)",
             "(allow signal (target same-sandbox))",

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -922,6 +922,17 @@ not claim more than that.</p>
   not built.</li>
 <li><strong>The container tier's egress scoping is L7.</strong> Its allowlist is a proxy, so it
   binds proxy-respecting tooling only.</li>
+<li><strong>An interactive session at a kernel tier shares your terminal.</strong> <code>box shell</code>
+  hands the box the terminal you launched it from, because that is what makes
+  job control and every TUI work — a box shell is a nested shell, not a
+  connection to somewhere else. A terminal is a two-way device, so a box that
+  can drive it can in principle push characters into its <em>input</em> queue
+  (<code>TIOCSTI</code>), which your own shell would then read as typing after the session
+  ends. Both kernel tiers close that particular door — macOS by refusing that
+  one ioctl in the profile, Linux by the kernel's <code>CONFIG_LEGACY_TIOCSTI</code>
+  default — but the terminal is still shared. Giving the box its own pty and
+  proxying it is the airtight fix, and it is not built. The container and
+  microVM tiers do not share a terminal at all.</li>
 <li><strong>Chrome runs with its own sandbox off.</strong> On Linux, h5i's seccomp deny-list
   blocks the namespace syscalls Chrome's sandbox needs, at every tier. h5i's box
   is the boundary; Chrome's is not available inside it. That is one layer fewer

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -922,31 +922,40 @@ not claim more than that.</p>
   not built.</li>
 <li><strong>The container tier's egress scoping is L7.</strong> Its allowlist is a proxy, so it
   binds proxy-respecting tooling only.</li>
-<li><strong>An interactive session at a kernel tier shares your terminal.</strong> <code>box shell</code>
+<li>
+<p><strong>An interactive session at a kernel tier shares your terminal.</strong> <code>box shell</code>
   hands the box the terminal you launched it from, because that is what makes
   job control and every TUI work — a box shell is a nested shell, not a
   connection to somewhere else. A terminal is a two-way device, and the box gets
-  both directions of it, so the residual is a list rather than a single door:<ul>
+  both directions of it, so the residual is a list rather than a single door:</p>
+<ul>
 <li><strong>Typing at your shell</strong> (<code>TIOCSTI</code> pushes characters into the terminal's
   <em>input</em> queue, which your shell reads as if you had typed them, after the
-  session ends). On macOS the profile subtracts that one ioctl, so it is
-  refused. On Linux it is <strong>your kernel's setting, not ours</strong>: 6.2 made it
-  disableable via <code>CONFIG_LEGACY_TIOCSTI</code> and <code>dev.tty.legacy_tiocsti</code>, but
-  upstream defaults that <em>open</em> — many distros ship it closed, and a kernel
-  older than 6.2 cannot close it at all. h5i does not assume:
-  <code>h5i box probe</code> reads the sysctl and prints <code>tty-injection = blocked</code> or
-  <code>possible</code>, and says how to close it. h5i does no ioctl filtering of its
-  own on Linux.</li>
-<li><strong>Reading what you type next.</strong> The session's read grant on the terminal
+  session ends). Whether that is closed is not h5i's to assert, and the two
+  platforms answer from different places. On macOS it is the Seatbelt
+  profile that subtracts the ioctl — so it holds at <code>process</code> and
+  <code>supervised</code>, and <strong>not</strong> at <code>isolation=workspace</code>, which applies no
+  profile by design, nor on a host whose Seatbelt is unusable. On Linux it
+  is <strong>your kernel's setting</strong>, the same at every tier, since h5i does no
+  ioctl filtering of its own there: 6.2 made TIOCSTI disableable via
+  <code>CONFIG_LEGACY_TIOCSTI</code> and <code>dev.tty.legacy_tiocsti</code>, but upstream
+  defaults that <em>open</em> — many distros ship it closed, and a kernel older
+  than 6.2 cannot close it at all. So h5i measures instead of claiming.
+  <code>h5i box probe</code> prints one of:</li>
+</ul>
+<p><code>tty-injection= blocked at every tier
+    tty-injection= blocked at the kernel tiers, possible at isolation=workspace
+    tty-injection= possible at every tier</code></p>
+<p>and, when anything is open, how to close it.
+- <strong>Reading what you type next.</strong> The session's read grant on the terminal
   is not revoked when the shell exits, so a box process that outlives the
   session — a stray background job — can read the terminal it still holds
   open. This predates the tty ioctl grant; it is a property of sharing the
-  device.</li>
-<li><strong>Leaving the terminal in a state.</strong> A box can set raw mode, turn echo
+  device.
+- <strong>Leaving the terminal in a state.</strong> A box can set raw mode, turn echo
   off, change the line discipline, or take the terminal exclusive so other
   programs cannot open it. Recoverable (<code>stty sane</code>, or a new terminal), not
-  an escape, but it is yours to recover.</li>
-</ul>
+  an escape, but it is yours to recover.</p>
 </li>
 </ul>
 <p>What is <em>not</em> reachable, checked rather than assumed: <code>TIOCCONS</code> (redirecting

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -925,19 +925,40 @@ not claim more than that.</p>
 <li><strong>An interactive session at a kernel tier shares your terminal.</strong> <code>box shell</code>
   hands the box the terminal you launched it from, because that is what makes
   job control and every TUI work — a box shell is a nested shell, not a
-  connection to somewhere else. A terminal is a two-way device, so a box that
-  can drive it can in principle push characters into its <em>input</em> queue
-  (<code>TIOCSTI</code>), which your own shell would then read as typing after the session
-  ends. Both kernel tiers close that particular door — macOS by refusing that
-  one ioctl in the profile, Linux by the kernel's <code>CONFIG_LEGACY_TIOCSTI</code>
-  default — but the terminal is still shared. Giving the box its own pty and
-  proxying it is the airtight fix, and it is not built. The container and
-  microVM tiers do not share a terminal at all.</li>
-<li><strong>Chrome runs with its own sandbox off.</strong> On Linux, h5i's seccomp deny-list
+  connection to somewhere else. A terminal is a two-way device, and the box gets
+  both directions of it, so the residual is a list rather than a single door:<ul>
+<li><strong>Typing at your shell</strong> (<code>TIOCSTI</code> pushes characters into the terminal's
+  <em>input</em> queue, which your shell reads as if you had typed them, after the
+  session ends). On macOS the profile subtracts that one ioctl, so it is
+  refused. On Linux it is <strong>your kernel's setting, not ours</strong>: 6.2 made it
+  disableable via <code>CONFIG_LEGACY_TIOCSTI</code> and <code>dev.tty.legacy_tiocsti</code>, but
+  upstream defaults that <em>open</em> — many distros ship it closed, and a kernel
+  older than 6.2 cannot close it at all. h5i does not assume:
+  <code>h5i box probe</code> reads the sysctl and prints <code>tty-injection = blocked</code> or
+  <code>possible</code>, and says how to close it. h5i does no ioctl filtering of its
+  own on Linux.</li>
+<li><strong>Reading what you type next.</strong> The session's read grant on the terminal
+  is not revoked when the shell exits, so a box process that outlives the
+  session — a stray background job — can read the terminal it still holds
+  open. This predates the tty ioctl grant; it is a property of sharing the
+  device.</li>
+<li><strong>Leaving the terminal in a state.</strong> A box can set raw mode, turn echo
+  off, change the line discipline, or take the terminal exclusive so other
+  programs cannot open it. Recoverable (<code>stty sane</code>, or a new terminal), not
+  an escape, but it is yours to recover.</li>
+</ul>
+</li>
+</ul>
+<p>What is <em>not</em> reachable, checked rather than assumed: <code>TIOCCONS</code> (redirecting
+  console output to the box's terminal) is refused by Darwin for a non-root
+  process with or without a sandbox. Giving the box its own pty and proxying it
+  is the fix that ends the whole list, and it is not built. The container and
+  microVM tiers do not share a terminal at all.
+- <strong>Chrome runs with its own sandbox off.</strong> On Linux, h5i's seccomp deny-list
   blocks the namespace syscalls Chrome's sandbox needs, at every tier. h5i's box
   is the boundary; Chrome's is not available inside it. That is one layer fewer
-  than a browser on the host has.</li>
-<li><strong>A dev server the box runs is reachable only if its port is declared.</strong> On
+  than a browser on the host has.
+- <strong>A dev server the box runs is reachable only if its port is declared.</strong> On
   macOS the box shares the <em>host's</em> loopback, so h5i denies outbound to it
   wholesale — otherwise a box could reach a database or a dev server belonging
   to the host. A box that runs its own dev server and wants to point its own
@@ -946,8 +967,8 @@ not claim more than that.</p>
   undeclared port fails with <code>net::ERR_ACCESS_DENIED</code>. The port a declared
   <code>[service]</code> is running on is granted automatically while that service is
   alive, so this is only needed for a server started by hand. On Linux the box
-  has its own network namespace and none of this applies.</li>
-<li><strong>On macOS the browser has no in-process domain check.</strong> agent-browser cannot
+  has its own network namespace and none of this applies.
+- <strong>On macOS the browser has no in-process domain check.</strong> agent-browser cannot
   start Chrome from inside a Seatbelt sandbox — the failure reproduces under a
   fully permissive <code>sandbox-exec</code> profile and disappears without the sandbox, so
   it is not something a grant fixes. h5i therefore launches Chrome itself and
@@ -955,8 +976,8 @@ not claim more than that.</p>
   with <code>--allowed-domains</code>. So that flag is not set for a macOS browser box: the
   tier's own egress enforcement is unchanged and still the boundary, but
   agent-browser's second, in-process domain list is gone. A page on a
-  non-allowlisted host fails inside Chrome with <code>net::ERR_ACCESS_DENIED</code>.</li>
-<li><strong>A browser box's Chrome is restarted when its route out changes.</strong> Chrome
+  non-allowlisted host fails inside Chrome with <code>net::ERR_ACCESS_DENIED</code>.
+- <strong>A browser box's Chrome is restarted when its route out changes.</strong> Chrome
   outlives the run that started it, and it takes its proxy address once, at
   launch — so a browser started before the box's current route (an upgrade, or a
   run whose proxy port moved) cannot reach the network through it. The box
@@ -965,8 +986,8 @@ not claim more than that.</p>
   It is detected in the box and stopped host-side at the start of the next run,
   so the fix costs one extra run and says so rather than failing with a proxy
   error that reads like a page problem. The relaunch starts from a clean profile
-  directory, so anything the old browser held — cookies, logins — is gone.</li>
-<li><strong>Two kernel mechanisms, not one.</strong> Linux confines with Landlock, seccomp and
+  directory, so anything the old browser held — cookies, logins — is gone.
+- <strong>Two kernel mechanisms, not one.</strong> Linux confines with Landlock, seccomp and
   namespaces. macOS confines with Seatbelt, which is default deny across
   filesystem, network, mach and sysctl in one policy, and which (unlike
   Landlock) can subtract a child from a granted parent, so the agent config lock
@@ -980,20 +1001,19 @@ not claim more than that.</p>
   user rather than to one box (applying it would cap your machine, not the
   box). <code>h5i box probe</code> names the mechanism and the gaps.
   Rootless Podman runs on Linux and WSL2 natively, and on macOS through a
-  <code>podman machine</code> VM.</li>
-<li><strong>A macOS box shares the host's loopback.</strong> A Linux box gets its own network
+  <code>podman machine</code> VM.
+- <strong>A macOS box shares the host's loopback.</strong> A Linux box gets its own network
   namespace, so its loopback is private. macOS has no namespaces, so a box binds
   the host's loopback (deliberately: it is the only way a dev server in a box is
   reachable). h5i closes the outbound half of this, denying the box every
   outbound loopback destination except its own egress proxy, but the box's own
-  listening ports are reachable by any local process.</li>
-<li><strong>Cost.</strong> A Chrome sidecar is real RAM and CPU, even headless. Headless boxes
-  stay first class, and the browser is opt-in per box.</li>
-<li><strong>The viewport is not a desktop.</strong> CDP screencast shows the page. Native
-  dialogs, browser chrome and anything outside the tab are invisible.</li>
-<li><strong>A dependency on the critical path.</strong> <code>agent-browser</code> is someone else's
-  release cadence. Pinned, CLI-boundary, forkable, but not ours.</li>
-</ul>
+  listening ports are reachable by any local process.
+- <strong>Cost.</strong> A Chrome sidecar is real RAM and CPU, even headless. Headless boxes
+  stay first class, and the browser is opt-in per box.
+- <strong>The viewport is not a desktop.</strong> CDP screencast shows the page. Native
+  dialogs, browser chrome and anything outside the tab are invisible.
+- <strong>A dependency on the critical path.</strong> <code>agent-browser</code> is someone else's
+  release cadence. Pinned, CLI-boundary, forkable, but not ours.</p>
 <hr />
 <h2 id="files">Files</h2>
 <table>

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -987,6 +987,30 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                         println!("  userns       = {}", caps.userns);
                         println!("  seccomp      = {}", caps.seccomp);
                     }
+                    // An interactive box shell shares the operator's terminal
+                    // (that is what makes job control work), so whether the box
+                    // can type into it is part of what this host enforces —
+                    // and on Linux it is the host's setting, not h5i's. Say
+                    // which it is rather than let the manual assume.
+                    let inject = h5i_core::sandbox::tty_input_injection();
+                    println!(
+                        "  tty-injection= {}",
+                        if inject {
+                            style("possible (a box shell can type at your terminal)").red()
+                        } else {
+                            style("blocked").green()
+                        }
+                    );
+                    if inject && caps.os == "linux" {
+                        println!(
+                            "    {}",
+                            style(
+                                "set dev.tty.legacy_tiocsti=0 (or build with \
+                                 CONFIG_LEGACY_TIOCSTI=n) to close it; upstream defaults it open"
+                            )
+                            .dim()
+                        );
+                    }
                     println!(
                         "  container    = {}",
                         caps.container_runtime.as_deref().unwrap_or("none")

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -989,25 +989,47 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                     }
                     // An interactive box shell shares the operator's terminal
                     // (that is what makes job control work), so whether the box
-                    // can type into it is part of what this host enforces —
-                    // and on Linux it is the host's setting, not h5i's. Say
-                    // which it is rather than let the manual assume.
-                    let inject = h5i_core::sandbox::tty_input_injection();
+                    // can type into it is part of what this host enforces — and
+                    // it is not h5i's to assert: on Linux it is the kernel's
+                    // setting, the same at every tier; on macOS it is the
+                    // Seatbelt profile, so it holds only where one is applied.
+                    // Report both, because they can disagree on the same host.
+                    let confined = h5i_core::sandbox::tty_input_injection(
+                        &caps,
+                        h5i_core::sandbox::IsolationClaim::Process,
+                    );
+                    let unconfined = h5i_core::sandbox::tty_input_injection(
+                        &caps,
+                        h5i_core::sandbox::IsolationClaim::Workspace,
+                    );
                     println!(
                         "  tty-injection= {}",
-                        if inject {
-                            style("possible (a box shell can type at your terminal)").red()
-                        } else {
-                            style("blocked").green()
+                        match (confined, unconfined) {
+                            (false, false) => style("blocked at every tier".to_string()).green(),
+                            (false, true) => style(
+                                "blocked at the kernel tiers, possible at isolation=workspace"
+                                    .to_string()
+                            )
+                            .yellow(),
+                            // Nothing subtracts it anywhere: a box shell can type
+                            // at the terminal you launched it from.
+                            (true, _) => style("possible at every tier".to_string()).red(),
                         }
                     );
-                    if inject && caps.os == "linux" {
+                    if confined {
                         println!(
                             "    {}",
-                            style(
-                                "set dev.tty.legacy_tiocsti=0 (or build with \
-                                 CONFIG_LEGACY_TIOCSTI=n) to close it; upstream defaults it open"
-                            )
+                            style(match caps.os.as_str() {
+                                "linux" =>
+                                    "set dev.tty.legacy_tiocsti=0 (or build with \
+                                     CONFIG_LEGACY_TIOCSTI=n) to close it; upstream defaults \
+                                     it open",
+                                "macos" =>
+                                    "no Seatbelt profile is applied on this host, so nothing \
+                                     subtracts the ioctl",
+                                _ => "this host has no confinement backend, so nothing \
+                                      subtracts the ioctl",
+                            })
                             .dim()
                         );
                     }

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -4186,8 +4186,11 @@ fn probe_reports_all_capability_lines() {
     for key in primitives {
         assert!(out.contains(key), "probe output missing {key}: {out}");
     }
-    // Workspace is satisfiable everywhere.
-    let ws_line = out.lines().find(|l| l.contains("workspace")).unwrap();
+    // Workspace is satisfiable everywhere. Match the *claim* line specifically:
+    // other lines name the tier too (`tty-injection` reports that the shared
+    // terminal is unprotected at `isolation=workspace`), and a substring search
+    // for "workspace" would assert against whichever came first.
+    let ws_line = out.lines().find(|l| l.contains("claim workspace")).unwrap();
     assert!(ws_line.contains("yes"), "{ws_line}");
     // The functional self-test line is present and agrees with create.
     let run_line = out


### PR DESCRIPTION
A `box shell` on macOS printed `zsh: can't set tty pgrp: operation not permitted` and then ignored every command typed into it — the prompt rendered, keystrokes echoed, and `ls` did nothing. Only ^C got out.

`file-ioctl` is its own SBPL operation and `file-write*` does not confer it, so the tty grant let the session read and write its terminal but not *configure* it. Every terminal ioctl came back EPERM under `(deny default)`. zsh's `tcsetpgrp` was one of them, which left the shell in a background process group where reading the terminal raises SIGTTIN and no typed line ever arrives; the echo is the tty driver's, not the shell's, which is why the session looked alive. `tcsetattr` went the same way, so raw mode — and with it ZLE and every TUI — was gone too.

Grant `file-ioctl` on the tty and pty nodes the interactive session already holds read/write on. A captured run reaches none of this: it gets `setsid`, so it has no controlling terminal to drive.

That grant puts TIOCSTI in reach, which pushes a byte into the terminal's *input* queue — a box able to issue it would be typing at the host shell, running after the session ends. Darwin appears to refuse it under any deny-default profile already; containment does not rest on an observation of undocumented behaviour, so the subtraction ships with the grant. The terminal is still shared, which the manual now states alongside the Linux CONFIG_LEGACY_TIOCSTI residual it matches; a pty proxy is the airtight fix on both and is not built.

Also `unsetopt bgnice` in the generated rc: zsh renices background jobs and the box cannot call setpriority(2), so every `cmd &` answered `zsh: nice(5) failed: operation not permitted` — the same class of noise that rc exists to keep off the prompt.