### PR TITLE
ci(release): keep the console bundle off the release page

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -208,14 +208,42 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Download all artifacts
+      # Only the packaged archives, never `web-dist`. The console bundle is an
+      # input to the *build* jobs, which embed it in the binary; this job has no
+      # use for it, and downloading everything meant `files:` swept it onto the
+      # release. v0.3.1 shipped 18 loose JS/CSS/font files next to the archives
+      # that way — harmless (the binary already carries its own copy) and wrong.
+      - name: Download the target artifacts
         uses: actions/download-artifact@v7
         with:
+          pattern: ${{ env.BINARY_NAME }}-*
           path: artifacts
           merge-multiple: true
 
       - name: List artifacts
         run: ls -lh artifacts/
+
+      # Fail loudly rather than publishing a short set: four targets, each with
+      # an archive and a checksum. A build job that silently stopped uploading
+      # would otherwise produce a release missing a platform, which nobody
+      # notices until someone's install breaks.
+      - name: Every expected asset is present, and nothing else
+        run: |
+          expected=8
+          found=$(find artifacts -maxdepth 1 -type f \
+            \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \) | wc -l)
+          extra=$(find artifacts -mindepth 1 -maxdepth 1 \
+            ! \( -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \) \) )
+          if [ "$found" -ne "$expected" ]; then
+            echo "::error::expected $expected release assets, found $found"
+            exit 1
+          fi
+          if [ -n "$extra" ]; then
+            echo "::error::unexpected entries in artifacts/:"
+            echo "$extra"
+            exit 1
+          fi
+          echo "ok: $found assets, nothing extra"
 
       - name: Create release
         uses: softprops/action-gh-release@v3
@@ -224,7 +252,13 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
-          files: artifacts/**
+          # Flat, and only the archives: `artifacts/**` would pick up any
+          # directory a future artifact adds. The guard above already refuses
+          # that case; this keeps the upload correct even if the guard changes.
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
+            artifacts/*.sha256
           body: |
             ## Install
 


### PR DESCRIPTION
## What happened

`v0.3.1` published **26 assets instead of 8**: the four archives and their checksums, plus 18 loose JS, CSS, SVG and font files from the web console.

```
h5i-v0.3.1-aarch64-apple-darwin.tar.gz          ← the 8 that belong
h5i-v0.3.1-aarch64-apple-darwin.tar.gz.sha256
… (6 more)
index.html                                      ← the 18 that do not
index-DLOviMB1.js
index-D-EoLU13.css
blueprint-icons-16-DwWyHYRo.woff2
… (14 more)
```

## Why

The publish job downloads *every* artifact and then uploads `artifacts/**`. Since #391 added the `bundle` job, one of those artifacts is `web-dist` — which exists so the `cross` build jobs (Docker images with no Node in them) can embed the console without rebuilding it. The publish job has no use for it and swept it onto the release anyway.

`v0.3.0` predates the `bundle` job, which is why this is the first release to show it.

The actual `artifacts/` layout on the v0.3.1 run:

```
artifacts/
├── assets/                     ← from web-dist
├── index.html                  ← from web-dist
└── h5i-v0.3.1-*.tar.gz|.zip|.sha256
```

## Impact: none on users

- `install.sh` only ever fetches `h5i-${VERSION}-${target}.tar.gz`.
- The binary embeds its own copy of the console. I served `h5i ui` from the released binary in an empty directory with no `web/`, `dist/` or `assets/` anywhere near it, and every deleted file came back byte-identical:

  | Path | Served from the binary | Deleted release asset |
  |---|---|---|
  | `assets/index-DLOviMB1.js` | 285,612 B | 285,612 B |
  | `assets/index-D-EoLU13.css` | 323,025 B | 323,025 B |
  | `assets/allPaths-BMdRQq1p.js` | 309 B | 309 B |
  | `assets/blueprint-icons-16-DwWyHYRo.woff2` | 47,912 B | 47,912 B |

  So they were duplicates of what is already compiled in, not a dependency of it. A console that fetched its own JS from a release URL would break exactly where it is meant to work: loopback-only, on a machine with no egress.

## The fix

Fixed at the **download** step rather than the upload glob, because the real error is fetching a 2 MB bundle this job never needed.

- `pattern: h5i-*` matches only the per-target artifacts (`h5i-<target>`); `web-dist` does not match.
- A **guard** refuses to publish unless `artifacts/` holds exactly the eight expected files and nothing else. That also catches the opposite failure: a build job that quietly stopped uploading, producing a release short a platform that nobody notices until someone's install breaks.
- `files:` is now three flat globs instead of `**`, so a future artifact cannot leak in even if the guard is relaxed.

## Verification

Pattern matching against the real artifact names:

| Artifact | `h5i-*` |
|---|---|
| `h5i-x86_64-unknown-linux-musl` | match |
| `h5i-aarch64-unknown-linux-musl` | match |
| `h5i-aarch64-apple-darwin` | match |
| `h5i-x86_64-pc-windows-msvc` | match |
| `web-dist` | **skipped** |

Guard replayed against three layouts:

| Case | Result |
|---|---|
| Fixed layout | `ok: 8 assets, nothing extra` |
| v0.3.1's broken layout | fails, naming `assets/` and `index.html` |
| A target missing its upload | fails, `expected 8, found 6` |

YAML parses; the workflow is otherwise untouched.

## Note

`v0.3.1` has already been cleaned up by hand and now carries the correct 8 assets. This only prevents a recurrence on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)