### PR TITLE
ci: move every action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -47,14 +47,22 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # `docs/` is served verbatim: no Jekyll, no generator, no build step.
       # `docs/.nojekyll` is kept for the same reason it was added, in case the
       # source is ever pointed back at a branch.
-      - uses: actions/upload-pages-artifact@v3
+      #
+      # `include-hidden-files` is what keeps that true. This action stopped
+      # putting dotfiles in the artifact in v4, so on the default the `.nojekyll`
+      # above would be dropped — silently, and with no effect on this deploy at
+      # all, because an artifact served verbatim never runs Jekyll. It would only
+      # surface on the day someone repoints the Pages source at a branch, which
+      # is the exact day the file exists for, and `_static/` would 404.
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
+          include-hidden-files: true
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm
@@ -48,7 +48,15 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
-      - uses: actions/upload-artifact@v4
+      # The artifact pair is held at the *oldest* major that runs on Node 24
+      # (upload v6, download v7) rather than at the newest, deliberately. Getting
+      # off the deprecated Node 20 runtime is the whole point of the pin, and the
+      # newer majors change behaviour rather than just the runtime: upload v7
+      # adds direct unzipped uploads, and download v8 turns a hash mismatch into
+      # an error. Both may well be improvements, and neither is testable here —
+      # nothing in this file runs on a pull request, so a release is where it
+      # would be found out. Take those on their own, when they are the change.
+      - uses: actions/upload-artifact@v6
         with:
           name: web-dist
           path: web/dist
@@ -88,13 +96,13 @@ jobs:
             archive_ext: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Placed before the build so `rust-embed` finds a real bundle. With
       # H5I_SKIP_WEB_BUILD set the build script leaves an existing web/dist
       # alone and never reaches for npm.
       - name: Fetch the console bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: web-dist
           path: web/dist
@@ -128,7 +136,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache Cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index
@@ -184,7 +192,7 @@ jobs:
           "$hash  $ARCHIVE" | Out-File -FilePath "${ARCHIVE}.sha256" -Encoding ASCII
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.BINARY_NAME }}-${{ matrix.target }}
           path: |
@@ -198,10 +206,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
@@ -210,7 +218,7 @@ jobs:
         run: ls -lh artifacts/
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: "h5i ${{ github.ref_name }}"
           draft: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
     # six-hour default before anyone learns anything.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set Git user for tests
         # Required because some tests perform real Git operations
@@ -43,7 +43,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm
@@ -100,7 +100,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set Git user for tests
         run: |
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -176,7 +176,7 @@ jobs:
       # runner-image Python bump would silently become an input to generated
       # HTML that is compared byte for byte. 3.12 matches what the committed
       # page was generated with.
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -237,7 +237,7 @@ jobs:
             os: windows-latest
             use_cross: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
GitHub is already forcing our Node 20 actions onto Node 24 and warning on every run. Nothing is failing yet; the warning is the notice period.

Each target's runtime was verified rather than assumed, by reading `runs.using` from the pinned tag:

| action | from | to | runtime |
|---|---|---|---|
| actions/checkout | v4 | v7 | node24 |
| actions/setup-node | v4 | v7 | node24 |
| actions/setup-python | v5 | v7 | node24 |
| actions/cache | v4 | v6 | node24 |
| actions/deploy-pages | v4 | v5 | node24 |
| actions/upload-pages-artifact | v3 | v5 | composite |
| actions/upload-artifact | v4 | v6 | node24 |
| actions/download-artifact | v4 | v7 | node24 |
| softprops/action-gh-release | v2 | v3 | node24 |

**Left alone.** `Swatinem/rust-cache@v2` is already node24. `dtolnay/rust-toolchain@stable` and `taiki-e/install-action@cross` are composite actions with no nested action of their own. Every `uses:` in the tree now resolves to a tag that exists and either runs on node24 or is composite, and every runner here is GitHub-hosted, so the `>= 2.327.1` requirement the node24 actions carry is already met.

## Two of these are not simple version bumps

**`upload-pages-artifact` stopped including dotfiles in v4.** `docs/.nojekyll` is tracked, and the comment above the step says it is kept deliberately, so the default would have dropped it. It would have dropped it *invisibly*: an artifact served verbatim never runs Jekyll, so this deploy would not have cared at all. It surfaces on the day someone repoints the Pages source at a branch, which is precisely the day that file exists for, and `_static/` would 404. `include-hidden-files: true` keeps the artifact's contents identical to today's.

**The artifact pair is held at the oldest major that runs on Node 24**, which is why upload is v6 and download is v7 when v7 and v8 exist. The newer majors change behaviour and not only the runtime: upload v7 adds direct unzipped uploads, download v8 turns a hash mismatch into an error. Nothing in `release.yaml` runs on a pull request, so a release is where either would be found out, and neither buys anything toward getting off Node 20. Both are worth taking deliberately, as their own change.

`download-artifact` v5 also changed path behaviour for single downloads **by ID**. Checked and it does not apply: this repo downloads by `name` and by `merge-multiple`, never by `artifact-ids`. Every input in use (`name`, `path`, `merge-multiple`, `if-no-files-found`, `key`, `restore-keys`) still exists in the target versions.

## Checked and deliberately not changed

`node-version: "20"` in `test.yaml` and `release.yaml` is the Node that builds `web/dist`, not an action runtime, and nothing deprecates it. It is easy to conflate with the warning. Moving it is a real change with its own failure mode (the rollup platform natives that broke CI once before) and wants its own PR.

## Testing

`test.yaml` is exercised by this PR's own CI, so those bumps are verified by a run.

**`release.yaml` and `pages.yaml` are not**: neither runs on a pull request. Those changes are verified by inspection, by confirming every tag resolves, and by checking the inputs in use still exist — not by execution. The first real exercise will be the next release and the next `main` push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
