### PR TITLE
fix: refuse Intel macOS in installer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -276,7 +276,12 @@ jobs:
             |--------|---------|
             | `x86_64-unknown-linux-musl` | Linux x86_64 (static, glibc-free) |
             | `aarch64-unknown-linux-musl` | Linux arm64 (static, glibc-free) |
-            | `aarch64-apple-darwin` | macOS (Apple Silicon + Rosetta) |
+            | `aarch64-apple-darwin` | macOS Apple Silicon (arm64) |
             | `x86_64-pc-windows-msvc` | Windows x86_64 |
+
+            Intel Macs have no published build: Rosetta 2 translates x86_64 to
+            arm64, not the reverse, so the `aarch64-apple-darwin` archive will
+            not run there. Build from source instead:
+            `cargo install --git https://github.com/${{ github.repository }}`
 
             Each archive is accompanied by a `.sha256` checksum file.

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -34,7 +34,23 @@ main() {
   case "${os}-${arch}" in
     linux-x86_64)  target="x86_64-unknown-linux-musl" ;;
     linux-aarch64) target="aarch64-unknown-linux-musl" ;;
-    macos-x86_64 | macos-aarch64) target="aarch64-apple-darwin" ;;
+    macos-aarch64) target="aarch64-apple-darwin" ;;
+    # Rosetta 2 translates x86_64 to arm64, not the reverse, so the published
+    # Apple Silicon archive cannot run here. Fail before the download rather
+    # than install a binary that will not execute.
+    macos-x86_64)
+      echo "Unsupported platform: macos-x86_64." >&2
+      echo "Only Apple Silicon macOS builds are published; Rosetta 2 cannot run a native arm64 binary on an Intel Mac." >&2
+      echo "Build from source instead: cargo install --git https://github.com/${REPO}" >&2
+      exit 1
+      ;;
+    # Unreachable while the two cases above cover every os/arch pair, but an
+    # unmatched pair would otherwise leave `target` empty and request a
+    # nonsense archive URL.
+    *)
+      echo "Unsupported platform: ${os}-${arch}" >&2
+      exit 1
+      ;;
   esac
 
   # ── resolve latest version ─────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,23 @@ main() {
   case "${os}-${arch}" in
     linux-x86_64)  target="x86_64-unknown-linux-musl" ;;
     linux-aarch64) target="aarch64-unknown-linux-musl" ;;
-    macos-x86_64 | macos-aarch64) target="aarch64-apple-darwin" ;;
+    macos-aarch64) target="aarch64-apple-darwin" ;;
+    # Rosetta 2 translates x86_64 to arm64, not the reverse, so the published
+    # Apple Silicon archive cannot run here. Fail before the download rather
+    # than install a binary that will not execute.
+    macos-x86_64)
+      echo "Unsupported platform: macos-x86_64." >&2
+      echo "Only Apple Silicon macOS builds are published; Rosetta 2 cannot run a native arm64 binary on an Intel Mac." >&2
+      echo "Build from source instead: cargo install --git https://github.com/${REPO}" >&2
+      exit 1
+      ;;
+    # Unreachable while the two cases above cover every os/arch pair, but an
+    # unmatched pair would otherwise leave `target` empty and request a
+    # nonsense archive URL.
+    *)
+      echo "Unsupported platform: ${os}-${arch}" >&2
+      exit 1
+      ;;
   esac
 
   # ── resolve latest version ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #413

## Summary

Fails before download on unsupported platform pairs instead of installing a binary that cannot run.

- `macos-aarch64` still maps to `aarch64-apple-darwin`.
- `macos-x86_64` exits with a clear message that only Apple Silicon builds are published, notes Rosetta is not a workaround, and points to `cargo install --path .`.
- Any unknown `os-arch` pair exits with `Unsupported platform: <os>-<arch>`.

## Verification

- `sh -n install.sh` passes.
- `git diff --check` passes.
- Supported Linux and Apple Silicon triples are unchanged.

Signed off with DCO.