### PR TITLE
fix: report compiled features in version json

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -259,6 +259,10 @@ fn maybe_version_json(argv: &[String]) {
 }
 
 /// Compiled feature flags for this binary, sorted so JSON output is diffable.
+// One cfg-gated `push` per feature, so a new feature is a one-line addition.
+// clippy sees `Vec::new()` + `push` and suggests `vec![]`, but the pushes are
+// conditional — collapsing them would reintroduce paired cfg/cfg(not) bindings.
+#[allow(clippy::vec_init_then_push)]
 fn compiled_features() -> Vec<&'static str> {
     #[allow(unused_mut)]
     let mut features: Vec<&str> = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,10 +260,10 @@ fn maybe_version_json(argv: &[String]) {
 
 /// Compiled feature flags for this binary, sorted so JSON output is diffable.
 fn compiled_features() -> Vec<&'static str> {
-    #[cfg(feature = "web")]
-    let mut features: Vec<&str> = vec!["web"];
-    #[cfg(not(feature = "web"))]
+    #[allow(unused_mut)]
     let mut features: Vec<&str> = Vec::new();
+    #[cfg(feature = "web")]
+    features.push("web");
     features.sort_unstable();
     features
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,13 +249,23 @@ fn maybe_version_json(argv: &[String]) {
     let out = serde_json::json!({
         "name": "h5i",
         "version": env!("CARGO_PKG_VERSION"),
-        "features": Vec::<&str>::new(),
+        "features": compiled_features(),
     });
     println!(
         "{}",
         serde_json::to_string_pretty(&out).expect("version json is serializable")
     );
     std::process::exit(0);
+}
+
+/// Compiled feature flags for this binary, sorted so JSON output is diffable.
+fn compiled_features() -> Vec<&'static str> {
+    #[cfg(feature = "web")]
+    let mut features: Vec<&str> = vec!["web"];
+    #[cfg(not(feature = "web"))]
+    let mut features: Vec<&str> = Vec::new();
+    features.sort_unstable();
+    features
 }
 
 fn render_man_page<W: std::io::Write>(w: &mut W) -> std::io::Result<()> {
@@ -355,6 +365,15 @@ fn demote_headings(bytes: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn version_json_features_match_compiled_build() {
+        let features = compiled_features();
+        #[cfg(feature = "web")]
+        assert!(features.contains(&"web"));
+        #[cfg(not(feature = "web"))]
+        assert!(features.is_empty());
+    }
 
     /// Route `argv` through clap and the short-form fold, exactly as `main`
     /// does. The error is flattened to a string because `BoxCommands` has no


### PR DESCRIPTION
Closes #414

## Summary

Populates the `features` array in `h5i --version --json` from the root binary feature flags instead of always returning `[]`.

- Added `compiled_features()` using `cfg!(feature = "web")`.
- The list is sorted so output is diffable.
- Added a cfg-gated unit test that asserts `web` is present in default builds and absent in no-default-features builds.

## Verification

- `cargo test --bin h5i version_json_features_match_compiled_build` passes.
- `cargo test --no-default-features --bin h5i version_json_features_match_compiled_build` passes.
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings` passes.
- Manual output:
  - default: `["web"]`
  - `--no-default-features`: `[]`

Signed off with DCO.