### PR TITLE
security: fix the 20 findings from the advisory review

### DIFF
--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -2385,6 +2385,18 @@ fn copy_tree(src: &Path, dst: &Path) -> Result<(), H5iError> {
     }
     if ft.is_dir() {
         std::fs::create_dir_all(dst).map_err(|e| H5iError::with_path(e, dst))?;
+        // Carry the source directory's mode across. `create_dir_all` uses
+        // 0777 & ~umask (typically 0755), so a 0700 `~/.codex` became a 0755
+        // copy: `std::fs::copy` preserves the *file's* mode, but a config file
+        // at 0644 was relying on its parent directory for protection, which is
+        // the common case for an agent credential.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = meta.permissions().mode() & 0o7777;
+            std::fs::set_permissions(dst, std::fs::Permissions::from_mode(mode))
+                .map_err(|e| H5iError::with_path(e, dst))?;
+        }
         for entry in std::fs::read_dir(src).map_err(|e| H5iError::with_path(e, src))? {
             let entry = entry.map_err(|e| H5iError::with_path(e, src))?;
             let name = entry.file_name();
@@ -10080,6 +10092,25 @@ mod tests {
 
         // A missing source fails closed.
         assert!(materialize_persona(work, &["plugin/persona/nope.md".to_string()]).is_err());
+    }
+
+    /// The per-env HOME copy must not be more permissive than the original. A
+    /// 0700 `~/.codex` copied to 0755 exposes a 0644 config that was relying on
+    /// its parent for protection.
+    #[test]
+    #[cfg(unix)]
+    fn the_home_seed_copy_keeps_the_source_directory_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let td = tempfile::tempdir().unwrap();
+        let src = td.path().join("src/.codex");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::write(src.join("config.toml"), "key = 1").unwrap();
+
+        let dst = td.path().join("dst/.codex");
+        copy_tree(&src, &dst).unwrap();
+        let mode = std::fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "copied dir must not widen, got {mode:o}");
     }
 
     /// The spool is written by the box and is therefore untrusted. A reader

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -3875,6 +3875,21 @@ fn announce_egress(policy: &sandbox::ResolvedPolicy) {
         _ => "proxy-enforced, everything else 403",
     };
     eprintln!("⦿ egress ({how}): {line}{user_part}");
+    // Say the cost of the allowlist plan out loud. Reaching a host-side proxy
+    // from a rootless container means `slirp4netns:allow_host_loopback=true`,
+    // which exposes *every* host loopback service at the gateway address — not
+    // just the proxy port. Choosing the allowlist therefore widens the box's
+    // reach compared with plain NAT, and a reader deserves to know that from
+    // the tier itself rather than from the source. (The supervised tiers do not
+    // share this: nftables narrows the jail to the proxy port, and Seatbelt
+    // refuses host loopback wholesale.)
+    if policy.claim == IsolationClaim::Container {
+        eprintln!(
+            "⦿ note: the allowlist proxy is reached over host loopback, so host services on \
+             127.0.0.1 are reachable from this box at the gateway address. The allowlist \
+             governs what leaves the host, not what the box can reach on it."
+        );
+    }
 }
 
 /// Run `argv` inside the env's worktree under its pinned policy, and record

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -4018,6 +4018,7 @@ fn run_inner(
         &secret_dir,
         is_workspace,
         policy.profile.allow_command_extractors,
+        &crate::secrets_broker::fingerprint_key(h5i_root)?,
     )?;
     let protected_hook_configs = ProtectedHookConfigGuard::prepare(&work, policy.claim)?;
     // Authenticated egress the profile declares (5.5). Host-side credentials
@@ -4393,6 +4394,7 @@ pub fn shell(
         &secret_dir,
         is_workspace,
         policy.profile.allow_command_extractors,
+        &crate::secrets_broker::fingerprint_key(h5i_root)?,
     )?;
     let protected_hook_configs = ProtectedHookConfigGuard::prepare(&work, policy.claim)?;
     let injected_env = merged_env(
@@ -5825,14 +5827,18 @@ pub struct SecretStatus {
     pub ttl: Option<String>,
     /// `ok` | `command (not evaluated)` | `error: …`.
     pub status: String,
-    /// `sha256:<12>` when resolvable (env:/file:), else `None`.
+    /// `fp:<12>` (keyed, see [`crate::secrets_broker::fingerprint`]) when
+    /// resolvable (env:/file:), else `None`.
     pub fingerprint: Option<String>,
 }
 
 /// Resolve each declared grant's *status* without injecting it — the read-only
 /// surface behind `h5i box secrets`. `command:` extractors are never executed
 /// here (they have host-side side effects); they show as "not evaluated".
-pub fn secrets_status(policy: &ResolvedPolicy) -> Vec<SecretStatus> {
+pub fn secrets_status(h5i_root: &Path, policy: &ResolvedPolicy) -> Vec<SecretStatus> {
+    // Best-effort: a fingerprint the reviewer cannot compare is better than one
+    // they can grind, so a key we cannot mint drops the fingerprint entirely.
+    let fp_key = crate::secrets_broker::fingerprint_key(h5i_root).ok();
     policy
         .profile
         .secret_grants
@@ -5848,7 +5854,9 @@ pub fn secrets_status(policy: &ResolvedPolicy) -> Vec<SecretStatus> {
                 match crate::secrets_broker::resolve_value(g, false) {
                     Ok(v) => (
                         "ok".to_string(),
-                        Some(crate::secrets_broker::fingerprint(&v)),
+                        fp_key
+                            .as_ref()
+                            .map(|k| crate::secrets_broker::fingerprint(k, &v)),
                     ),
                     Err(e) => (format!("error: {e}"), None),
                 }

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -4970,11 +4970,22 @@ const SPOOL_MAX_CMD_BYTES: u64 = 64 * 1024;
 /// capped at `cap` bytes with an explicit truncation marker.
 fn read_spool_capped(p: &Path, cap: u64) -> Option<Vec<u8>> {
     use std::io::Read as _;
-    let meta = std::fs::symlink_metadata(p).ok()?;
+    // `symlink_metadata` then `open` would be two resolutions of a path in a
+    // directory the box writes: it can stat as a regular file and be a symlink
+    // by the time we open it. Open first with O_NOFOLLOW, then `fstat` that
+    // descriptor, so the thing we check is the thing we read.
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    let f = opts.open(p).ok()?;
+    let meta = f.metadata().ok()?;
     if !meta.file_type().is_file() {
         return None;
     }
-    let f = std::fs::File::open(p).ok()?;
     let mut buf = Vec::new();
     f.take(cap).read_to_end(&mut buf).ok()?;
     if meta.len() > cap {
@@ -6520,8 +6531,11 @@ fn scan_spool_pending(h5i_root: &Path, m: &EnvManifest) -> SpoolPending {
         let name = e.file_name().to_string_lossy().into_owned();
         if let Some(base) = name.strip_suffix(".json") {
             if base.starts_with("cap-") {
-                let cmd = std::fs::read(e.path())
-                    .ok()
+                // Through the same capped, symlink-refusing reader the ingest
+                // path uses. A plain `fs::read` here followed a symlink to
+                // /dev/zero and had no size cap, so a box could hang or OOM
+                // `h5i box status` — which the console polls.
+                let cmd = read_spool_capped(&e.path(), SPOOL_MAX_CMD_BYTES)
                     .and_then(|b| serde_json::from_slice::<InboxCaptureMeta>(&b).ok())
                     .map(|meta| meta.cmd)
                     .unwrap_or_default();
@@ -10066,6 +10080,32 @@ mod tests {
 
         // A missing source fails closed.
         assert!(materialize_persona(work, &["plugin/persona/nope.md".to_string()]).is_err());
+    }
+
+    /// The spool is written by the box and is therefore untrusted. A reader
+    /// that follows a symlink there can be pointed at any host file — or at
+    /// /dev/zero, which with no size cap hangs the host process. `box status`
+    /// (which the console polls every 8s) used a plain `fs::read`.
+    #[test]
+    #[cfg(unix)]
+    fn spool_reads_refuse_symlinks_and_stay_capped() {
+        let td = tempfile::tempdir().unwrap();
+        let spool = td.path().join("spool");
+        std::fs::create_dir_all(&spool).unwrap();
+
+        // A symlink is refused outright, even to a perfectly ordinary file.
+        let real = td.path().join("host-secret");
+        std::fs::write(&real, "PRIVATE").unwrap();
+        std::os::unix::fs::symlink(&real, spool.join("cap-1.json")).unwrap();
+        assert_eq!(read_spool_capped(&spool.join("cap-1.json"), 1024), None);
+
+        // A regular file is read, and a large one is capped rather than
+        // pulled into memory whole.
+        let big = spool.join("cmd-1-0.out");
+        std::fs::write(&big, vec![b'x'; 4096]).unwrap();
+        let got = read_spool_capped(&big, 512).unwrap();
+        assert!(got.starts_with(&[b'x'; 512][..]));
+        assert!(String::from_utf8_lossy(&got).contains("truncated"));
     }
 
     /// The remembered loopback ports decide what `policy.loopback_ports` grants,

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -1763,6 +1763,84 @@ fn no_workspace_err(m: &EnvManifest, op: &str) -> H5iError {
     ))
 }
 
+// ─── opening the env worktree (host side) ────────────────────────────────────
+
+/// Open the env's worktree repository, refusing any handle that is not this
+/// box's own.
+///
+/// Plain `Repository::open(work)` trusts two things the box can write: the
+/// `$WORK/.git` pointer file, which lives in the box's rw workspace, and the
+/// worktree admin dir (`HEAD`, `commondir`, `gitdir`), which [`box_git_plumbing`]
+/// grants rw so in-box git keeps working. A box that rewrites either one
+/// redirects every host-side git operation that follows. The consequence is
+/// worst in [`mediated_commit`], which would stage the box's tree into whatever
+/// repository the pointer names and commit it onto whatever ref its HEAD names
+/// — landing unreviewed work on the parent branch without `apply` ever running.
+///
+/// So the invariant [`box_git_plumbing`] states for grant computation — never
+/// derive host behaviour from box-writable state — is enforced here for every
+/// host-side open: the handle must sit on the manifest's branch, and its object
+/// store must be the one this box was created against.
+fn open_env_worktree(h5i_root: &Path, m: &EnvManifest) -> Result<Repository, H5iError> {
+    let work = m.work_dir(h5i_root);
+    let wt_repo = Repository::open(&work)?;
+    verify_env_worktree(h5i_root, &wt_repo, m)?;
+    Ok(wt_repo)
+}
+
+/// The two checks behind [`open_env_worktree`], split out so the refusal can be
+/// unit-tested against a deliberately redirected worktree.
+fn verify_env_worktree(
+    h5i_root: &Path,
+    wt_repo: &Repository,
+    m: &EnvManifest,
+) -> Result<(), H5iError> {
+    // Canonicalize both sides: the comparison has to survive symlinked repo
+    // paths (`/tmp` on macOS is the standing example) without being loosened
+    // into a prefix match.
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    let got = canon(wt_repo.commondir());
+
+    // 1. Same object store. An attached box is a worktree of this repository,
+    //    so it shares the common dir; a detached box carries its own repository
+    //    inside the env directory and must stay inside it.
+    let ok = if is_detached(m) {
+        got.starts_with(canon(&m.dir(h5i_root)))
+    } else {
+        // `h5i_root` is `<repo>/.git/.h5i` (see `storage::h5i_root_for_repo`),
+        // so its parent is the common dir this box belongs to.
+        h5i_root.parent().is_some_and(|d| got == canon(d))
+    };
+    if !ok {
+        return Err(H5iError::Metadata(format!(
+            "{}: the box's worktree points at a git directory that is not this box's \
+             ({}). `$WORK/.git` and the worktree admin dir are writable inside the box, so \
+             h5i refuses to run a host-side git operation through a redirected pointer \
+             (fail-closed). Recreate the box to continue.",
+            m.id,
+            got.display()
+        )));
+    }
+
+    // 2. On its own branch. Without this a rewritten worktree HEAD would let a
+    //    mediated commit land on the parent branch.
+    let head_ref = wt_repo
+        .head()
+        .ok()
+        .and_then(|h| h.name().map(str::to_string));
+    if head_ref.as_deref() != Some(m.branch.as_str()) {
+        return Err(H5iError::Metadata(format!(
+            "{}: the box's worktree is on {} but this box owns {}. The worktree HEAD is \
+             writable inside the box, so h5i refuses to commit through it (fail-closed). \
+             Recreate the box to continue.",
+            m.id,
+            head_ref.as_deref().unwrap_or("a detached HEAD"),
+            m.branch
+        )));
+    }
+    Ok(())
+}
+
 // ─── in-box git plumbing grants ──────────────────────────────────────────────
 
 /// The repo-`.git` plumbing surface that makes the env's worktree a
@@ -4017,7 +4095,7 @@ fn run_inner(
         });
 
     // Read HEAD from the WORKTREE repo so the tree recorded is the env's.
-    let wt_repo = Repository::open(&work)?;
+    let wt_repo = open_env_worktree(h5i_root, m)?;
     let head_tree = wt_repo
         .head()
         .ok()
@@ -4493,7 +4571,7 @@ fn capture_shell_egress(
             h.host, h.port, h.allowed, h.denied
         ));
     }
-    let wt_repo = Repository::open(work)?;
+    let wt_repo = open_env_worktree(h5i_root, m)?;
     let head_tree = wt_repo
         .head()
         .ok()
@@ -4889,7 +4967,7 @@ fn ingest_shell_spool(
         return Ok(0);
     }
     let work = m.work_dir(h5i_root);
-    let wt_repo = Repository::open(&work)?;
+    let wt_repo = open_env_worktree(h5i_root, m)?;
     let head_tree = wt_repo
         .head()
         .ok()
@@ -5131,7 +5209,7 @@ pub fn diff(
 
     let work = m.work_dir(h5i_root);
     if work.is_dir() {
-        let wt_repo = Repository::open(&work)?;
+        let wt_repo = open_env_worktree(h5i_root, m)?;
         let base_tree = wt_repo.find_tree(git2::Oid::from_str(&m.base_tree)?)?;
         let mut opts = git2::DiffOptions::new();
         opts.include_untracked(true)
@@ -5220,7 +5298,7 @@ pub fn diffstat_report(
 
     let work = m.work_dir(h5i_root);
     if work.is_dir() {
-        let wt_repo = Repository::open(&work)?;
+        let wt_repo = open_env_worktree(h5i_root, m)?;
         let base_tree = wt_repo.find_tree(git2::Oid::from_str(&m.base_tree)?)?;
         let mut opts = git2::DiffOptions::new();
         opts.include_untracked(true)
@@ -6197,7 +6275,7 @@ pub fn service_stop(
         if let Ok(raw) = std::fs::read(&log_path) {
             if !raw.is_empty() {
                 let work = m.work_dir(h5i_root);
-                if let Ok(wt_repo) = Repository::open(&work) {
+                if let Ok(wt_repo) = open_env_worktree(h5i_root, m) {
                     let head_tree = wt_repo
                         .head()
                         .ok()
@@ -6724,7 +6802,7 @@ pub fn mediated_commit(
     if !work.is_dir() {
         return Err(no_workspace_err(m, "propose/rebase"));
     }
-    let wt_repo = Repository::open(&work)?;
+    let wt_repo = open_env_worktree(h5i_root, m)?;
     let canon_work = work
         .canonicalize()
         .map_err(|e| H5iError::with_path(e, &work))?;
@@ -7409,8 +7487,7 @@ pub fn rebase(repo: &Repository, h5i_root: &Path, m: &mut EnvManifest) -> Result
     // Snapshot the worktree onto the env branch (host-side, path-allowlisted).
     mediated_commit(repo, h5i_root, m)?;
 
-    let work = m.work_dir(h5i_root);
-    let wt_repo = Repository::open(&work)?;
+    let wt_repo = open_env_worktree(h5i_root, m)?;
     let env_tip = wt_repo.head()?.peel_to_commit()?;
     let parent_tip = repo
         .find_reference(&format!("refs/heads/{}", m.parent_branch))?
@@ -9955,5 +10032,110 @@ mod tests {
 
         // A missing source fails closed.
         assert!(materialize_persona(work, &["plugin/persona/nope.md".to_string()]).is_err());
+    }
+
+    /// Build a manifest for an attached box on `refs/heads/h5i/env/<agent>/<slug>`.
+    fn wt_manifest(agent: &str, slug: &str) -> EnvManifest {
+        EnvManifest {
+            id: format!("env/{agent}/{slug}"),
+            agent: agent.into(),
+            slug: slug.into(),
+            base_commit: String::new(),
+            base_tree: String::new(),
+            parent_branch: "main".into(),
+            branch: format!("refs/heads/{BRANCH_PREFIX}{agent}/{slug}"),
+            source: "repo".into(),
+            profile: "default".into(),
+            policy_digest: String::new(),
+            isolation_claim: "workspace".into(),
+            backend: "worktree".into(),
+            created_at: now_ts(),
+            updated_at: now_ts(),
+            status: ST_CREATED.into(),
+            captures: Vec::new(),
+            service_digest: None,
+            persona_digest: None,
+            pr: None,
+            pr_head_ref: None,
+        }
+    }
+
+    /// A host repo with one commit, plus a real worktree for the env branch.
+    /// Returns (tempdir, h5i_root, manifest).
+    fn worktree_fixture() -> (tempfile::TempDir, PathBuf, EnvManifest) {
+        let dir = tempfile::tempdir().unwrap();
+        let host = dir.path().join("host");
+        std::fs::create_dir_all(&host).unwrap();
+        let repo = Repository::init(&host).unwrap();
+        let sig = git2::Signature::now("t", "t@example.com").unwrap();
+        let tree = repo.find_tree(repo.treebuilder(None).unwrap().write().unwrap()).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "base", &tree, &[]).unwrap();
+
+        let m = wt_manifest("human", "t");
+        let h5i_root = repo.commondir().join(".h5i");
+        let work = m.work_dir(&h5i_root);
+        std::fs::create_dir_all(work.parent().unwrap()).unwrap();
+
+        let out = std::process::Command::new("git")
+            .current_dir(&host)
+            .args(["worktree", "add", "-b", m.branch_short()])
+            .arg(&work)
+            .arg("HEAD")
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+        (dir, h5i_root, m)
+    }
+
+    #[test]
+    fn open_env_worktree_accepts_the_box_it_belongs_to() {
+        let (_d, h5i_root, m) = worktree_fixture();
+        let wt = open_env_worktree(&h5i_root, &m).expect("the box's own worktree opens");
+        assert_eq!(wt.head().unwrap().name(), Some(m.branch.as_str()));
+    }
+
+    /// The advisory case: the box rewrites `$WORK/.git` to point at the host
+    /// repository, so a later `propose`/`rebase` would stage the box tree onto
+    /// whatever the host has checked out (`main`) instead of the env branch.
+    /// The object store still matches — only HEAD gives it away.
+    #[test]
+    fn open_env_worktree_refuses_a_pointer_redirected_at_the_host_repo() {
+        let (_d, h5i_root, m) = worktree_fixture();
+        let work = m.work_dir(&h5i_root);
+        let host_git = h5i_root.parent().unwrap().to_path_buf();
+        std::fs::write(work.join(".git"), format!("gitdir: {}\n", host_git.display())).unwrap();
+
+        let err = open_env_worktree(&h5i_root, &m).map(|_| ()).expect_err("must fail closed");
+        let msg = err.to_string();
+        assert!(msg.contains(&m.branch), "should name the branch it owns: {msg}");
+        assert!(msg.contains("fail-closed"), "{msg}");
+    }
+
+    /// The same pointer rewritten at an unrelated repository: caught by the
+    /// object-store check rather than the branch check.
+    #[test]
+    fn open_env_worktree_refuses_a_pointer_redirected_at_a_foreign_repo() {
+        let (d, h5i_root, m) = worktree_fixture();
+        let other = d.path().join("other");
+        std::fs::create_dir_all(&other).unwrap();
+        let orepo = Repository::init(&other).unwrap();
+        let sig = git2::Signature::now("t", "t@example.com").unwrap();
+        let tree = orepo.find_tree(orepo.treebuilder(None).unwrap().write().unwrap()).unwrap();
+        orepo.commit(Some("HEAD"), &sig, &sig, "other", &tree, &[]).unwrap();
+        // Give the foreign repo the same branch name, so only the object-store
+        // check can distinguish it.
+        let head = orepo.head().unwrap().peel_to_commit().unwrap();
+        orepo.branch(m.branch_short(), &head, false).unwrap();
+        orepo.set_head(&m.branch).unwrap();
+
+        let work = m.work_dir(&h5i_root);
+        std::fs::write(
+            work.join(".git"),
+            format!("gitdir: {}\n", orepo.path().display()),
+        )
+        .unwrap();
+
+        let err = open_env_worktree(&h5i_root, &m).map(|_| ()).expect_err("must fail closed");
+        assert!(err.to_string().contains("not this box's"), "{err}");
     }
 }

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -2088,9 +2088,11 @@ fn prepare_private_paths(
             let _ = std::fs::remove_dir_all(&backing);
         }
         std::fs::create_dir_all(&backing).map_err(|e| H5iError::with_path(e, &backing))?;
-        // The mountpoint must exist inside the worktree.
-        let target = work.join(&rel);
-        std::fs::create_dir_all(&target).map_err(|e| H5iError::with_path(e, &target))?;
+        // The mountpoint must exist inside the worktree — and *stay* inside it.
+        // `rel` and the worktree are both repo-supplied, so a symlinked
+        // ancestor would otherwise put the mountpoint (and the bind's rw grant)
+        // on an arbitrary host path.
+        sandbox::create_private_mountpoint(work, &rel)?;
         // The image-backed tiers carry the backing dir as a mount *spec string*,
         // and each runtime's syntax reserves a separator its paths cannot
         // contain: Podman's `--mount` splits on ',', microsandbox's

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -2998,20 +2998,35 @@ pub struct BrowserShim {
     pub port: u16,
 }
 
+/// The two directories a `browser` box uses, and the trust line between them.
+///
+/// `state` is granted **write**: it is where the box's own Chrome records its
+/// pid and port. `dir` is granted **read** only, and is where the host keeps
+/// the loopback ports it reserved — those decide what
+/// `policy.loopback_ports` will grant, so they must not be box-writable.
+fn browser_dirs(h5i_root: &Path, m: &EnvManifest) -> (PathBuf, PathBuf) {
+    let dir = m.dir(h5i_root).join("browser");
+    let state = dir.join("state");
+    (dir, state)
+}
+
 /// A loopback port held for the life of the env: read back from `file` when it
 /// is already there, otherwise reserved once and written down. Both ports a
 /// browser box depends on are memorised by something that outlives a single run
 /// (Chrome's CDP endpoint, and the proxy address Chrome was launched with), so
 /// neither can be re-drawn per run.
 fn remembered_port(file: &Path, what: &str, avoid: &[u16]) -> Result<u16, H5iError> {
-    // The file lives under `<env>/browser/state`, which the box is granted write
-    // on (it is where the box's own Chrome records its pid and port), so the
-    // value read back here is box-controlled. Nothing catastrophic follows from
-    // that — a port the box picks is one it could bind itself, and the policy
-    // only ever grants the port the host actually bound — but a `0` would ask
-    // for an ephemeral port under the name of a pinned one, and a privileged
-    // port would fail to bind on every run. Both are rejected in favour of
-    // drawing a fresh port, which is also what a corrupt file gets.
+    // `file` MUST live outside every write grant the box holds. The value read
+    // back here is pushed into `policy.loopback_ports`, which Seatbelt renders
+    // as `(allow network-outbound (remote ip "localhost:<port>"))` — so a box
+    // that could write it would be choosing which host loopback service its own
+    // next session may reach (the operator's Postgres, another box's dev
+    // server). That is why these files sit in `<env>/browser`, which the box is
+    // granted read on, and not in `<env>/browser/state`, which it can write.
+    //
+    // A `0` would still ask for an ephemeral port under the name of a pinned
+    // one and a privileged port would fail to bind on every run, so both are
+    // rejected in favour of drawing a fresh port — as is a corrupt file.
     //
     // `avoid` is the ports this env already holds. A drawn port is found by
     // binding an ephemeral listener and dropping it, so the next draw can be
@@ -3214,8 +3229,7 @@ fn prepare_browser_shim(
     let Some(real) = sandbox::agent_browser_binary() else {
         return Ok(None);
     };
-    let dir = m.dir(h5i_root).join("browser");
-    let state = dir.join("state");
+    let (dir, state) = browser_dirs(h5i_root, m);
     std::fs::create_dir_all(&state).map_err(|e| H5iError::with_path(e, &state))?;
     // Before anything else: a browser the last run found stranded on an old
     // route is stopped here, so the shim launches a fresh one below.
@@ -3226,14 +3240,17 @@ fn prepare_browser_shim(
     // the next run would be a port the still-running Chrome is not listening on
     // — and, worse, the only port the policy grants. Allocated once, then read
     // back for the life of the env.
-    let port = remembered_port(&state.join("cdp-port"), "the box's browser", &[])?;
+    // Reserved in `dir`, not `state`: the box has write on `state` and only read
+    // on `dir`, and these two numbers decide which host loopback ports the
+    // policy will grant.
+    let port = remembered_port(&dir.join("cdp-port"), "the box's browser", &[])?;
     policy.loopback_ports.push(port);
     // The egress allowlist proxy is remembered for the same reason, in the
     // other direction: that surviving Chrome memorises the proxy address it was
     // launched with, and on the macOS supervised tier that proxy is the box's
     // only route out. See [`sandbox::ResolvedPolicy::egress_proxy_port`].
     policy.egress_proxy_port = Some(remembered_port(
-        &state.join("egress-port"),
+        &dir.join("egress-port"),
         "the box's egress proxy",
         &[port],
     )?);
@@ -10034,6 +10051,31 @@ mod tests {
 
         // A missing source fails closed.
         assert!(materialize_persona(work, &["plugin/persona/nope.md".to_string()]).is_err());
+    }
+
+    /// The remembered loopback ports decide what `policy.loopback_ports` grants,
+    /// which macOS turns into `(allow network-outbound (remote ip
+    /// "localhost:<port>"))`. They must therefore live outside the one browser
+    /// directory the box can write, or a box picks the host service its own
+    /// next session may reach.
+    #[test]
+    fn remembered_browser_ports_are_not_box_writable() {
+        let td = tempfile::tempdir().unwrap();
+        let m = wt_manifest("human", "b");
+        let (dir, state) = browser_dirs(td.path(), &m);
+        for f in ["cdp-port", "egress-port"] {
+            assert!(
+                !dir.join(f).starts_with(&state),
+                "{f} must not sit under the box-writable state dir"
+            );
+        }
+        // And the port that is read back is still validated.
+        std::fs::create_dir_all(&dir).unwrap();
+        for bad in ["0", "80", "-1", "not a port", ""] {
+            std::fs::write(dir.join("cdp-port"), bad).unwrap();
+            let got = remembered_port(&dir.join("cdp-port"), "test", &[]).unwrap();
+            assert!(got >= 1024, "{bad:?} yielded {got}");
+        }
     }
 
     /// Build a manifest for an attached box on `refs/heads/h5i/env/<agent>/<slug>`.

--- a/crates/h5i-core/src/receipt.rs
+++ b/crates/h5i-core/src/receipt.rs
@@ -246,17 +246,23 @@ pub fn append(env_dir: &Path, input: RecordInput, raw: &[u8]) -> Result<ExecReco
     let redacted_holder;
     let raw: &[u8] = match std::str::from_utf8(raw) {
         Ok(text) => {
+            // Redaction is UNCONDITIONAL. `scan_text` applies a placeholder
+            // stoplist (`example`, `dummy`, `fake`, …) and skips the whole line
+            // when it hits one, which is right for detection and fail-open for
+            // publication: a box printing `example config: ghp_<real>` produced
+            // no findings, so the credential was stored verbatim. `redact_line`
+            // deliberately has no stoplist for exactly this reason, and there is
+            // a regression test pinning that — gating the call on the detector
+            // put the hole back one level up.
+            //
+            // So scan only to name the rules that fired, and always scrub.
             let findings = crate::secrets::scan_text(Path::new("<receipt>"), text);
-            if findings.is_empty() {
-                raw
-            } else {
-                let mut ids: Vec<String> = findings.iter().map(|f| f.rule_id.to_string()).collect();
-                ids.sort();
-                ids.dedup();
-                redactions = ids;
-                redacted_holder = crate::secrets::redact_text(text).into_bytes();
-                &redacted_holder[..]
-            }
+            let mut ids: Vec<String> = findings.iter().map(|f| f.rule_id.to_string()).collect();
+            ids.sort();
+            ids.dedup();
+            redactions = ids;
+            redacted_holder = crate::secrets::redact_text(text).into_bytes();
+            &redacted_holder[..]
         }
         // Binary payloads are left as-is: the secret scanner is line oriented.
         Err(_) => raw,
@@ -624,6 +630,37 @@ mod tests {
         let rec = append(td.path(), input(), &big).unwrap();
         assert!(rec.raw_truncated);
         assert_eq!(rec.raw_size, RAW_CAP as u64);
+    }
+
+    /// The advisory case: a box prints a credential on a line that also carries
+    /// a placeholder word. `scan_text` skips that line via its stoplist, so
+    /// gating redaction on "did the scanner find anything" stored the token
+    /// verbatim in `<env>/raw/<id>.raw` and in the published evidence.
+    #[test]
+    fn a_stoplist_word_cannot_smuggle_a_credential_into_the_raw_store() {
+        let td = TempDir::new().unwrap();
+        let token = format!("ghp_{}", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8");
+        for line in [
+            format!("example config: {token}"),
+            format!("dummy value {token}"),
+            format!("# fake, do not use: {token}"),
+            format!("${{PLACEHOLDER}} {token}"),
+        ] {
+            let rec = append(td.path(), input(), line.as_bytes()).unwrap();
+            let stored = String::from_utf8(raw_bytes(td.path(), &rec.id).unwrap()).unwrap();
+            assert!(!stored.contains(&token), "stored verbatim: {stored}");
+        }
+    }
+
+    /// Redaction is unconditional now, so a payload with nothing to scrub must
+    /// still round-trip byte for byte.
+    #[test]
+    fn a_clean_payload_is_stored_unchanged() {
+        let td = TempDir::new().unwrap();
+        let body = b"line one\r\nline two\n";
+        let rec = append(td.path(), input(), body).unwrap();
+        assert_eq!(raw_bytes(td.path(), &rec.id).unwrap(), body);
+        assert!(rec.redactions.is_empty());
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/auth_proxy.rs
+++ b/crates/h5i-sandbox/src/auth_proxy.rs
@@ -750,39 +750,54 @@ pub struct Engagement {
 
 /// Decide + spawn the credential-injecting proxy for a run. Shared by both the
 /// container and supervised backends (their only difference is `tier_ok` —
-/// whether the box can reach the host proxy on this tier). `None` keeps the box
-/// on its existing in-box-login path — never a downgrade of an active protection.
-pub fn engage(profile_name: &str, tier_ok: bool) -> Option<Engagement> {
+/// whether the box can reach the host proxy on this tier).
+///
+/// `Ok(None)` means the proxy does not apply: opted out, an unsupported tier, a
+/// non-agent profile, or no host credential to broker. Those keep the box on
+/// its existing in-box-login path and are not a downgrade of anything.
+///
+/// `Err` means the proxy was *supposed* to engage and could not. That is a
+/// different thing entirely and must not be swallowed: the caller would keep
+/// the real credential in the box's HOME copy *and* open the full `net.egress`
+/// allowlist instead of narrowing to the proxy port, which is precisely the
+/// state this module's header claims is unreachable.
+pub fn engage(profile_name: &str, tier_ok: bool) -> Result<Option<Engagement>, H5iError> {
     engage_at(profile_name, tier_ok, SLIRP_GATEWAY_HOST)
 }
 
 /// [`engage`] for a backend whose box reaches the host proxy at `host` rather
 /// than the slirp gateway — the macOS Seatbelt tiers, where the box shares the
 /// host's loopback instead of living in its own network namespace.
-pub fn engage_at(profile_name: &str, tier_ok: bool, host: &str) -> Option<Engagement> {
+pub fn engage_at(
+    profile_name: &str,
+    tier_ok: bool,
+    host: &str,
+) -> Result<Option<Engagement>, H5iError> {
     if !tier_ok || opted_out() {
-        return None;
+        return Ok(None);
     }
-    let rt = AgentRuntime::from_profile_name(profile_name)?;
-    let cred = resolve_credential(rt)?;
-    let token = match new_client_token() {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("note: credential proxy unavailable ({e}); box uses in-box login");
-            return None;
-        }
+    let Some(rt) = AgentRuntime::from_profile_name(profile_name) else {
+        return Ok(None);
     };
-    match spawn(rt, cred, token.clone()) {
-        Ok(handle) => Some(Engagement {
-            box_env: box_env_at(rt, host, handle.port, &token),
-            handle,
-            runtime: rt,
-        }),
-        Err(e) => {
-            eprintln!("note: credential proxy unavailable ({e}); box uses in-box login");
-            None
-        }
-    }
+    let Some(cred) = resolve_credential(rt) else {
+        return Ok(None);
+    };
+    // From here the proxy is expected. Entropy or bind failure is a refusal,
+    // not a fallback: silently continuing would put the long-lived token back
+    // in the box and widen its egress at the same time.
+    let token = new_client_token()?;
+    let handle = spawn(rt, cred, token.clone()).map_err(|e| {
+        H5iError::Metadata(format!(
+            "credential proxy failed to start ({e}) — refusing to run the box with its own \
+             credentials and the full egress allowlist instead (fail-closed). Set \
+             H5I_NO_AUTH_PROXY=1 to opt out deliberately."
+        ))
+    })?;
+    Ok(Some(Engagement {
+        box_env: box_env_at(rt, host, handle.port, &token),
+        handle,
+        runtime: rt,
+    }))
 }
 
 #[cfg(test)]
@@ -795,6 +810,22 @@ mod tests {
     /// otherwise race on the same vars. Poison-tolerant (a panicking test must
     /// not wedge the rest).
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// The not-applicable cases stay `Ok(None)`: they keep a working in-box
+    /// login working and are not a downgrade of anything.
+    #[test]
+    fn engage_reports_not_applicable_as_ok_none() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Unsupported tier.
+        assert!(engage_at("agent-claude", false, "127.0.0.1").unwrap().is_none());
+        // Not an agent profile.
+        assert!(engage_at("default", true, "127.0.0.1").unwrap().is_none());
+        // Agent profile with no host credential to broker.
+        for v in ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"] {
+            std::env::remove_var(v);
+        }
+        assert!(engage_at("agent-claude", true, "127.0.0.1").unwrap().is_none());
+    }
 
     #[test]
     fn resolve_credential_precedence_claude() {

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -1290,6 +1290,23 @@ pub fn build_run_argv(
             // Default rootless network (slirp4netns/pasta) gives NAT'd egress.
         }
         NetPlan::Proxy(port) => {
+            // HONESTY: `allow_host_loopback=true` is what lets the box reach the
+            // host-side proxy at the gateway address — and it exposes every
+            // *other* host loopback service there too. Choosing the allowlist
+            // plan therefore widens the box's reach relative to plain rootless
+            // NAT, which is the opposite of how an allowlist reads.
+            //
+            // Two consequences worth naming: the box can reach `h5i ui`'s
+            // console API and any local database on 127.0.0.1, and it can reach
+            // another concurrent box's egress proxy, which has no client
+            // authentication — borrowing that box's wider allowlist.
+            //
+            // Not fixable at this layer: the proxy has to be reachable, and
+            // slirp4netns exposes loopback all-or-nothing. Narrowing it needs
+            // the proxy inside the box's network namespace instead. The
+            // supervised tiers already avoid it (nftables narrows the jail to
+            // the proxy port; Seatbelt refuses host loopback wholesale), and
+            // `announce_egress` states the caveat at session start.
             if let Some(mode) = HOST_ROUTE.network_arg {
                 a.push(format!("--network={mode}"));
             }

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -1313,26 +1313,32 @@ pub fn build_run_argv(
 /// stays host-side in the proxy; the box never receives it — this is "option 2":
 /// the box can authenticate to its provider API without ever holding the token.
 ///
-/// Returns `None` (keeping the box on its existing in-box-login path) when: the
-/// net plan has no proxy to reach the host loopback, the profile is not a known
-/// agent runtime, no host credential is available, or the proxy fails to spawn.
-/// We never *downgrade* an active protection, and never break a working
-/// interactive-login flow that has no host token to broker.
+/// `Ok(None)` (keeping the box on its existing in-box-login path) when: the net
+/// plan has no proxy to reach the host loopback, the profile is not a known
+/// agent runtime, or no host credential is available. Those never break a
+/// working interactive-login flow that has no host token to broker.
+///
+/// A proxy that was supposed to start and could not is an `Err`, not a `None`:
+/// falling back would leave the real credential in the box while also widening
+/// its egress, which is the opposite of what this exists to do.
 fn maybe_auth_proxy(
     profile: &Profile,
     net: &NetPlan,
-) -> Option<(crate::auth_proxy::AuthProxyHandle, Vec<(String, String)>)> {
+) -> Result<Option<(crate::auth_proxy::AuthProxyHandle, Vec<(String, String)>)>, H5iError> {
     // The box reaches the host proxy only on the egress-proxy net plan, and at
     // whichever address this platform routes to the host ([`HOST_ROUTE`]).
     // `engage_at` handles opt-out + runtime + credential resolution; the
     // container tier ignores the returned runtime (there is no per-env HOME copy
     // to scrub — the rootfs never mounts host HOME).
-    let e = crate::auth_proxy::engage_at(
+    let Some(e) = crate::auth_proxy::engage_at(
         &profile.name,
         matches!(net, NetPlan::Proxy(_)),
         HOST_ROUTE.host_addr,
-    )?;
-    Some((e.handle, e.box_env))
+    )?
+    else {
+        return Ok(None);
+    };
+    Ok(Some((e.handle, e.box_env)))
 }
 
 /// Live proxies for a box's authenticated-egress grants, and the env the box
@@ -1416,7 +1422,7 @@ pub fn run(
     // Credential-injecting auth proxy (option 2): held for the container's
     // lifetime. When engaged, the real API token stays host-side and the box is
     // handed only a base-URL override + per-run dummy (appended to the env).
-    let (_auth_proxy, effective_env) = match maybe_auth_proxy(p, &net) {
+    let (_auth_proxy, effective_env) = match maybe_auth_proxy(p, &net)? {
         Some((handle, extra)) => {
             let mut env = injected_env.to_vec();
             env.extend(extra);
@@ -1524,7 +1530,7 @@ pub fn run_interactive(
     };
 
     // Credential-injecting auth proxy (option 2), held for the session lifetime.
-    let (_auth_proxy, effective_env) = match maybe_auth_proxy(p, &net) {
+    let (_auth_proxy, effective_env) = match maybe_auth_proxy(p, &net)? {
         Some((handle, extra)) => {
             let mut env = injected_env.to_vec();
             env.extend(extra);

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -281,6 +281,68 @@ struct AllowEntry {
     pinned: Vec<IpAddr>,
 }
 
+/// Parse one `net.egress` entry into `(host, wildcard, port)`, fail-closed.
+///
+/// This is the single definition of the grammar. It used to exist twice — here
+/// and in `microvm::egress_rule_tokens` — and the copies drifted: the microvm
+/// side refused an out-of-range port, a single-label wildcard, an IPv6 literal
+/// and the reserved `,`/`@`, while this side silently widened or mangled all
+/// four. `example.com:99999` in particular became an *any-port* rule, the exact
+/// opposite of what the entry asked for.
+///
+/// `Ok(None)` is a blank entry (skip it); anything malformed is an error.
+pub fn parse_egress_rule(raw: &str) -> Result<Option<(String, bool, Option<u16>)>, H5iError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    if raw.contains(',') || raw.contains('@') {
+        return Err(H5iError::Metadata(format!(
+            "net.egress entry '{raw}' contains ',' or '@', which the rule grammar reserves — \
+             refusing rather than emitting a rule that means something else (fail-closed). \
+             Split it into separate entries."
+        )));
+    }
+    // An IPv6 literal is full of colons and the port split cannot tell one from
+    // a `host:port`: `2001:db8::1` came out as host `2001:db8:` port 1. There is
+    // no unambiguous spelling here, so refuse rather than translate it wrong.
+    if raw.matches(':').count() > 1 {
+        return Err(H5iError::Metadata(format!(
+            "net.egress entry '{raw}' looks like an IPv6 literal (more than one ':'), which the \
+             rule grammar cannot carry unambiguously — refusing rather than emitting a rule that \
+             means something else (fail-closed). Use a hostname, or an IPv4 address or CIDR."
+        )));
+    }
+    let (host_part, port) = match raw.rsplit_once(':') {
+        // Only a trailing all-digit segment is a port.
+        Some((h, p)) if !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()) => {
+            let port = p.parse::<u16>().map_err(|_| {
+                H5iError::Metadata(format!(
+                    "net.egress entry '{raw}' has a port outside 1-65535 — refusing rather than \
+                     falling back to an any-port rule (fail-closed)."
+                ))
+            })?;
+            (h, Some(port))
+        }
+        _ => (raw, None),
+    };
+    let lower = host_part.to_ascii_lowercase();
+    let (host, wildcard) = match lower.strip_prefix("*.").or_else(|| lower.strip_prefix('.')) {
+        Some(rest) => (rest.to_string(), true),
+        None => (lower, false),
+    };
+    if host.is_empty() {
+        return Ok(None);
+    }
+    if wildcard && host.split('.').filter(|l| !l.is_empty()).count() < 2 {
+        return Err(H5iError::Metadata(format!(
+            "net.egress wildcard '{raw}' covers a single label — a suffix rule must name at \
+             least two (e.g. '*.example.com', not '*.com'). Refusing (fail-closed)."
+        )));
+    }
+    Ok(Some((host, wildcard, port)))
+}
+
 impl AllowEntry {
     /// Does this entry open `port`? `None` means any.
     fn port_ok(&self, port: u16) -> bool {
@@ -407,30 +469,13 @@ pub struct AllowList {
 }
 
 impl AllowList {
-    /// Parse `net.egress` entries (no DNS yet — pure, for tests).
-    pub fn parse(egress: &[String]) -> AllowList {
+    /// Parse `net.egress` entries through [`parse_egress_rule`] (no DNS yet —
+    /// pure, for tests). Fail-closed: a malformed entry is an error, never a
+    /// rule that means something wider than what was written.
+    pub fn parse(egress: &[String]) -> Result<AllowList, H5iError> {
         let mut entries = Vec::new();
         for raw in egress {
-            let raw = raw.trim();
-            if raw.is_empty() {
-                continue;
-            }
-            let (host_part, port) = match raw.rsplit_once(':') {
-                // Only treat the suffix as a port if it's numeric (IPv6 has colons).
-                Some((h, p)) if p.chars().all(|c| c.is_ascii_digit()) && !p.is_empty() => {
-                    (h, p.parse::<u16>().ok())
-                }
-                _ => (raw, None),
-            };
-            let lower = host_part.to_ascii_lowercase();
-            let (host, wildcard) = if let Some(s) = lower.strip_prefix("*.") {
-                (s.to_string(), true)
-            } else if let Some(s) = lower.strip_prefix('.') {
-                (s.to_string(), true)
-            } else {
-                (lower, false)
-            };
-            if !host.is_empty() {
+            if let Some((host, wildcard, port)) = parse_egress_rule(raw)? {
                 entries.push(AllowEntry {
                     host,
                     wildcard,
@@ -439,7 +484,7 @@ impl AllowList {
                 });
             }
         }
-        AllowList { entries }
+        Ok(AllowList { entries })
     }
 
     /// Resolve every exact allowed host and pin the answers onto its entry.
@@ -1407,7 +1452,7 @@ pub fn run(
     let egress_rules = effective_egress(&p.net_egress, &policy.user_egress_allow);
     let mut _proxy: Option<ProxyHandle> = None;
     let net = if !egress_rules.is_empty() {
-        let mut allow = AllowList::parse(&egress_rules);
+        let mut allow = AllowList::parse(&egress_rules)?;
         allow.pin_dns();
         let handle = spawn_proxy(allow)?;
         let port = handle.port;
@@ -1517,7 +1562,7 @@ pub fn run_interactive(
     let egress_rules = effective_egress(&p.net_egress, &policy.user_egress_allow);
     let mut _proxy: Option<ProxyHandle> = None;
     let net = if !egress_rules.is_empty() {
-        let mut allow = AllowList::parse(&egress_rules);
+        let mut allow = AllowList::parse(&egress_rules)?;
         allow.pin_dns();
         let handle = spawn_proxy(allow)?;
         let port = handle.port;
@@ -1772,7 +1817,7 @@ mod tests {
             "github.com:443".into(),
             ".githubusercontent.com".into(),
             "*.pythonhosted.org".into(),
-        ]);
+        ]).unwrap();
         // Exact host, any port.
         assert!(a.allows("pypi.org", 443));
         assert!(a.allows("pypi.org", 80));
@@ -1796,14 +1841,14 @@ mod tests {
 
     #[test]
     fn empty_allowlist_denies_everything() {
-        let a = AllowList::parse(&[]);
+        let a = AllowList::parse(&[]).unwrap();
         assert!(!a.allows("anything.com", 443));
     }
 
     /// Build an allowlist with a hand-placed pin, so the pinning behaviour is
     /// testable without touching the network.
     fn pinned(rule: &str, ips: &[&str]) -> AllowList {
-        let mut a = AllowList::parse(&[rule.to_string()]);
+        let mut a = AllowList::parse(&[rule.to_string()]).unwrap();
         a.entries[0].pinned = ips.iter().map(|i| i.parse().unwrap()).collect();
         a
     }
@@ -1896,12 +1941,40 @@ mod tests {
         }
     }
 
+    /// The container tier used to widen or mangle four inputs the microvm tier
+    /// already refused. One parser now, so they cannot disagree again.
+    #[test]
+    fn the_egress_grammar_is_fail_closed_for_both_tiers() {
+        // An out-of-range port became an ANY-port rule — the opposite of the ask.
+        for bad in [
+            "example.com:99999",
+            "*.com",                  // a whole TLD
+            "2001:db8::1",            // mangled into host "2001:db8:" port 1
+            "a,b.example.com",        // reserved separator
+            "user@example.com",
+        ] {
+            assert!(
+                AllowList::parse(&[bad.to_string()]).is_err(),
+                "container tier accepted {bad:?}"
+            );
+            assert!(
+                crate::microvm::egress_rule_tokens(&[bad.to_string()]).is_err(),
+                "microvm tier accepted {bad:?}"
+            );
+        }
+        // And the well-formed shapes still parse on both.
+        for good in ["example.com", "example.com:443", ".example.com", "*.example.com"] {
+            assert!(AllowList::parse(&[good.to_string()]).is_ok(), "{good}");
+            assert!(crate::microvm::egress_rule_tokens(&[good.to_string()]).is_ok(), "{good}");
+        }
+    }
+
     /// An operator may list a literal address. That entry must keep matching
     /// itself even though nothing pinned it (the proxy's relay tests dial a
     /// local upstream this way).
     #[test]
     fn a_literal_ip_entry_still_matches_itself() {
-        let a = AllowList::parse(&["127.0.0.1:8080".into()]);
+        let a = AllowList::parse(&["127.0.0.1:8080".into()]).unwrap();
         assert!(a.allows("127.0.0.1", 8080));
         assert!(!a.allows("127.0.0.1", 9090), "the port on the entry still binds");
         assert_eq!(a.dial_addrs("127.0.0.1", 8080)[0].to_string(), "127.0.0.1:8080");
@@ -1910,7 +1983,7 @@ mod tests {
     /// Wildcard matching stays anchored on a label boundary.
     #[test]
     fn wildcard_matching_is_label_anchored() {
-        let a = AllowList::parse(&[".githubusercontent.com".into()]);
+        let a = AllowList::parse(&[".githubusercontent.com".into()]).unwrap();
         assert!(a.allows("raw.githubusercontent.com", 443));
         assert!(a.allows("githubusercontent.com", 443));
         assert!(!a.allows("evilgithubusercontent.com", 443));
@@ -1937,7 +2010,7 @@ mod tests {
     #[test]
     fn allowlist_does_not_treat_ipv6_as_port() {
         // A bare IPv6-ish string must not be mis-split on its colons.
-        let a = AllowList::parse(&["example.org".into()]);
+        let a = AllowList::parse(&["example.org".into()]).unwrap();
         assert!(a.allows("example.org", 443));
     }
 
@@ -2789,7 +2862,7 @@ mod tests {
 
         // Allow only an unreachable host so we never actually open egress; we
         // only assert the gate's accept/deny verdict.
-        let allow = AllowList::parse(&["allowed.invalid:443".into()]);
+        let allow = AllowList::parse(&["allowed.invalid:443".into()]).unwrap();
         let proxy = spawn_proxy(allow).unwrap();
 
         // Denied host → 403, fail-closed.
@@ -2844,7 +2917,7 @@ mod tests {
             s.write_all(b"PONG").unwrap();
         });
 
-        let allow = AllowList::parse(&[format!("127.0.0.1:{origin_port}")]);
+        let allow = AllowList::parse(&[format!("127.0.0.1:{origin_port}")]).unwrap();
         let proxy = spawn_proxy(allow).unwrap();
         let mut c = TcpStream::connect(("127.0.0.1", proxy.port)).unwrap();
         c.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
@@ -2900,7 +2973,7 @@ mod tests {
         // One connection into `handle_proxy_client`, no accept loop involved.
         let front = TcpListener::bind("127.0.0.1:0").unwrap();
         let front_port = front.local_addr().unwrap().port();
-        let allow = AllowList::parse(&[format!("127.0.0.1:{origin_port}")]);
+        let allow = AllowList::parse(&[format!("127.0.0.1:{origin_port}")]).unwrap();
         std::thread::spawn(move || {
             let (s, _) = front.accept().unwrap();
             let tally = Arc::new(Mutex::new(EgressTally::default()));
@@ -2954,7 +3027,7 @@ mod tests {
 
         let front = TcpListener::bind("127.0.0.1:0").unwrap();
         let front_port = front.local_addr().unwrap().port();
-        let allow = AllowList::parse(&[format!("127.0.0.1:{origin_port}")]);
+        let allow = AllowList::parse(&[format!("127.0.0.1:{origin_port}")]).unwrap();
         std::thread::spawn(move || {
             let (s, _) = front.accept().unwrap();
             s.set_nonblocking(true).unwrap();
@@ -2999,7 +3072,7 @@ mod tests {
     /// ephemeral-fallback note on success; that stderr line is expected here.
     #[test]
     fn proxy_binds_the_requested_port_and_falls_back_when_it_cannot() {
-        let allow = || AllowList::parse(&["allowed.invalid".into()]);
+        let allow = || AllowList::parse(&["allowed.invalid".into()]).unwrap();
 
         let mut honoured = None;
         for _ in 0..5 {

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -276,6 +276,67 @@ struct AllowEntry {
     wildcard: bool,
     /// Restrict to a single port when present; `None` = any port.
     port: Option<u16>,
+    /// Addresses this exact host resolved to at startup. Empty for a wildcard
+    /// (unenumerable) or when startup resolution failed.
+    pinned: Vec<IpAddr>,
+}
+
+impl AllowEntry {
+    /// Does this entry open `port`? `None` means any.
+    fn port_ok(&self, port: u16) -> bool {
+        self.port.is_none_or(|p| p == port)
+    }
+
+    /// Does this entry cover `host:port`? `host` must already be lower-cased
+    /// and free of a trailing dot.
+    fn matches(&self, host: &str, port: u16) -> bool {
+        self.port_ok(port)
+            && if self.wildcard {
+                host == self.host
+                    || host
+                        .strip_suffix(self.host.as_str())
+                        .is_some_and(|p| p.ends_with('.'))
+            } else {
+                host == self.host
+            }
+    }
+}
+
+/// Is this address one the box has no business reaching through the proxy?
+///
+/// Used only where a destination could not be pinned. The proxy runs on the
+/// host with full host network access, so an unpinned name that resolves to
+/// loopback, a private range, or the cloud metadata link-local address turns
+/// the egress boundary into an SSRF gadget. `IpAddr::is_global` is still
+/// unstable, so the ranges are spelled out.
+fn is_internal(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(a) => {
+            let [o0, o1, ..] = a.octets();
+            a.is_loopback()
+                || a.is_private()
+                || a.is_link_local()
+                || a.is_broadcast()
+                || a.is_documentation()
+                || a.is_unspecified()
+                || a.is_multicast()
+                || o0 == 0
+                || (o0 == 100 && (64..128).contains(&o1)) // CGNAT 100.64/10
+                || (o0 == 198 && (o1 & 0xfe) == 18) // benchmarking 198.18/15
+                || o0 >= 240 // reserved 240/4
+        }
+        IpAddr::V6(a) => {
+            if let Some(v4) = a.to_ipv4_mapped() {
+                return is_internal(&IpAddr::V4(v4));
+            }
+            let s0 = a.segments()[0];
+            a.is_loopback()
+                || a.is_unspecified()
+                || a.is_multicast()
+                || (s0 & 0xfe00) == 0xfc00 // unique-local fc00::/7
+                || (s0 & 0xffc0) == 0xfe80 // link-local fe80::/10
+        }
+    }
 }
 
 /// The agent hook-config files that every image-backed tier mounts read-only
@@ -331,13 +392,18 @@ pub fn effective_egress(profile_egress: &[String], user_allow: &[String]) -> Vec
     out
 }
 
-/// A resolved egress allowlist: parsed host rules plus the set of IPs the
-/// allowed domains pinned to at startup (so a client connecting by a pinned IP
-/// is permitted, and the proxy is DNS-rebinding resistant).
+/// A resolved egress allowlist: parsed host rules, each carrying the addresses
+/// its host pinned to at startup.
+///
+/// The pin is what makes the proxy DNS-rebinding resistant, and it only works
+/// if the proxy *dials* the pinned address. Matching a name and then calling
+/// `TcpStream::connect((host, port))` re-resolves, which is how an allowlisted
+/// domain under attacker DNS control used to reach host loopback or a metadata
+/// endpoint through a proxy that has full host network access. See
+/// [`AllowList::dial_addrs`].
 #[derive(Debug, Clone, Default)]
 pub struct AllowList {
     entries: Vec<AllowEntry>,
-    pinned_ips: HashSet<IpAddr>,
 }
 
 impl AllowList {
@@ -369,58 +435,78 @@ impl AllowList {
                     host,
                     wildcard,
                     port,
+                    pinned: Vec::new(),
                 });
             }
         }
-        AllowList {
-            entries,
-            pinned_ips: HashSet::new(),
-        }
+        AllowList { entries }
     }
 
-    /// Resolve every allowed host to IPs and pin them. Best-effort: a host that
-    /// fails to resolve simply contributes no pinned IPs (it can still match by
-    /// name at CONNECT time). Returns the count pinned.
+    /// Resolve every exact allowed host and pin the answers onto its entry.
+    /// Best-effort: a host that fails to resolve keeps an empty pin and falls
+    /// back to a guarded resolve at CONNECT time (see [`Self::dial_addrs`]).
+    /// Returns the number of distinct addresses pinned.
     pub fn pin_dns(&mut self) -> usize {
-        let mut pinned = HashSet::new();
-        for e in &self.entries {
+        let mut distinct = HashSet::new();
+        for e in &mut self.entries {
             if e.wildcard {
                 continue; // can't enumerate a wildcard's IPs
             }
             let port = e.port.unwrap_or(443);
             if let Ok(addrs) = (e.host.as_str(), port).to_socket_addrs() {
-                for a in addrs {
-                    pinned.insert(a.ip());
-                }
+                e.pinned = addrs.map(|a| a.ip()).collect();
+                distinct.extend(e.pinned.iter().copied());
             }
         }
-        let n = pinned.len();
-        self.pinned_ips = pinned;
-        n
+        distinct.len()
+    }
+
+    /// The addresses the proxy may dial for an already-[`allowed`](Self::allows)
+    /// request. Empty means refuse.
+    ///
+    /// Pinned addresses win, so the name the allowlist matched and the address
+    /// the socket reaches are decided by the *same* DNS answer. Only a wildcard
+    /// entry (or a host that would not resolve at startup) falls through to a
+    /// live lookup, and that answer is filtered to globally routable addresses:
+    /// without a pin there is nothing else standing between a rebound record
+    /// and the host's own loopback.
+    pub fn dial_addrs(&self, host: &str, port: u16) -> Vec<std::net::SocketAddr> {
+        let h = host.trim().trim_end_matches('.').to_ascii_lowercase();
+        if let Ok(ip) = h.parse::<IpAddr>() {
+            return vec![std::net::SocketAddr::new(ip, port)];
+        }
+        let mut out: Vec<std::net::SocketAddr> = Vec::new();
+        for e in self.entries.iter().filter(|e| e.matches(&h, port)) {
+            out.extend(e.pinned.iter().map(|ip| std::net::SocketAddr::new(*ip, port)));
+        }
+        if !out.is_empty() {
+            out.sort();
+            out.dedup();
+            return out;
+        }
+        (h.as_str(), port)
+            .to_socket_addrs()
+            .map(|it| it.filter(|a| !is_internal(&a.ip())).collect())
+            .unwrap_or_default()
     }
 
     /// Decide whether a CONNECT/request to `host:port` is allowed (fail-closed:
     /// the empty allowlist permits nothing).
     pub fn allows(&self, host: &str, port: u16) -> bool {
         let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
-        // Direct connection to a pinned IP of an allowed host.
+        // Direct connection by address: permitted only when some entry pinned
+        // that exact IP *and* opened this port. Ignoring the port here let
+        // `CONNECT <pinned-ip>:22` through on an allowlist of `host:443`.
         if let Ok(ip) = host.parse::<IpAddr>() {
-            if self.pinned_ips.contains(&ip) {
-                return true;
-            }
+            return self.entries.iter().any(|e| {
+                e.port_ok(port)
+                    // Either an address the allowlist pinned for one of its
+                    // names, or an address the operator listed literally.
+                    && (e.pinned.contains(&ip) || (!e.wildcard && e.host == host))
+            });
         }
         for e in &self.entries {
-            if let Some(p) = e.port {
-                if p != port {
-                    continue;
-                }
-            }
-            let name_ok = if e.wildcard {
-                host == e.host || host.ends_with(&format!(".{}", e.host))
-            } else {
-                host == e.host
-            };
-            if name_ok {
+            if e.matches(&host, port) {
                 return true;
             }
         }
@@ -637,9 +723,13 @@ fn handle_proxy_client(
         let _ = client.write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n");
         return Ok(());
     }
-    let mut upstream = match TcpStream::connect((host.as_str(), port)) {
-        Ok(s) => s,
-        Err(_) => {
+    // Dial the address the allowlist pinned, not a fresh lookup of the name it
+    // matched: re-resolving here is what let a rebound record send the proxy —
+    // a host process with full host network access — at loopback instead.
+    let addrs = allow.dial_addrs(&host, port);
+    let mut upstream = match addrs.iter().find_map(|a| TcpStream::connect(a).ok()) {
+        Some(s) => s,
+        None => {
             let _ = client.write_all(b"HTTP/1.1 502 Bad Gateway\r\n\r\n");
             return Ok(());
         }
@@ -1672,6 +1762,91 @@ mod tests {
     fn empty_allowlist_denies_everything() {
         let a = AllowList::parse(&[]);
         assert!(!a.allows("anything.com", 443));
+    }
+
+    /// Build an allowlist with a hand-placed pin, so the pinning behaviour is
+    /// testable without touching the network.
+    fn pinned(rule: &str, ips: &[&str]) -> AllowList {
+        let mut a = AllowList::parse(&[rule.to_string()]);
+        a.entries[0].pinned = ips.iter().map(|i| i.parse().unwrap()).collect();
+        a
+    }
+
+    /// Matching by name and then re-resolving let an allowlisted domain under
+    /// attacker DNS control point the proxy at anything. The proxy must dial
+    /// the address the allowlist pinned.
+    #[test]
+    fn dial_uses_the_pinned_address_not_a_fresh_lookup() {
+        let a = pinned("api.example.com", &["203.0.113.10", "203.0.113.11"]);
+        let addrs = a.dial_addrs("api.example.com", 443);
+        assert_eq!(addrs.len(), 2);
+        assert!(addrs.iter().all(|x| x.ip().to_string().starts_with("203.0.113.")));
+        assert!(addrs.iter().all(|x| x.port() == 443));
+    }
+
+    /// A pinned IP opens only the port its entry named. Ignoring the port here
+    /// turned an allowlist of `host:443` into a free pass to `host:22`.
+    #[test]
+    fn a_pinned_ip_does_not_open_every_port() {
+        let a = pinned("github.com:443", &["140.82.121.4"]);
+        assert!(a.allows("140.82.121.4", 443));
+        assert!(!a.allows("140.82.121.4", 22));
+        // An address nobody pinned stays refused on any port.
+        assert!(!a.allows("140.82.121.5", 443));
+    }
+
+    /// A wildcard cannot be pinned, so its lookup happens at CONNECT time —
+    /// and that answer must not be allowed to name an internal address.
+    #[test]
+    fn unpinnable_destinations_refuse_internal_addresses() {
+        for ip in [
+            "127.0.0.1",
+            "169.254.169.254", // cloud metadata
+            "10.1.2.3",
+            "192.168.1.1",
+            "172.16.0.1",
+            "100.64.0.1", // CGNAT
+            "0.0.0.0",
+            "::1",
+            "fd00::1",   // unique-local
+            "fe80::1",   // link-local
+            "::ffff:127.0.0.1",
+        ] {
+            assert!(is_internal(&ip.parse().unwrap()), "{ip} should be internal");
+        }
+        for ip in ["93.184.216.34", "8.8.8.8", "2606:4700::1111"] {
+            assert!(!is_internal(&ip.parse().unwrap()), "{ip} should be routable");
+        }
+    }
+
+    /// A literal IP target is dialled verbatim — `allows` has already checked
+    /// it against the pins, so there is nothing left to resolve.
+    #[test]
+    fn a_literal_ip_target_is_dialled_as_given() {
+        let a = pinned("api.example.com", &["203.0.113.10"]);
+        let addrs = a.dial_addrs("203.0.113.10", 443);
+        assert_eq!(addrs.len(), 1);
+        assert_eq!(addrs[0].to_string(), "203.0.113.10:443");
+    }
+
+    /// An operator may list a literal address. That entry must keep matching
+    /// itself even though nothing pinned it (the proxy's relay tests dial a
+    /// local upstream this way).
+    #[test]
+    fn a_literal_ip_entry_still_matches_itself() {
+        let a = AllowList::parse(&["127.0.0.1:8080".into()]);
+        assert!(a.allows("127.0.0.1", 8080));
+        assert!(!a.allows("127.0.0.1", 9090), "the port on the entry still binds");
+        assert_eq!(a.dial_addrs("127.0.0.1", 8080)[0].to_string(), "127.0.0.1:8080");
+    }
+
+    /// Wildcard matching stays anchored on a label boundary.
+    #[test]
+    fn wildcard_matching_is_label_anchored() {
+        let a = AllowList::parse(&[".githubusercontent.com".into()]);
+        assert!(a.allows("raw.githubusercontent.com", 443));
+        assert!(a.allows("githubusercontent.com", 443));
+        assert!(!a.allows("evilgithubusercontent.com", 443));
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -683,6 +683,27 @@ fn parse_target(head: &[u8]) -> Option<(String, u16, bool)> {
 /// box that points its Chrome elsewhere reaches a port it is denied anyway.
 pub const EGRESS_PROXY_VAR: &str = "H5I_EGRESS_PROXY";
 
+/// Environment variables that carry the egress proxy wiring. A profile's
+/// `env.pass` must never re-export one of these: podman applies `--env` in
+/// order, so a later name-only pass would replace h5i's value with the host's
+/// and route the box around the allowlist entirely.
+pub const PROXY_WIRING_VARS: [&str; 8] = [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
+
+/// Is `key` part of the proxy wiring (case-insensitively)?
+pub fn is_proxy_wiring_var(key: &str) -> bool {
+    key.eq_ignore_ascii_case(EGRESS_PROXY_VAR)
+        || PROXY_WIRING_VARS.iter().any(|v| key.eq_ignore_ascii_case(v))
+}
+
 /// How long a connection may take to finish sending its request head. It bounds
 /// only the head: a client that connects and says nothing must not hold a thread,
 /// but once the tunnel is up the relay has no clock of its own (see the reset
@@ -1254,7 +1275,16 @@ pub fn build_run_argv(
     // value never lands in the container's argv — which is world-readable on a
     // default host via `/proc/<podman-pid>/cmdline`. (`--env KEY=VALUE` would
     // leak it there.)
+    let proxied = matches!(net, NetPlan::Proxy(_));
     for key in &profile.env_pass {
+        // Podman applies `--env` in order, and the proxy wiring was pushed
+        // above. A profile passing HTTPS_PROXY or NO_PROXY through — plausible
+        // behind a corporate proxy, and repo-supplied like the rest of the
+        // policy — would otherwise replace h5i's value with the host's and
+        // egress unfiltered through the rootless NAT.
+        if proxied && is_proxy_wiring_var(key) {
+            continue;
+        }
         if std::env::var_os(key).is_some() {
             a.push("--env".into());
             a.push(key.clone());
@@ -1827,6 +1857,37 @@ mod tests {
         let addrs = a.dial_addrs("203.0.113.10", 443);
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0].to_string(), "203.0.113.10:443");
+    }
+
+    /// Podman applies `--env` in order and the proxy wiring is pushed first, so
+    /// an `env.pass` entry naming one of those variables would replace h5i's
+    /// value with the host's and route the box around the allowlist.
+    #[test]
+    fn env_pass_cannot_shadow_the_egress_proxy_wiring() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut p = Profile::builtin("default", crate::sandbox_policy::IsolationClaim::Container);
+        p.env_pass = vec!["HTTPS_PROXY".into(), "no_proxy".into(), "PATH".into()];
+        // Safety: single-threaded test; the vars are read back immediately.
+        unsafe {
+            std::env::set_var("HTTPS_PROXY", "http://attacker.invalid:3128");
+            std::env::set_var("no_proxy", "*");
+        }
+        let argv = build_run_argv(
+            &rt(), &p, &[], None, tmp.path(), "img", "n", &NetPlan::Proxy(9999),
+            &["true".into()], &[], None, None, &[], None, None, None, &[],
+        );
+        // The wiring h5i pushed is present exactly once and is never re-passed
+        // by name (a name-only `--env HTTPS_PROXY` would take the host value).
+        assert!(argv.iter().any(|a| a == "HTTPS_PROXY=http://10.0.2.2:9999"
+            || a.starts_with("HTTPS_PROXY=http://")));
+        assert!(!argv.iter().any(|a| a == "HTTPS_PROXY"), "{argv:?}");
+        assert!(!argv.iter().any(|a| a == "no_proxy"), "{argv:?}");
+        // Unrelated allowlist entries still pass.
+        assert!(argv.iter().any(|a| a == "PATH"));
+        unsafe {
+            std::env::remove_var("HTTPS_PROXY");
+            std::env::remove_var("no_proxy");
+        }
     }
 
     /// An operator may list a literal address. That entry must keep matching

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -278,6 +278,35 @@ struct AllowEntry {
     port: Option<u16>,
 }
 
+/// The agent hook-config files that every image-backed tier mounts read-only
+/// over their place in `$WORK`, so the in-box agent cannot rewrite the file
+/// that defines its own observation hook.
+pub const AGENT_CONFIG_RELS: [&str; 2] = [".claude/settings.json", ".codex/config.toml"];
+
+/// Resolve one agent config file into a mount source, refusing anything that is
+/// not a regular file that really lives inside `$WORK`.
+///
+/// `$WORK` holds the branch under review, so this path and every directory
+/// above it are supplied by the repository. `Path::exists()` follows symlinks
+/// and the *unresolved* path is what would reach the mount spec, which the
+/// kernel then resolves host-side: a branch shipping `.claude/settings.json`
+/// as a symlink to `~/.ssh` would have h5i mount that directory into the box.
+/// The exposure is created entirely by the mount — left alone, the link dangles
+/// inside the box's mount namespace because the target is not in it.
+///
+/// `symlink_metadata` refuses a symlinked final component; canonicalizing and
+/// re-checking the prefix refuses a symlinked *ancestor*, which is the same
+/// trick one directory up.
+pub fn agent_config_mount_source(work: &Path, rel: &str) -> Option<PathBuf> {
+    let source = work.join(rel);
+    if !std::fs::symlink_metadata(&source).is_ok_and(|md| md.file_type().is_file()) {
+        return None;
+    }
+    let canon_work = work.canonicalize().ok()?;
+    let canon = source.canonicalize().ok()?;
+    canon.starts_with(&canon_work).then_some(canon)
+}
+
 /// Combine the digested profile allowlist with the host-side user extras
 /// (`h5i box allow`) into the rule set the proxy enforces. **Fail-closed
 /// widening rule:** when the profile's own `net.egress` is empty (deny-all),
@@ -971,9 +1000,11 @@ pub fn build_run_argv(
             b.target.display()
         ));
     }
-    for rel in [".claude/settings.json", ".codex/config.toml"] {
-        let source = work.join(rel);
-        if source.exists() && !source.display().to_string().contains(',') {
+    for rel in AGENT_CONFIG_RELS {
+        let Some(source) = agent_config_mount_source(work, rel) else {
+            continue;
+        };
+        if !source.display().to_string().contains(',') {
             a.push("--mount".into());
             a.push(format!(
                 "type=bind,source={},target=/work/{rel},ro",
@@ -1730,7 +1761,9 @@ mod tests {
     #[test]
     fn run_argv_mounts_agent_hook_configs_read_only() {
         let tmp = tempfile::tempdir().unwrap();
-        let work = tmp.path();
+        // Canonicalized: the mount source is the resolved path, so the test has
+        // to agree on hosts where the temp root is itself a symlink.
+        let work = &tmp.path().canonicalize().unwrap();
         std::fs::create_dir_all(work.join(".claude")).unwrap();
         std::fs::create_dir_all(work.join(".codex")).unwrap();
         std::fs::write(work.join(".claude/settings.json"), "{}").unwrap();
@@ -1765,6 +1798,52 @@ mod tests {
             "type=bind,source={},target=/work/.codex/config.toml,ro",
             work.join(".codex/config.toml").display()
         )));
+    }
+
+    /// A branch under review can ship `.claude/settings.json` as a symlink.
+    /// `exists()` follows it and the unresolved path is what the kernel would
+    /// mount, so h5i would bind the link's target — a host path the box has no
+    /// grant on — into `/work`. Refuse the mount instead.
+    #[test]
+    fn run_argv_refuses_a_symlinked_agent_config() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let work = root.join("work");
+        let secret_dir = root.join("secrets");
+        std::fs::create_dir_all(work.join(".claude")).unwrap();
+        std::fs::create_dir_all(&secret_dir).unwrap();
+        std::fs::write(secret_dir.join("id_rsa"), "PRIVATE KEY").unwrap();
+
+        // (a) the file itself is a symlink out of $WORK
+        std::os::unix::fs::symlink(secret_dir.join("id_rsa"), work.join(".claude/settings.json"))
+            .unwrap();
+        assert_eq!(agent_config_mount_source(&work, ".claude/settings.json"), None);
+
+        // (b) a real file, but reached through a symlinked ancestor
+        std::fs::create_dir_all(root.join("elsewhere/.codex")).unwrap();
+        std::fs::write(root.join("elsewhere/.codex/config.toml"), "").unwrap();
+        std::os::unix::fs::symlink(root.join("elsewhere/.codex"), work.join(".codex")).unwrap();
+        assert_eq!(agent_config_mount_source(&work, ".codex/config.toml"), None);
+
+        // Neither reaches the argv.
+        let p = Profile::builtin("default", crate::sandbox_policy::IsolationClaim::Container);
+        let argv = build_run_argv(
+            &rt(), &p, &[], None, &work, "img", "n", &NetPlan::None,
+            &["true".into()], &[], None, None, &[], None, None, None, &[],
+        );
+        let joined = argv.join(" ");
+        assert!(!joined.contains("id_rsa"), "leaked the symlink target: {joined}");
+        assert!(!joined.contains("elsewhere"), "leaked through a symlinked parent: {joined}");
+        assert!(!joined.contains("target=/work/.claude/settings.json"));
+        assert!(!joined.contains("target=/work/.codex/config.toml"));
+
+        // A real regular file inside $WORK still mounts.
+        std::fs::remove_file(work.join(".claude/settings.json")).unwrap();
+        std::fs::write(work.join(".claude/settings.json"), "{}").unwrap();
+        assert_eq!(
+            agent_config_mount_source(&work, ".claude/settings.json"),
+            Some(work.join(".claude/settings.json")),
+        );
     }
 
     // In-box git plumbing mounts: identical source/target host paths, ro/rw

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -1383,10 +1383,13 @@ pub fn build_run_argv(
 /// A proxy that was supposed to start and could not is an `Err`, not a `None`:
 /// falling back would leave the real credential in the box while also widening
 /// its egress, which is the opposite of what this exists to do.
+/// A live credential proxy and the env additions the box needs to reach it.
+type AuthProxyEngagement = (crate::auth_proxy::AuthProxyHandle, Vec<(String, String)>);
+
 fn maybe_auth_proxy(
     profile: &Profile,
     net: &NetPlan,
-) -> Result<Option<(crate::auth_proxy::AuthProxyHandle, Vec<(String, String)>)>, H5iError> {
+) -> Result<Option<AuthProxyEngagement>, H5iError> {
     // The box reaches the host proxy only on the egress-proxy net plan, and at
     // whichever address this platform routes to the host ([`HOST_ROUTE`]).
     // `engage_at` handles opt-out + runtime + credential resolution; the

--- a/crates/h5i-sandbox/src/microvm.rs
+++ b/crates/h5i-sandbox/src/microvm.rs
@@ -269,65 +269,17 @@ pub fn egress_rule_tokens(egress: &[String]) -> Result<Vec<String>, H5iError> {
     };
 
     for raw in egress {
-        let raw = raw.trim();
-        if raw.is_empty() {
+        // One grammar for every tier: `container::parse_egress_rule` is the
+        // single definition, so the strictness here and the allowlist the
+        // container proxy enforces cannot drift apart again.
+        let Some((host, wildcard, port)) = crate::container::parse_egress_rule(raw)? else {
             continue;
-        }
-        if raw.contains(',') || raw.contains('@') {
-            return Err(H5iError::Metadata(format!(
-                "net.egress entry '{raw}' contains ',' or '@', which the microvm tier's rule \
-                 grammar reserves — refusing rather than emitting a rule that means something \
-                 else (fail-closed). Split it into separate entries."
-            )));
-        }
-        // An IPv6 literal is full of colons, and the port split below cannot tell
-        // one from a `host:port`: `2001:db8::1` used to come out as
-        // `allow@2001:db8::tcp:1` — a rule that means nothing anyone asked for.
-        // The grammar has no unambiguous spelling for one here, so refuse it
-        // rather than translate it wrong.
-        if raw.matches(':').count() > 1 {
-            return Err(H5iError::Metadata(format!(
-                "net.egress entry '{raw}' looks like an IPv6 literal (more than one ':'), which \
-                 the microvm tier's rule grammar cannot carry unambiguously — refusing rather \
-                 than emitting a rule that means something else (fail-closed). Use a hostname, \
-                 or an IPv4 address or CIDR."
-            )));
-        }
-        // Only a trailing all-digit segment is a port.
-        let (host_part, port) = match raw.rsplit_once(':') {
-            Some((h, p)) if !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()) => {
-                // Out of range is an error, never a silent widening: `.ok()` here
-                // turned `example.com:99999` into `allow@example.com`, which is
-                // *every* port — the opposite of what the entry asked for.
-                let port = p.parse::<u16>().map_err(|_| {
-                    H5iError::Metadata(format!(
-                        "net.egress entry '{raw}' has a port outside 1-65535 — refusing rather \
-                         than falling back to an any-port rule (fail-closed)."
-                    ))
-                })?;
-                (h, Some(port))
-            }
-            _ => (raw, None),
         };
-        let lower = host_part.to_ascii_lowercase();
-        let (host, wildcard) = match lower.strip_prefix("*.").or_else(|| lower.strip_prefix('.')) {
-            Some(rest) => (rest.to_string(), true),
-            None => (lower, false),
-        };
-        if host.is_empty() {
-            continue;
-        }
         let qualifier = match port {
             Some(p) => format!(":tcp:{p}"),
             None => String::new(),
         };
         if wildcard {
-            if host.split('.').filter(|l| !l.is_empty()).count() < 2 {
-                return Err(H5iError::Metadata(format!(
-                    "net.egress wildcard '{raw}' covers a single label — a suffix rule must name \
-                     at least two (e.g. '*.example.com', not '*.com'). Refusing (fail-closed)."
-                )));
-            }
             push(format!("allow@domain={host}{qualifier}"), &mut tokens);
             push(format!("allow@suffix={host}{qualifier}"), &mut tokens);
         } else {

--- a/crates/h5i-sandbox/src/microvm.rs
+++ b/crates/h5i-sandbox/src/microvm.rs
@@ -511,9 +511,11 @@ pub fn build_run_argv(rt: &Runtime, policy: &ResolvedPolicy, work: &Path, plan: 
     // exist host-side (an image-backed tier writes a sentinel when there is no
     // real config), so a missing source here means the guard deliberately left
     // it out, not that we should mount something else.
-    for rel in [".claude/settings.json", ".codex/config.toml"] {
-        let source = work.join(rel);
-        if source.is_file() {
+    for rel in crate::container::AGENT_CONFIG_RELS {
+        // Resolved through the shared guard: `$WORK` is repo-supplied, so a
+        // symlink here (or at any directory above it) would otherwise mount an
+        // arbitrary host path into the guest.
+        if let Some(source) = crate::container::agent_config_mount_source(work, rel) {
             a.push("--mount-file".into());
             a.push(format!("{}:{WORK_MOUNT}/{rel}:ro", source.display()));
         }
@@ -1319,8 +1321,10 @@ mod tests {
         // $WORK is rw, so without this mount an in-box agent could rewrite the
         // file that defines its observation hook and go dark.
         let dir = std::env::temp_dir().join(format!("h5i-microvm-cfg-{}", std::process::id()));
-        let work = dir.join("work");
-        std::fs::create_dir_all(work.join(".claude")).unwrap();
+        std::fs::create_dir_all(dir.join("work/.claude")).unwrap();
+        // Canonicalized: the mount source is the resolved path, so the
+        // expectation has to agree where the temp root is itself a symlink.
+        let work = dir.canonicalize().unwrap().join("work");
         std::fs::write(work.join(".claude/settings.json"), "{}").unwrap();
         let a = build_run_argv(
             &rt(),

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -193,12 +193,18 @@ struct ContainerToml {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct FsToml {
+    // `Option`, like `net.egress`, so an author can tell h5i "nothing" and be
+    // believed. Omitted (`None`) inherits the built-in base, which is what
+    // makes a partial overlay usable; an explicit `read = []` means the empty
+    // list. Treating `[]` as "omitted" turned a narrowing into a widening: a
+    // profile written as `fs.write = []` to get a read-only box was handed
+    // `$WORK`, `~/.claude`, `/tmp` and `/dev/tty` instead.
     #[serde(default)]
-    read: Vec<String>,
+    read: Option<Vec<String>>,
     #[serde(default)]
-    write: Vec<String>,
+    write: Option<Vec<String>>,
     #[serde(default)]
-    deny: Vec<String>,
+    deny: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -234,8 +240,10 @@ struct ResourcesToml {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct EnvVarsToml {
+    /// `Option` for the same reason as [`FsToml`]: an explicit `pass = []`
+    /// means an empty environment, not "inherit PATH/HOME/LANG/TERM/…".
     #[serde(default)]
-    pass: Vec<String>,
+    pass: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -383,9 +391,11 @@ pub fn load_profile(
             Profile {
                 name: name.to_string(),
                 isolation,
-                fs_read: if t.fs.read.is_empty() { base.fs_read } else { t.fs.read },
-                fs_write: if t.fs.write.is_empty() { base.fs_write } else { t.fs.write },
-                fs_deny: if t.fs.deny.is_empty() { base.fs_deny } else { t.fs.deny },
+                // Omitted → inherit the base; explicit `[]` → empty. Same rule
+                // as `net.egress` below, so narrowing a profile never widens it.
+                fs_read: t.fs.read.unwrap_or(base.fs_read),
+                fs_write: t.fs.write.unwrap_or(base.fs_write),
+                fs_deny: t.fs.deny.unwrap_or(base.fs_deny),
                 net_mode: match t.net.mode {
                     Some(ref s) => NetMode::parse(s)?,
                     None => base.net_mode,
@@ -422,7 +432,7 @@ pub fn load_profile(
                 },
                 tools: t.tools,
                 image: t.container.image.or(base.image),
-                env_pass: if t.env.pass.is_empty() { base.env_pass } else { t.env.pass },
+                env_pass: t.env.pass.unwrap_or(base.env_pass),
                 private_paths: if t.private_paths.is_empty() {
                     base.private_paths
                 } else {
@@ -3815,6 +3825,39 @@ net.egress = []
 "#;
         let p = load_from_str(toml_text, "agent-claude", None).unwrap();
         assert!(p.net_egress.is_empty(), "explicit [] must stay empty");
+    }
+
+    /// The same opt-out rule for the filesystem and environment lists. Treating
+    /// `[]` as "omitted" inverted a narrowing into a widening: an author asking
+    /// for a read-only box with `fs.write = []` was handed the builtin base
+    /// ($WORK, ~/.claude, ~/.cache, /tmp, /dev/tty) instead.
+    #[test]
+    fn explicit_empty_fs_and_env_lists_are_not_re_widened() {
+        let toml_text = r#"
+[profile.agent-claude]
+isolation = "supervised"
+net.egress = ["api.anthropic.com"]
+fs.write = []
+fs.read = []
+env.pass = []
+"#;
+        let p = load_from_str(toml_text, "agent-claude", None).unwrap();
+        assert!(p.fs_write.is_empty(), "explicit fs.write = [] must stay empty: {:?}", p.fs_write);
+        assert!(p.fs_read.is_empty(), "explicit fs.read = [] must stay empty: {:?}", p.fs_read);
+        assert!(p.env_pass.is_empty(), "explicit env.pass = [] must stay empty: {:?}", p.env_pass);
+    }
+
+    /// Omitting them still inherits the base, so a partial overlay stays usable.
+    #[test]
+    fn omitted_fs_and_env_lists_still_inherit_the_builtin_base() {
+        let toml_text = r#"
+[profile.agent-claude]
+isolation = "supervised"
+"#;
+        let p = load_from_str(toml_text, "agent-claude", None).unwrap();
+        assert!(!p.fs_write.is_empty(), "omitted fs.write inherits the base");
+        assert!(!p.env_pass.is_empty(), "omitted env.pass inherits the base");
+        assert!(p.env_pass.iter().any(|k| k == "PATH"));
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -659,11 +659,26 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
         )));
     }
     // fs.deny preflight lint: Landlock has no deny rules, so a granted parent
-    // must never contain a denied child. Compare on expanded, normalized text.
+    // must never contain a denied child.
+    //
+    // Compare on *resolved* paths, not on expanded text. Landlock grants follow
+    // symlinks — the builder opens the grant path and hands the result to
+    // `path_beneath_rules` — so a grant of `~/work-tools` on a host where that
+    // is a symlink to `$HOME` really grants the whole home directory. A textual
+    // prefix check never saw `~/.ssh` underneath it and let the policy load.
+    // Canonicalization is best-effort: a path that does not exist yet cannot be
+    // resolved, and the expanded text is the right fallback there (a
+    // non-existent grant is skipped by the Landlock builder anyway).
+    let resolve = |s: &str| -> String {
+        let expanded = expand_tilde(s);
+        std::fs::canonicalize(&expanded)
+            .map(|p| p.display().to_string())
+            .unwrap_or(expanded)
+    };
     for grant in p.fs_read.iter().chain(p.fs_write.iter()) {
-        let g = expand_tilde(grant);
+        let g = resolve(grant);
         for deny in &p.fs_deny {
-            let d = expand_tilde(deny);
+            let d = resolve(deny);
             if d == g || d.starts_with(&format!("{}/", g.trim_end_matches('/'))) {
                 return Err(H5iError::Metadata(format!(
                     "policy refused: granted path '{grant}' contains denied child '{deny}' \
@@ -3076,9 +3091,43 @@ fn seccomp_deny_program() -> Result<seccompiler::BpfProgram, H5iError> {
         arch,
     )
     .map_err(|e| H5iError::Metadata(format!("seccomp filter build failed: {e}")))?;
-    filter
+    let program: seccompiler::BpfProgram = filter
         .try_into()
-        .map_err(|e: seccompiler::BackendError| H5iError::Metadata(format!("seccomp compile failed: {e}")))
+        .map_err(|e: seccompiler::BackendError| {
+            H5iError::Metadata(format!("seccomp compile failed: {e}"))
+        })?;
+    Ok(prepend_x32_guard(program))
+}
+
+/// Refuse the x32 ABI before the deny-list runs.
+///
+/// On x86_64, x32 reports `AUDIT_ARCH_X86_64` in `seccomp_data.arch` — so
+/// seccompiler's own arch check passes — but ORs `X32_SYSCALL_BIT` into `nr`.
+/// Every syscall-number comparison in the compiled deny-list therefore misses,
+/// and an x32 `mount`/`ptrace`/`unshare` falls through to the default Allow.
+/// seccompiler has no knob for this, so the guard is prepended to the compiled
+/// program: BPF jumps are relative, so shifting the original block is safe.
+///
+/// Architecture-independent by construction — no aarch64 syscall number comes
+/// near `0x4000_0000`, so the comparison never fires there.
+fn prepend_x32_guard(program: seccompiler::BpfProgram) -> seccompiler::BpfProgram {
+    use seccompiler::sock_filter;
+    const BPF_LD_W_ABS: u16 = 0x00 | 0x00 | 0x20; // BPF_LD | BPF_W | BPF_ABS
+    const BPF_JMP_JGE_K: u16 = 0x05 | 0x30 | 0x00; // BPF_JMP | BPF_JGE | BPF_K
+    const BPF_RET_K: u16 = 0x06;
+    const OFF_NR: u32 = 0;
+    const X32_SYSCALL_BIT: u32 = 0x4000_0000;
+    const SECCOMP_RET_KILL_PROCESS: u32 = 0x8000_0000;
+
+    let mut out: seccompiler::BpfProgram = vec![
+        // A = nr
+        sock_filter { code: BPF_LD_W_ABS, jt: 0, jf: 0, k: OFF_NR },
+        // nr >= X32 bit → fall through to the kill; otherwise skip it.
+        sock_filter { code: BPF_JMP_JGE_K, jt: 0, jf: 1, k: X32_SYSCALL_BIT },
+        sock_filter { code: BPF_RET_K, jt: 0, jf: 0, k: SECCOMP_RET_KILL_PROCESS },
+    ];
+    out.extend(program);
+    out
 }
 
 /// Spawn `cmd`, stream stdout/stderr off-thread, and enforce `wall` as a hard
@@ -3668,6 +3717,30 @@ resources = { mem = "2G", fsize = "100M", cpu = "5s" }
         // The default deny set survives and no grant contains a denied child
         // (validate_profile ran inside load_profile).
         assert!(p.fs_deny.iter().any(|s| s == "~/.ssh"));
+    }
+
+    /// Landlock grants follow symlinks, so the lint has to as well. A grant of
+    /// a symlink into `$HOME` really grants the home directory, and a textual
+    /// prefix check never saw the denied child underneath it.
+    #[test]
+    #[cfg(unix)]
+    fn fs_deny_lint_sees_through_a_symlinked_grant() {
+        let td = tempfile::tempdir().unwrap();
+        let home = td.path().join("home");
+        std::fs::create_dir_all(home.join(".ssh")).unwrap();
+        // The grant is a symlink to the directory that holds the denied child.
+        let tools = td.path().join("work-tools");
+        std::os::unix::fs::symlink(&home, &tools).unwrap();
+
+        let mut p = Profile::builtin("default", IsolationClaim::Process);
+        p.fs_read = vec![tools.display().to_string()];
+        p.fs_deny = vec![home.join(".ssh").display().to_string()];
+        let err = validate_profile(&p).map(|_| ()).unwrap_err();
+        assert!(err.to_string().contains("denied child"), "{err}");
+
+        // An unrelated grant still loads.
+        p.fs_read = vec![td.path().join("elsewhere").display().to_string()];
+        assert!(validate_profile(&p).is_ok());
     }
 
     /// Host-side scratch must not be pre-plantable. The nftables ruleset lands

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -717,13 +717,18 @@ fn random_suffix() -> Result<String, H5iError> {
 /// default.
 pub fn private_scratch_dir(prefix: &str) -> Result<PathBuf, H5iError> {
     let dir = std::env::temp_dir().join(format!("{prefix}-{}", random_suffix()?));
-    let mut b = std::fs::DirBuilder::new();
     #[cfg(unix)]
     {
         use std::os::unix::fs::DirBuilderExt;
-        b.mode(0o700);
+        std::fs::DirBuilder::new()
+            .mode(0o700)
+            .create(&dir)
+            .map_err(|e| H5iError::with_path(e, &dir))?;
     }
-    b.create(&dir).map_err(|e| H5iError::with_path(e, &dir))?;
+    #[cfg(not(unix))]
+    std::fs::DirBuilder::new()
+        .create(&dir)
+        .map_err(|e| H5iError::with_path(e, &dir))?;
     Ok(dir)
 }
 
@@ -2023,6 +2028,9 @@ fn augment_injected_env(
 }
 
 /// Monotonic counter so concurrent runs get distinct per-run cgroup names.
+/// cgroups are Linux-only, and since the exec probe stopped using this for its
+/// scratch path the cgroup builder is its sole consumer.
+#[cfg(target_os = "linux")]
 static PROBE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 static VERIFIED_EXEC_POLICIES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -25,10 +25,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
-// PathBuf is only referenced from the confinement paths (Landlock grants,
-// config-lock, the Seatbelt plan); gate the import so targets with neither
-// backend don't see it as unused under `-D warnings`.
-#[cfg(unix)]
+// Used on every target now: the private-path and scratch-dir helpers below
+// return PathBuf regardless of which confinement backend (if any) this target
+// has.
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
@@ -3101,6 +3100,8 @@ fn seccomp_deny_program() -> Result<seccompiler::BpfProgram, H5iError> {
 
 /// Refuse the x32 ABI before the deny-list runs.
 ///
+/// Linux only, like `seccompiler` and its caller.
+///
 /// On x86_64, x32 reports `AUDIT_ARCH_X86_64` in `seccomp_data.arch` — so
 /// seccompiler's own arch check passes — but ORs `X32_SYSCALL_BIT` into `nr`.
 /// Every syscall-number comparison in the compiled deny-list therefore misses,
@@ -3110,6 +3111,7 @@ fn seccomp_deny_program() -> Result<seccompiler::BpfProgram, H5iError> {
 ///
 /// Architecture-independent by construction — no aarch64 syscall number comes
 /// near `0x4000_0000`, so the comparison never fires there.
+#[cfg(target_os = "linux")]
 fn prepend_x32_guard(program: seccompiler::BpfProgram) -> seccompiler::BpfProgram {
     use seccompiler::sock_filter;
     // Spelled as literals: the classic-BPF opcode components (BPF_LD|BPF_W|

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -3112,8 +3112,11 @@ fn seccomp_deny_program() -> Result<seccompiler::BpfProgram, H5iError> {
 /// near `0x4000_0000`, so the comparison never fires there.
 fn prepend_x32_guard(program: seccompiler::BpfProgram) -> seccompiler::BpfProgram {
     use seccompiler::sock_filter;
-    const BPF_LD_W_ABS: u16 = 0x00 | 0x00 | 0x20; // BPF_LD | BPF_W | BPF_ABS
-    const BPF_JMP_JGE_K: u16 = 0x05 | 0x30 | 0x00; // BPF_JMP | BPF_JGE | BPF_K
+    // Spelled as literals: the classic-BPF opcode components (BPF_LD|BPF_W|
+    // BPF_ABS, BPF_JMP|BPF_JGE|BPF_K, BPF_RET|BPF_K) include zero-valued terms,
+    // and clippy rightly objects to `x | 0`.
+    const BPF_LD_W_ABS: u16 = 0x20;
+    const BPF_JMP_JGE_K: u16 = 0x35;
     const BPF_RET_K: u16 = 0x06;
     const OFF_NR: u32 = 0;
     const X32_SYSCALL_BIT: u32 = 0x4000_0000;

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -645,6 +645,68 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
     Ok(())
 }
 
+/// Create the directory chain for `rel` under `work` without ever traversing a
+/// symlink, and return the joined path. `keep_last` decides whether the final
+/// component is created too (the Linux bind mountpoint) or left for the caller
+/// (the macOS redirect, which puts a symlink there).
+///
+/// `validate_private_paths` rejects a leading `/`, `..` and `,`, but it never
+/// *resolves* the path — and both `private_paths` and the worktree contents are
+/// repo-supplied. A branch shipping `a` as a symlink to `$HOME` turns a
+/// perfectly valid `a/bin` entry into a write outside `$WORK`: on Linux
+/// `create_dir_all` makes the mountpoint at the link's target and the bind
+/// grants the box rw there; on macOS `apply_symlinks` plants its redirect there
+/// instead. Walking component by component refuses both.
+fn create_dirs_within(work: &Path, rel: &str, keep_last: bool) -> Result<PathBuf, H5iError> {
+    let comps: Vec<&str> = rel
+        .trim_matches('/')
+        .split('/')
+        .filter(|c| !c.is_empty())
+        .collect();
+    let stop = if keep_last {
+        comps.len()
+    } else {
+        comps.len().saturating_sub(1)
+    };
+    let mut cur = work.to_path_buf();
+    for (i, c) in comps.iter().enumerate() {
+        cur.push(c);
+        if i >= stop {
+            break;
+        }
+        match std::fs::symlink_metadata(&cur) {
+            Ok(md) if md.file_type().is_symlink() => {
+                return Err(H5iError::Metadata(format!(
+                    "private_paths '{rel}': '{}' is a symlink, and h5i will not follow one out \
+                     of the workspace to place a private path (fail-closed). Remove it from the \
+                     branch, or point the entry somewhere else.",
+                    cur.display()
+                )))
+            }
+            Ok(md) if md.is_dir() => {}
+            Ok(_) => {
+                return Err(H5iError::Metadata(format!(
+                    "private_paths '{rel}': '{}' exists and is not a directory (fail-closed)",
+                    cur.display()
+                )))
+            }
+            Err(_) => std::fs::create_dir(&cur).map_err(|e| H5iError::with_path(e, &cur))?,
+        }
+    }
+    Ok(cur)
+}
+
+/// Create the mountpoint for a private bind, refusing a symlinked ancestor.
+pub fn create_private_mountpoint(work: &Path, rel: &str) -> Result<PathBuf, H5iError> {
+    create_dirs_within(work, rel, true)
+}
+
+/// Create the *parent* directories for a private path, refusing a symlinked
+/// ancestor, and return the path the caller should place there.
+pub fn prepare_private_link_site(work: &Path, rel: &str) -> Result<PathBuf, H5iError> {
+    create_dirs_within(work, rel, false)
+}
+
 /// Validate `private_paths` (Idea 3), fail-closed: each path is
 /// workspace-relative, free of `..` traversal, has a known `kind`, and no two
 /// paths overlap (a parent would shadow the nested child's bind). Mirrors the

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -552,6 +552,28 @@ pub fn effective_auto(
 /// Fail-closed policy lints (§7). These reject *policies*, before any env is
 /// created — never silently weaken them.
 pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
+    // A profile that opts into an egress allowlist may not also re-export the
+    // proxy wiring: `env.pass` is applied after it, so the host's value would
+    // win and the box would route around the allowlist. Refused at load, so the
+    // author is told rather than silently getting a wider box. (Harmless with
+    // no `net.egress` — there is no proxy to shadow — so it is not refused
+    // there.)
+    if !p.net_egress.iter().all(|e| e.trim().is_empty()) {
+        if let Some(bad) = p
+            .env_pass
+            .iter()
+            .find(|k| crate::container::is_proxy_wiring_var(k))
+        {
+            return Err(H5iError::Metadata(format!(
+                "profile '{}': env.pass carries '{bad}', which is part of the egress proxy \
+                 wiring. Passing it through would replace the allowlist proxy's address with \
+                 the host's and let the box egress unfiltered — remove it from env.pass \
+                 (fail-closed).",
+                p.name
+            )));
+        }
+    }
+
     // Secret grants are brokered (docs/secrets-broker-design.md). Validate the
     // *config* here (names + source/inject syntax); values are resolved
     // fail-closed at run time, never at policy-load time.

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -645,6 +645,42 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
     Ok(())
 }
 
+/// 16 hex chars of OS entropy — enough that no other local user can guess or
+/// pre-plant a scratch path before we create it.
+fn random_suffix() -> Result<String, H5iError> {
+    let mut raw = [0u8; 8];
+    getrandom::fill(&mut raw).map_err(|e| {
+        H5iError::Metadata(format!(
+            "no OS entropy for a private scratch path ({e}) — refusing to fall back to a \
+             guessable one (fail-closed)"
+        ))
+    })?;
+    Ok(raw.iter().map(|b| format!("{b:02x}")).collect())
+}
+
+/// A private scratch directory under the system temp dir.
+///
+/// `<tmp>/<prefix>-<pid>-<seq>` was guessable, and both `create_dir_all` and
+/// `fs::write` are happy to land inside a directory (or through a symlink)
+/// another user pre-created. That matters most for the nftables ruleset, which
+/// a child then `execve`s `nft -f` on with CAP_NET_ADMIN: an attacker-supplied
+/// ruleset becomes the box's entire L3/L4 egress policy.
+///
+/// So: an unguessable name, and `mkdir(0700)` — which fails if the path exists,
+/// and sets the mode atomically rather than leaving a window at the umask
+/// default.
+pub fn private_scratch_dir(prefix: &str) -> Result<PathBuf, H5iError> {
+    let dir = std::env::temp_dir().join(format!("{prefix}-{}", random_suffix()?));
+    let mut b = std::fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        b.mode(0o700);
+    }
+    b.create(&dir).map_err(|e| H5iError::with_path(e, &dir))?;
+    Ok(dir)
+}
+
 /// Create the directory chain for `rel` under `work` without ever traversing a
 /// symlink, and return the joined path. `keep_last` decides whether the final
 /// component is created too (the Linux bind mountpoint) or left for the caller
@@ -1940,7 +1976,7 @@ fn augment_injected_env(
     env
 }
 
-/// Monotonic counter so concurrent functional probes get distinct temp dirs.
+/// Monotonic counter so concurrent runs get distinct per-run cgroup names.
 static PROBE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 static VERIFIED_EXEC_POLICIES: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
@@ -1968,9 +2004,7 @@ pub fn verify_exec(policy: &ResolvedPolicy) -> Result<(), H5iError> {
             return Ok(());
         }
     }
-    let seq = PROBE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!("h5i-exec-probe-{}-{seq}", std::process::id()));
-    std::fs::create_dir_all(&dir).map_err(|e| H5iError::with_path(e, &dir))?;
+    let dir = private_scratch_dir("h5i-exec-probe")?;
     // Clone the profile but clear the tools allowlist so our internal probe
     // command isn't rejected by a user-pinned list that omits `true`.
     let mut profile = policy.profile.clone();
@@ -3602,6 +3636,28 @@ resources = { mem = "2G", fsize = "100M", cpu = "5s" }
         // The default deny set survives and no grant contains a denied child
         // (validate_profile ran inside load_profile).
         assert!(p.fs_deny.iter().any(|s| s == "~/.ssh"));
+    }
+
+    /// Host-side scratch must not be pre-plantable. The nftables ruleset lands
+    /// in one of these and is then executed by a child with CAP_NET_ADMIN, so a
+    /// guessable path let another local user pick the box's egress policy.
+    #[test]
+    fn private_scratch_is_unguessable_and_owner_only() {
+        let a = private_scratch_dir("h5i-test-scratch").unwrap();
+        let b = private_scratch_dir("h5i-test-scratch").unwrap();
+        assert_ne!(a, b, "two scratch dirs must not collide");
+        // Not derived from the pid: that is what made the old name guessable.
+        assert!(!a.to_string_lossy().contains(&std::process::id().to_string()));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&a).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "scratch dir must be 0700, got {mode:o}");
+        }
+        // Never reuses an existing directory.
+        assert!(std::fs::DirBuilder::new().create(&a).is_err());
+        let _ = std::fs::remove_dir_all(&a);
+        let _ = std::fs::remove_dir_all(&b);
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/seatbelt.rs
+++ b/crates/h5i-sandbox/src/seatbelt.rs
@@ -211,6 +211,10 @@ pub struct SeatbeltPlan {
     /// `(link, target)` pairs to materialize before the run: the workspace-relative
     /// private paths, which Linux gets via bind mounts.
     pub symlinks: Vec<(PathBuf, PathBuf)>,
+    /// The workspace root every `symlinks` link must stay inside. Carried so
+    /// `apply_symlinks` can create the parents without following a repo-planted
+    /// symlink out of the box.
+    pub work: PathBuf,
     /// Redirects with no macOS equivalent, reported rather than silently dropped
     /// (h5i never downgrades quietly). Surfaced by `env probe` and the run's
     /// diagnostics.
@@ -845,6 +849,7 @@ pub fn plan(policy: &ResolvedPolicy, work: &Path, opts: &SeatbeltOptions) -> Sea
         env,
         symlinks,
         unmapped,
+        work: work.to_path_buf(),
     }
 }
 
@@ -897,9 +902,18 @@ fn apply_symlinks(plan: &SeatbeltPlan) -> Result<(), H5iError> {
             }
             None => {}
         }
-        if let Some(parent) = link.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| H5iError::with_path(e, parent))?;
-        }
+        // Create the parents component by component rather than with
+        // `create_dir_all`, which would happily follow a repo-planted symlink
+        // at any level and plant this redirect — a box-writable path — outside
+        // the workspace entirely.
+        let rel = link.strip_prefix(&plan.work).map_err(|_| {
+            H5iError::Metadata(format!(
+                "private_paths: redirect '{}' is not inside the workspace '{}' (fail-closed)",
+                link.display(),
+                plan.work.display()
+            ))
+        })?;
+        crate::sandbox::prepare_private_link_site(&plan.work, &rel.to_string_lossy())?;
         std::os::unix::fs::symlink(target, link).map_err(|e| H5iError::with_path(e, link))?;
     }
     Ok(())
@@ -1616,9 +1630,10 @@ mod tests {
 
     /// A helper that builds a plan with one private-path redirect from `link`
     /// to a fresh backing dir.
-    fn symlink_plan(link: &Path, backing: &Path) -> SeatbeltPlan {
+    fn symlink_plan(work: &Path, link: &Path, backing: &Path) -> SeatbeltPlan {
         SeatbeltPlan {
             symlinks: vec![(link.to_path_buf(), backing.to_path_buf())],
+            work: work.to_path_buf(),
             ..Default::default()
         }
     }
@@ -1630,7 +1645,7 @@ mod tests {
         let backing = tmp.path().join("backing");
         std::fs::create_dir_all(&link).unwrap();
         std::fs::create_dir_all(&backing).unwrap();
-        apply_symlinks(&symlink_plan(&link, &backing)).unwrap();
+        apply_symlinks(&symlink_plan(tmp.path(), &link, &backing)).unwrap();
         assert_eq!(std::fs::read_link(&link).unwrap(), backing);
     }
 
@@ -1640,7 +1655,7 @@ mod tests {
         let link = tmp.path().join("target");
         let backing = tmp.path().join("backing");
         std::fs::create_dir_all(&backing).unwrap();
-        let plan = symlink_plan(&link, &backing);
+        let plan = symlink_plan(tmp.path(), &link, &backing);
         apply_symlinks(&plan).unwrap();
         apply_symlinks(&plan).unwrap();
         assert_eq!(std::fs::read_link(&link).unwrap(), backing);
@@ -1656,7 +1671,7 @@ mod tests {
         std::fs::create_dir_all(&link).unwrap();
         std::fs::create_dir_all(&backing).unwrap();
         std::fs::write(link.join("artifact.o"), b"precious").unwrap();
-        let err = apply_symlinks(&symlink_plan(&link, &backing)).unwrap_err();
+        let err = apply_symlinks(&symlink_plan(tmp.path(), &link, &backing)).unwrap_err();
         assert!(err.to_string().contains("not empty"), "{err}");
         assert!(link.join("artifact.o").exists(), "must not have been deleted");
     }
@@ -1670,7 +1685,46 @@ mod tests {
         std::fs::create_dir_all(&old).unwrap();
         std::fs::create_dir_all(&backing).unwrap();
         std::os::unix::fs::symlink(&old, &link).unwrap();
-        apply_symlinks(&symlink_plan(&link, &backing)).unwrap();
+        apply_symlinks(&symlink_plan(tmp.path(), &link, &backing)).unwrap();
+        assert_eq!(std::fs::read_link(&link).unwrap(), backing);
+    }
+
+    /// `private_paths` and the worktree are both repo-supplied. A branch that
+    /// ships `a` as a symlink to somewhere outside the workspace would, with
+    /// `create_dir_all`, have h5i plant the redirect at the link's target — a
+    /// box-writable path on the operator's filesystem, e.g. a directory on
+    /// their PATH. Refuse instead of following it.
+    #[test]
+    fn redirect_refuses_a_symlinked_ancestor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("work");
+        let outside = tmp.path().join("outside");
+        let backing = tmp.path().join("backing");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::create_dir_all(&backing).unwrap();
+        // The repo ships `a` as a symlink pointing out of the workspace.
+        std::os::unix::fs::symlink(&outside, work.join("a")).unwrap();
+
+        let link = work.join("a/bin");
+        let err = apply_symlinks(&symlink_plan(&work, &link, &backing)).unwrap_err();
+        assert!(err.to_string().contains("symlink"), "{err}");
+        assert!(
+            !outside.join("bin").exists(),
+            "must not have created the redirect outside the workspace"
+        );
+    }
+
+    /// The same walk still creates honest nested parents inside the workspace.
+    #[test]
+    fn redirect_creates_real_nested_parents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let work = tmp.path().join("work");
+        let backing = tmp.path().join("backing");
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::create_dir_all(&backing).unwrap();
+        let link = work.join("a/b/cache");
+        apply_symlinks(&symlink_plan(&work, &link, &backing)).unwrap();
         assert_eq!(std::fs::read_link(&link).unwrap(), backing);
     }
 

--- a/crates/h5i-sandbox/src/seatbelt.rs
+++ b/crates/h5i-sandbox/src/seatbelt.rs
@@ -957,17 +957,30 @@ impl ProfileFile {
     fn write(profile: &str) -> Result<ProfileFile, H5iError> {
         static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "h5i-seatbelt-{}-{seq}.sb",
-            std::process::id()
-        ));
-        std::fs::write(&path, profile).map_err(|e| H5iError::with_path(e, &path))?;
+        // In a private 0700 scratch dir with an unguessable name, and created
+        // with `create_new` + 0600 rather than written at the umask default and
+        // narrowed afterwards. The doc above claimed 0600; `fs::write` gave it
+        // 0644 first, and the predictable name meant a pre-existing file (or a
+        // symlink) at that path was followed and overwritten. The profile
+        // enumerates every path the box may touch, so on a shared TMPDIR that
+        // window is both a disclosure and a write primitive.
+        let dir = crate::sandbox::private_scratch_dir("h5i-seatbelt")?;
+        let path = dir.join(format!("{seq}.sb"));
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&path)
+                .map_err(|e| H5iError::with_path(e, &path))?;
+            f.write_all(profile.as_bytes())
                 .map_err(|e| H5iError::with_path(e, &path))?;
         }
+        #[cfg(not(unix))]
+        std::fs::write(&path, profile).map_err(|e| H5iError::with_path(e, &path))?;
         Ok(ProfileFile { path })
     }
 
@@ -978,7 +991,12 @@ impl ProfileFile {
 
 impl Drop for ProfileFile {
     fn drop(&mut self) {
+        // The profile now lives in its own private scratch dir, so take the
+        // directory with it rather than leaving an empty one behind per run.
         let _ = std::fs::remove_file(&self.path);
+        if let Some(dir) = self.path.parent() {
+            let _ = std::fs::remove_dir(dir);
+        }
     }
 }
 

--- a/crates/h5i-sandbox/src/seccomp_notify.rs
+++ b/crates/h5i-sandbox/src/seccomp_notify.rs
@@ -82,6 +82,8 @@ const BPF_W: u16 = 0x00;
 const BPF_ABS: u16 = 0x20;
 const BPF_JMP: u16 = 0x05;
 const BPF_JEQ: u16 = 0x10;
+/// `A >= K` — used to catch the x32 syscall-number range in one comparison.
+const BPF_JGE: u16 = 0x30;
 const BPF_K: u16 = 0x00;
 const BPF_RET: u16 = 0x06;
 
@@ -102,7 +104,7 @@ fn jump(code: u16, k: u32, jt: u8, jf: u8) -> SockFilter {
 /// allocation-free and therefore async-signal-safe to call in a `fork`ed child —
 /// a `Vec` here would risk a malloc-lock deadlock when the parent is
 /// multithreaded (e.g. the cargo test harness). Pure; structurally unit-tested.
-pub fn build_socket_notify_program() -> [SockFilter; 8] {
+pub fn build_socket_notify_program() -> [SockFilter; 10] {
     [
         // 0: A = arch
         stmt(BPF_LD | BPF_W | BPF_ABS, OFF_ARCH),
@@ -112,20 +114,38 @@ pub fn build_socket_notify_program() -> [SockFilter; 8] {
         stmt(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
         // 3: A = nr
         stmt(BPF_LD | BPF_W | BPF_ABS, OFF_NR),
-        // 4: nr == socket → NOTIFY (idx 7)
+        // 4: x32 → kill (idx 9). See X32_SYSCALL_BIT: x32 passes the arch guard
+        //    above but carries different syscall numbers, so without this the
+        //    `nr` comparisons below miss and instruction 7 ALLOWs an unmediated
+        //    socket(2). The notify handler cannot help — no notification is
+        //    ever generated.
+        jump(BPF_JMP | BPF_JGE | BPF_K, X32_SYSCALL_BIT, 4, 0),
+        // 5: nr == socket → NOTIFY (idx 8)
         jump(BPF_JMP | BPF_JEQ | BPF_K, NR_SOCKET, 2, 0),
-        // 5: nr == socketpair → NOTIFY (idx 7)
+        // 6: nr == socketpair → NOTIFY (idx 8)
         jump(BPF_JMP | BPF_JEQ | BPF_K, NR_SOCKETPAIR, 1, 0),
-        // 6: everything else → allow
+        // 7: everything else → allow
         stmt(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
-        // 7: mediate
+        // 8: mediate
         stmt(BPF_RET | BPF_K, SECCOMP_RET_USER_NOTIF),
+        // 9: x32 → kill
+        stmt(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
     ]
 }
 
+/// On x86_64 the x32 ABI reports `AUDIT_ARCH_X86_64` in `seccomp_data.arch` but
+/// ORs this bit into `nr`, so an arch guard alone lets it through with syscall
+/// numbers that match none of the comparisons that follow. Kernels built with
+/// `CONFIG_X86_X32_ABI=n` never produce it; the filter refuses it either way
+/// rather than depending on the host's config.
+///
+/// Defined unconditionally so both architectures compile one program shape: no
+/// aarch64 syscall number comes near this value, so the test is a no-op there.
+pub const X32_SYSCALL_BIT: u32 = 0x4000_0000;
+
 /// Compile-time guard: the BPF builder's array length must match what
 /// [`install_listener`] tells the kernel (`SockFprog::len`).
-const _: () = assert!(std::mem::size_of::<[SockFilter; 8]>() == 8 * 8);
+const _: () = assert!(std::mem::size_of::<[SockFilter; 10]>() == 10 * 8);
 
 // ─── kernel ABI: seccomp_data / seccomp_notif / resp / sizes ──────────────────
 
@@ -510,18 +530,53 @@ pub unsafe fn recv_fd(sock: RawFd) -> std::io::Result<RawFd> {
 mod tests {
     use super::*;
 
+    /// x32 reports AUDIT_ARCH_X86_64, so the arch guard passes, but its syscall
+    /// numbers carry X32_SYSCALL_BIT and match none of the comparisons below —
+    /// the filter used to fall through to ALLOW and no notification was ever
+    /// generated, so the handler's defence-in-depth re-check could not help.
+    #[test]
+    fn the_socket_gate_refuses_the_x32_abi() {
+        let p = build_socket_notify_program();
+        // The nr load is followed immediately by the x32 test, before any
+        // syscall-number comparison can miss.
+        let nr_load = p.iter().position(|i| i.code == (BPF_LD | BPF_W | BPF_ABS) && i.k == OFF_NR).unwrap();
+        let guard = &p[nr_load + 1];
+        assert_eq!(guard.code, BPF_JMP | BPF_JGE | BPF_K, "x32 test must come first");
+        assert_eq!(guard.k, X32_SYSCALL_BIT);
+        // Taking that branch lands on a kill, never on the allow.
+        let target = nr_load + 2 + guard.jt as usize;
+        assert_eq!(p[target].code, BPF_RET | BPF_K);
+        assert_eq!(p[target].k, SECCOMP_RET_KILL_PROCESS, "x32 must be killed, not allowed");
+    }
+
     #[test]
     fn bpf_program_shape() {
+        // Asserted structurally rather than by index: the program grows when a
+        // guard is added, and a positional test just breaks without saying
+        // anything about the policy.
         let p = build_socket_notify_program();
-        assert_eq!(p.len(), 8);
-        // Last two are ALLOW then USER_NOTIF.
-        assert_eq!(p[6], stmt(BPF_RET | BPF_K, SECCOMP_RET_ALLOW));
-        assert_eq!(p[7], stmt(BPF_RET | BPF_K, SECCOMP_RET_USER_NOTIF));
-        // Arch guard kills on mismatch.
+
+        // It starts by checking the arch, and a mismatch kills.
+        assert_eq!(p[0], stmt(BPF_LD | BPF_W | BPF_ABS, OFF_ARCH));
+        assert_eq!(p[1].k, AUDIT_ARCH);
         assert_eq!(p[2], stmt(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS));
-        // socket / socketpair compares jump forward to the NOTIFY instruction.
-        assert_eq!(p[4].k, NR_SOCKET);
-        assert_eq!(p[5].k, NR_SOCKETPAIR);
+
+        // Both socket-creating calls are compared, and every comparison lands
+        // on the USER_NOTIF instruction rather than on the allow.
+        for want in [NR_SOCKET, NR_SOCKETPAIR] {
+            let i = p
+                .iter()
+                .position(|ins| ins.code == (BPF_JMP | BPF_JEQ | BPF_K) && ins.k == want)
+                .unwrap_or_else(|| panic!("no comparison for syscall {want}"));
+            let target = i + 1 + p[i].jt as usize;
+            assert_eq!(p[target], stmt(BPF_RET | BPF_K, SECCOMP_RET_USER_NOTIF));
+        }
+
+        // Exactly one fall-through allow, and it is the last thing reached.
+        assert_eq!(
+            p.iter().filter(|i| i.code == (BPF_RET | BPF_K) && i.k == SECCOMP_RET_ALLOW).count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/secrets.rs
+++ b/crates/h5i-sandbox/src/secrets.rs
@@ -492,19 +492,31 @@ const REDACTION_MARKER: &str = "‹redacted›";
 ///
 /// The guillemet marker is intentionally free of Markdown/HTML metacharacters so
 /// it survives a later escaping pass unchanged.
+/// Redact every line, preserving the payload's exact framing.
+///
+/// Line endings and a trailing newline are kept byte-for-byte. `lines()` would
+/// fold `\r\n` into `\n` and drop a trailing newline, which mattered little
+/// while redaction was conditional but rewrites every receipt now that it is
+/// unconditional — and `raw_oid`/`raw_size` are supposed to describe the bytes
+/// the run actually produced.
 pub fn redact_text(text: &str) -> String {
-    let mut lines = text.lines().map(redact_line);
-    match lines.next() {
-        None => String::new(),
-        Some(first) => {
-            let mut out = first;
-            for line in lines {
-                out.push('\n');
-                out.push_str(&line);
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while !rest.is_empty() {
+        let (line, sep, tail) = match rest.find('\n') {
+            Some(i) => {
+                let (l, t) = rest.split_at(i);
+                let l = l.strip_suffix('\r').unwrap_or(l);
+                let sep = &rest[l.len()..i + 1];
+                (l, sep, &t[1..])
             }
-            out
-        }
+            None => (rest, "", ""),
+        };
+        out.push_str(&redact_line(line));
+        out.push_str(sep);
+        rest = tail;
     }
+    out
 }
 
 /// Redact one line. Mirrors the per-line *matching* in [`scan_lines`] but
@@ -634,6 +646,28 @@ mod tests {
         assert_eq!(lines[0], "key = your-key-here");
         assert!(!lines[1].contains("AKIAZZZZZZZZZZZZZZZZ"));
         assert!(lines[1].contains(REDACTION_MARKER));
+    }
+
+    #[test]
+    fn redact_text_preserves_framing() {
+        // Unconditional redaction means every receipt goes through here, so the
+        // payload's exact framing has to survive: CRLF stays CRLF, a trailing
+        // newline stays, and a payload with nothing to scrub is unchanged.
+        for text in [
+            "alpha\r\nbeta\r\n",
+            "alpha\nbeta\n",
+            "alpha\nbeta",
+            "\n\n",
+            "",
+            "no trailing newline",
+        ] {
+            assert_eq!(redact_text(text), text, "framing changed for {text:?}");
+        }
+        // And it still scrubs, without disturbing the line endings around it.
+        let token = format!("ghp_{}", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8");
+        let out = redact_text(&format!("x\r\ntoken={token}\r\ny\r\n"));
+        assert!(!out.contains(&token), "{out}");
+        assert!(out.starts_with("x\r\n") && out.ends_with("y\r\n"), "{out:?}");
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/secrets_broker.rs
+++ b/crates/h5i-sandbox/src/secrets_broker.rs
@@ -79,13 +79,80 @@ impl Drop for TempFiles {
     }
 }
 
-/// `sha256:<12 hex>` of a value — lets a reviewer confirm "same token across
-/// runs" without ever seeing it. Public so `env secrets` can fingerprint a
-/// dry-run resolution.
-pub fn fingerprint(value: &str) -> String {
-    let mut h = Sha256::new();
-    h.update(value.as_bytes());
-    format!("sha256:{:x}", h.finalize())[..19].to_string() // "sha256:" + 12 hex
+/// `fp:<12 hex>` of a value under a per-repository key — lets a reviewer confirm
+/// "same token across runs" without ever seeing it. Public so `env secrets` can
+/// fingerprint a dry-run resolution.
+///
+/// Keyed, not a bare digest. This lands in `GrantRecord::detail`, the env event
+/// log, and `h5i box secrets` output, all of which are durable and reviewable
+/// and may be mirrored through `refs/h5i/*`. An unsalted `sha256(value)` prefix
+/// is 48 bits of an offline oracle: against a deploy password or a PIN-shaped
+/// token, anyone holding the log can just enumerate candidates. HMAC under a
+/// key that never leaves the repository gives the same "same token?" answer
+/// with nothing to grind against.
+pub fn fingerprint(key: &[u8], value: &str) -> String {
+    let mac = hmac_sha256(key, value.as_bytes());
+    let hex: String = mac.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    format!("fp:{hex}")
+}
+
+/// HMAC-SHA256 (RFC 2104). Hand-rolled against the `sha2` dependency already
+/// present rather than adding a crate for sixteen lines.
+fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
+    const BLOCK: usize = 64;
+    let mut k = [0u8; BLOCK];
+    if key.len() > BLOCK {
+        k[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        k[..key.len()].copy_from_slice(key);
+    }
+    let mut ipad = [0x36u8; BLOCK];
+    let mut opad = [0x5cu8; BLOCK];
+    for i in 0..BLOCK {
+        ipad[i] ^= k[i];
+        opad[i] ^= k[i];
+    }
+    let inner = Sha256::new().chain_update(ipad).chain_update(msg).finalize();
+    Sha256::new().chain_update(opad).chain_update(inner).finalize().into()
+}
+
+/// Load (or mint) the per-repository fingerprint key at
+/// `<h5i_root>/secrets-fp.key`, 32 bytes at 0600.
+///
+/// Per repository rather than per run, because the whole point of the
+/// fingerprint is comparing one run against another. It is not a secret whose
+/// loss is catastrophic — it only makes the fingerprints grindable again — but
+/// it is written owner-only and never leaves the host.
+pub fn fingerprint_key(h5i_root: &Path) -> Result<Vec<u8>, H5iError> {
+    let path = h5i_root.join("secrets-fp.key");
+    if let Ok(k) = std::fs::read(&path) {
+        if k.len() >= 32 {
+            return Ok(k);
+        }
+    }
+    let mut raw = [0u8; 32];
+    getrandom::fill(&mut raw).map_err(|e| {
+        H5iError::Metadata(format!(
+            "no OS entropy for the secret fingerprint key ({e}) — refusing to fall back to an \
+             unkeyed digest, which would be grindable offline (fail-closed)"
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let _ = std::fs::remove_file(&path);
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| H5iError::with_path(e, &path))?;
+        f.write_all(&raw).map_err(|e| H5iError::with_path(e, &path))?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(&path, raw).map_err(|e| H5iError::with_path(e, &path))?;
+    Ok(raw.to_vec())
 }
 
 /// Wall-clock timeout for a `command:` secret extractor.
@@ -276,6 +343,7 @@ pub fn broker(
     secret_dir: &Path,
     is_workspace: bool,
     allow_command: bool,
+    fp_key: &[u8],
 ) -> Result<Brokered, H5iError> {
     let mut env = Vec::new();
     let mut redactions = Vec::new();
@@ -314,7 +382,7 @@ pub fn broker(
             source: g.source_or_default(),
             inject: inject.to_string(),
             ttl: g.ttl.clone(),
-            fingerprint: fingerprint(&value),
+            fingerprint: fingerprint(fp_key, &value),
         });
         redactions.push(value);
     }
@@ -487,7 +555,7 @@ mod tests {
         std::env::set_var("H5I_TEST_TOKEN_B", "tok-B");
         let g = grant("API_KEY", Some("env:H5I_TEST_TOKEN_B"), Some("env"));
         let dir = tempfile::tempdir().unwrap();
-        let b = broker(&[g], &dir.path().join("secrets"), false, false).unwrap();
+        let b = broker(&[g], &dir.path().join("secrets"), false, false, b"test-key").unwrap();
         assert_eq!(b.env, vec![("API_KEY".to_string(), "tok-B".to_string())]);
         assert_eq!(b.redactions, vec!["tok-B".to_string()]);
         assert_eq!(b.records.len(), 1);
@@ -505,7 +573,7 @@ mod tests {
         let g = grant("CERT", Some("env:H5I_TEST_TOKEN_C"), Some("file"));
         let dir = tempfile::tempdir().unwrap();
         let sdir = dir.path().join("secrets");
-        let b = broker(&[g], &sdir, true, false).unwrap();
+        let b = broker(&[g], &sdir, true, false, b"test-key").unwrap();
         // Injected as NAME_FILE → path.
         assert_eq!(b.env.len(), 1);
         assert_eq!(b.env[0].0, "CERT_FILE");
@@ -530,7 +598,7 @@ mod tests {
         std::env::set_var("H5I_TEST_TOKEN_D", "x");
         let g = grant("T", Some("env:H5I_TEST_TOKEN_D"), Some("file"));
         let dir = tempfile::tempdir().unwrap();
-        let err = broker(&[g], &dir.path().join("secrets"), false, false).unwrap_err();
+        let err = broker(&[g], &dir.path().join("secrets"), false, false, b"test-key").unwrap_err();
         assert!(format!("{err}").contains("inject=env"));
         std::env::remove_var("H5I_TEST_TOKEN_D");
     }
@@ -544,7 +612,7 @@ mod tests {
             grant("TOK_B", Some("env:H5I_TEST_M2"), Some("env")),
         ];
         let dir = tempfile::tempdir().unwrap();
-        let b = broker(&grants, &dir.path().join("secrets"), false, false).unwrap();
+        let b = broker(&grants, &dir.path().join("secrets"), false, false, b"test-key").unwrap();
         assert_eq!(b.env.len(), 2);
         assert!(b.env.contains(&("TOK_A".into(), "val-one".into())));
         assert!(b.env.contains(&("TOK_B".into(), "val-two".into())));
@@ -568,17 +636,65 @@ mod tests {
             grant("MISSING", Some("env:H5I_TEST_ABSENT_ZZZ"), Some("env")),
         ];
         let dir = tempfile::tempdir().unwrap();
-        assert!(broker(&grants, &dir.path().join("secrets"), false, false).is_err());
+        assert!(broker(&grants, &dir.path().join("secrets"), false, false, b"test-key").is_err());
         std::env::remove_var("H5I_TEST_PRESENT");
     }
 
     #[test]
     fn fingerprint_is_stable_and_value_free() {
-        let fp = fingerprint("hello");
-        assert!(fp.starts_with("sha256:"));
-        assert_eq!(fp.len(), "sha256:".len() + 12);
-        assert_eq!(fp, fingerprint("hello"));
-        assert_ne!(fp, fingerprint("world"));
+        let k = b"per-repo-key";
+        let fp = fingerprint(k, "hello");
+        assert!(fp.starts_with("fp:"));
+        assert_eq!(fp.len(), "fp:".len() + 12);
+        assert_eq!(fp, fingerprint(k, "hello"), "stable across runs");
+        assert_ne!(fp, fingerprint(k, "world"));
+        assert!(!fp.contains("hello"));
+    }
+
+    /// The fingerprint reaches durable, reviewable records, so it must not be a
+    /// bare digest anyone holding the log can grind offline against a
+    /// low-entropy credential. Under a different key the same value must
+    /// fingerprint differently.
+    #[test]
+    fn fingerprints_are_keyed_not_a_plain_digest() {
+        let a = fingerprint(b"key-a", "deploy-password");
+        let b = fingerprint(b"key-b", "deploy-password");
+        assert_ne!(a, b, "the fingerprint must depend on the repository key");
+
+        // And it is not sha256(value) truncated, which is what was grindable.
+        let mut h = Sha256::new();
+        h.update(b"deploy-password");
+        let plain = format!("{:x}", h.finalize());
+        assert!(!a.contains(&plain[..12]), "still a bare digest");
+    }
+
+    /// RFC 2104 test vector, so the hand-rolled HMAC is pinned to the standard.
+    #[test]
+    fn hmac_matches_the_rfc_vector() {
+        let mac = hmac_sha256(&[0x0b; 20], b"Hi There");
+        let hex: String = mac.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            hex,
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+        );
+    }
+
+    #[test]
+    fn the_fingerprint_key_is_per_repo_and_owner_only() {
+        let td = tempfile::tempdir().unwrap();
+        let k1 = fingerprint_key(td.path()).unwrap();
+        assert_eq!(k1.len(), 32);
+        // Stable across calls, so fingerprints compare across runs.
+        assert_eq!(k1, fingerprint_key(td.path()).unwrap());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let m = std::fs::metadata(td.path().join("secrets-fp.key")).unwrap();
+            assert_eq!(m.permissions().mode() & 0o777, 0o600);
+        }
+        // A different repository gets a different key.
+        let other = tempfile::tempdir().unwrap();
+        assert_ne!(k1, fingerprint_key(other.path()).unwrap());
     }
 
     #[test]

--- a/crates/h5i-sandbox/src/secrets_broker.rs
+++ b/crates/h5i-sandbox/src/secrets_broker.rs
@@ -323,23 +323,54 @@ pub fn broker(
 }
 
 /// Write a secret to `secret_dir/<name>` with mode `0600` (dir `0700`).
+///
+/// Fail-closed against a pre-planted path. `inject=file` is only permitted on
+/// the workspace tier, which applies no kernel confinement, so the box — or any
+/// same-uid process — can create `<env>/secrets/<name>` before the run. Without
+/// `O_NOFOLLOW|O_EXCL` the open would follow a symlink and write the plaintext
+/// credential to its target, and `mode()` is ignored for a file that already
+/// exists, so a pre-created 0644 file would keep those permissions. `TempFiles`
+/// would then unlink only the link, leaving the secret behind.
 fn write_secret_file(secret_dir: &Path, name: &str, value: &str) -> Result<PathBuf, H5iError> {
     std::fs::create_dir_all(secret_dir).map_err(|e| H5iError::with_path(e, secret_dir))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(secret_dir, std::fs::Permissions::from_mode(0o700));
+        // Propagated, not swallowed: a directory left at the umask default is
+        // a readable secret store, which is the thing this function exists to
+        // prevent.
+        std::fs::set_permissions(secret_dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| H5iError::with_path(e, secret_dir))?;
+        if std::fs::symlink_metadata(secret_dir)
+            .map_err(|e| H5iError::with_path(e, secret_dir))?
+            .file_type()
+            .is_symlink()
+        {
+            return Err(H5iError::Metadata(format!(
+                "secrets: '{}' is a symlink — refusing to materialize a credential through it \
+                 (fail-closed)",
+                secret_dir.display()
+            )));
+        }
     }
     let path = secret_dir.join(name);
     #[cfg(unix)]
     {
         use std::io::Write;
         use std::os::unix::fs::OpenOptionsExt;
+        // A leftover from an earlier run is ours to clear; `create_new` then
+        // guarantees we created this file, so its mode was never wider than
+        // 0600 and it is not a link to somewhere else.
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(H5iError::with_path(e, &path)),
+        }
         let mut f = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
+            .create_new(true)
             .write(true)
             .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW)
             .open(&path)
             .map_err(|e| H5iError::with_path(e, &path))?;
         f.write_all(value.as_bytes()).map_err(|e| H5iError::with_path(e, &path))?;
@@ -354,6 +385,52 @@ fn write_secret_file(secret_dir: &Path, name: &str, value: &str) -> Result<PathB
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `inject=file` runs on the workspace tier, which confines nothing, so the
+    /// destination can be pre-planted. Writing through a symlink would put the
+    /// plaintext credential wherever the link pointed and leave it there after
+    /// teardown (TempFiles unlinks only the link).
+    #[test]
+    #[cfg(unix)]
+    fn a_planted_symlink_cannot_capture_a_brokered_secret() {
+        let td = tempfile::tempdir().unwrap();
+        let secrets = td.path().join("secrets");
+        let stolen = td.path().join("stolen");
+        std::fs::create_dir_all(&secrets).unwrap();
+        std::os::unix::fs::symlink(&stolen, secrets.join("DEPLOY_KEY")).unwrap();
+
+        let err = write_secret_file(&secrets, "DEPLOY_KEY", "s3cret").map(|_| ());
+        // Either refused, or replaced with a fresh 0600 regular file — never
+        // written through to the link's target.
+        assert!(
+            !stolen.exists(),
+            "credential was written through the planted symlink"
+        );
+        if err.is_ok() {
+            let md = std::fs::symlink_metadata(secrets.join("DEPLOY_KEY")).unwrap();
+            assert!(md.file_type().is_file());
+        }
+    }
+
+    /// A pre-created world-readable file must not keep its mode: `mode()` on
+    /// `OpenOptions` is ignored when the file already exists.
+    #[test]
+    #[cfg(unix)]
+    fn a_pre_created_loose_mode_file_is_replaced_not_reused() {
+        use std::os::unix::fs::PermissionsExt;
+        let td = tempfile::tempdir().unwrap();
+        let secrets = td.path().join("secrets");
+        std::fs::create_dir_all(&secrets).unwrap();
+        let victim = secrets.join("TOKEN");
+        std::fs::write(&victim, "").unwrap();
+        std::fs::set_permissions(&victim, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let p = write_secret_file(&secrets, "TOKEN", "s3cret").unwrap();
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "secret file must be 0600, got {mode:o}");
+        let dmode = std::fs::metadata(&secrets).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dmode, 0o700, "secret dir must be 0700, got {dmode:o}");
+    }
 
     fn grant(name: &str, source: Option<&str>, inject: Option<&str>) -> SecretGrant {
         SecretGrant {

--- a/crates/h5i-sandbox/src/supervisor.rs
+++ b/crates/h5i-sandbox/src/supervisor.rs
@@ -1116,7 +1116,7 @@ fn run_supervised(
     // narrows the nftables ruleset to the auth proxy alone in that case).
     let mut env = effective_env;
     let (_egress_proxy, egress_port) = if has_egress && auth_port.is_none() {
-        let mut allow = crate::container::AllowList::parse(&policy.profile.net_egress);
+        let mut allow = crate::container::AllowList::parse(&policy.profile.net_egress)?;
         // Pin now, so a later DNS answer cannot move the allowlist under us.
         allow.pin_dns();
         // On the pinned port when the box has one: a `browser` box's Chrome

--- a/crates/h5i-sandbox/src/supervisor.rs
+++ b/crates/h5i-sandbox/src/supervisor.rs
@@ -731,9 +731,11 @@ fn setup_egress(
     let slirp = slirp4netns_path()
         .ok_or_else(|| H5iError::Metadata("`slirp4netns` not found on PATH".into()))?;
 
-    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let tmp = std::env::temp_dir().join(format!("h5i-egress-{}-{seq}", std::process::id()));
-    std::fs::create_dir_all(&tmp).map_err(H5iError::Io)?;
+    // Unguessable and 0700: the ruleset written here is handed to `nft -f` by a
+    // child holding CAP_NET_ADMIN, so a pre-planted directory or symlink at a
+    // predictable path would let another local user choose the box's egress
+    // policy outright.
+    let tmp = crate::sandbox::private_scratch_dir("h5i-egress")?;
     // No resolver port: DNS is pinned via /etc/hosts, so port 53 stays closed.
     let rules = build_nft_ruleset(&dests, None);
     let rules_path = tmp.join("egress.nft");

--- a/crates/h5i-sandbox/src/supervisor.rs
+++ b/crates/h5i-sandbox/src/supervisor.rs
@@ -858,7 +858,7 @@ fn run_supervised(
     // and the real credential is scrubbed from the box's per-env HOME copy, so
     // the token is absent from the box entirely.
     let auth = if !policy.profile.net_egress.is_empty() {
-        crate::auth_proxy::engage(&policy.profile.name, true)
+        crate::auth_proxy::engage(&policy.profile.name, true)?
     } else {
         None
     };
@@ -1095,7 +1095,7 @@ fn run_supervised(
     // Credential-injecting auth proxy (option 2). `tier_ok` is true because the
     // box shares the host's loopback and the profile will open exactly this port.
     let auth = if has_egress {
-        crate::auth_proxy::engage_at(&policy.profile.name, true, LOOPBACK_HOST)
+        crate::auth_proxy::engage_at(&policy.profile.name, true, LOOPBACK_HOST)?
     } else {
         None
     };

--- a/install.sh
+++ b/install.sh
@@ -1,67 +1,114 @@
 #!/usr/bin/env sh
 set -e
 
-REPO="h5i-dev/h5i"
-BINARY="h5i"
-INSTALL_DIR="${H5I_INSTALL_DIR:-/usr/local/bin}"
+# Everything lives in main() and main is called on the last line, so a
+# truncated `curl … | sh` cannot execute a half-downloaded prefix.
+main() {
+  REPO="h5i-dev/h5i"
+  BINARY="h5i"
+  INSTALL_DIR="${H5I_INSTALL_DIR:-/usr/local/bin}"
 
-# ── detect OS ────────────────────────────────────────────────────────────────
-OS="$(uname -s)"
-case "$OS" in
-  Linux)  os="linux" ;;
-  Darwin) os="macos" ;;
-  *)
-    echo "Unsupported OS: $OS" >&2
+  # ── detect OS ──────────────────────────────────────────────────────────────
+  OS="$(uname -s)"
+  case "$OS" in
+    Linux)  os="linux" ;;
+    Darwin) os="macos" ;;
+    *)
+      echo "Unsupported OS: $OS" >&2
+      exit 1
+      ;;
+  esac
+
+  # ── detect arch ────────────────────────────────────────────────────────────
+  ARCH="$(uname -m)"
+  case "$ARCH" in
+    x86_64 | amd64)  arch="x86_64" ;;
+    arm64 | aarch64) arch="aarch64" ;;
+    *)
+      echo "Unsupported architecture: $ARCH" >&2
+      exit 1
+      ;;
+  esac
+
+  # ── map to release target triple ───────────────────────────────────────────
+  case "${os}-${arch}" in
+    linux-x86_64)  target="x86_64-unknown-linux-musl" ;;
+    linux-aarch64) target="aarch64-unknown-linux-musl" ;;
+    macos-x86_64 | macos-aarch64) target="aarch64-apple-darwin" ;;
+  esac
+
+  # ── resolve latest version ─────────────────────────────────────────────────
+  VERSION="${H5I_VERSION:-}"
+  if [ -z "$VERSION" ]; then
+    VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+      | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  fi
+
+  if [ -z "$VERSION" ]; then
+    echo "Could not determine latest version. Set H5I_VERSION=vX.Y.Z to override." >&2
     exit 1
-    ;;
-esac
+  fi
 
-# ── detect arch ──────────────────────────────────────────────────────────────
-ARCH="$(uname -m)"
-case "$ARCH" in
-  x86_64 | amd64)  arch="x86_64" ;;
-  arm64 | aarch64) arch="aarch64" ;;
-  *)
-    echo "Unsupported architecture: $ARCH" >&2
-    exit 1
-    ;;
-esac
+  # ── download ───────────────────────────────────────────────────────────────
+  ARCHIVE="${BINARY}-${VERSION}-${target}.tar.gz"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
 
-# ── map to release target triple ─────────────────────────────────────────────
-case "${os}-${arch}" in
-  linux-x86_64)  target="x86_64-unknown-linux-musl" ;;
-  linux-aarch64) target="aarch64-unknown-linux-musl" ;;
-  macos-x86_64 | macos-aarch64) target="aarch64-apple-darwin" ;;
-esac
+  echo "Installing h5i ${VERSION} (${target}) → ${INSTALL_DIR}/${BINARY}"
 
-# ── resolve latest version ───────────────────────────────────────────────────
-VERSION="${H5I_VERSION:-}"
-if [ -z "$VERSION" ]; then
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
-fi
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
 
-if [ -z "$VERSION" ]; then
-  echo "Could not determine latest version. Set H5I_VERSION=vX.Y.Z to override." >&2
-  exit 1
-fi
+  curl -fsSL "$URL" -o "${TMP}/${ARCHIVE}"
 
-# ── download and install ─────────────────────────────────────────────────────
-ARCHIVE="${BINARY}-${VERSION}-${target}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+  # ── verify against the checksum the release publishes ──────────────────────
+  # Not a substitute for signing — same origin as the archive — but it does
+  # catch a truncated or corrupted download, and it makes tampering with the
+  # asset alone insufficient. H5I_SKIP_CHECKSUM=1 is an explicit, visible
+  # escape hatch rather than a silent skip.
+  if [ "${H5I_SKIP_CHECKSUM:-0}" = "1" ]; then
+    echo "!  checksum verification skipped (H5I_SKIP_CHECKSUM=1)" >&2
+  else
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256_of() { sha256sum "$1" | cut -d' ' -f1; }
+    elif command -v shasum >/dev/null 2>&1; then
+      sha256_of() { shasum -a 256 "$1" | cut -d' ' -f1; }
+    else
+      echo "Neither sha256sum nor shasum found; cannot verify the download." >&2
+      echo "Install one, or re-run with H5I_SKIP_CHECKSUM=1 to accept the risk." >&2
+      exit 1
+    fi
 
-echo "Installing h5i ${VERSION} (${target}) → ${INSTALL_DIR}/${BINARY}"
+    if ! curl -fsSL "${URL}.sha256" -o "${TMP}/${ARCHIVE}.sha256"; then
+      echo "Could not fetch ${ARCHIVE}.sha256 — refusing to install unverified." >&2
+      echo "Re-run with H5I_SKIP_CHECKSUM=1 to accept the risk." >&2
+      exit 1
+    fi
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+    expected="$(cut -d' ' -f1 < "${TMP}/${ARCHIVE}.sha256")"
+    actual="$(sha256_of "${TMP}/${ARCHIVE}")"
+    if [ -z "$expected" ] || [ "$expected" != "$actual" ]; then
+      echo "Checksum mismatch for ${ARCHIVE}" >&2
+      echo "  expected: ${expected:-<empty>}" >&2
+      echo "  actual:   ${actual}" >&2
+      exit 1
+    fi
+  fi
 
-curl -fsSL "$URL" -o "${TMP}/${ARCHIVE}"
-tar -xzf "${TMP}/${ARCHIVE}" -C "$TMP"
+  tar -xzf "${TMP}/${ARCHIVE}" -C "$TMP"
 
-if [ -w "$INSTALL_DIR" ]; then
-  mv "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
-else
-  sudo mv "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
-fi
+  # ── install ────────────────────────────────────────────────────────────────
+  # `install` rather than `mv`: `mv` preserves the *invoking user's* ownership,
+  # which under sudo leaves a user-writable h5i sitting in a root-owned PATH
+  # directory. Anything running as that user — including an agent in a
+  # workspace-tier box, which shares the uid — could then replace the binary
+  # that enforces every box's confinement, and `sudo h5i` would run it as root.
+  if [ -w "$INSTALL_DIR" ]; then
+    install -m 755 "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  else
+    sudo install -o root -g 0 -m 755 "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  fi
 
-echo "✔  h5i ${VERSION} installed — run: h5i --help"
+  echo "✔  h5i ${VERSION} installed — run: h5i --help"
+}
+
+main "$@"

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -1306,7 +1306,7 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                 BoxCommands::Secrets { name, json } => {
                     let m = h5i_core::env::find(&h5i_root, &name)?;
                     let policy = h5i_core::env::load_policy(&h5i_root, &m)?;
-                    let rows = h5i_core::env::secrets_status(&policy);
+                    let rows = h5i_core::env::secrets_status(&h5i_root, &policy);
                     if json {
                         println!("{}", serde_json::to_string_pretty(&rows)?);
                     } else {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -4396,7 +4396,11 @@ fn env_secrets_reports_status_without_values() {
     let row = &rows.as_array().unwrap()[0];
     assert_eq!(row["name"], "API_KEY");
     assert_eq!(row["status"], "ok");
-    assert!(row["fingerprint"].as_str().unwrap().starts_with("sha256:"));
+    // Keyed (HMAC under the per-repo key), not a bare digest — an unsalted
+    // sha256 prefix in a durable audit record is grindable offline.
+    let fp = row["fingerprint"].as_str().unwrap();
+    assert!(fp.starts_with("fp:"), "{fp}");
+    assert!(!fp.contains("sha256:"), "must not be a plain digest: {fp}");
 }
 
 #[test]


### PR DESCRIPTION
Fixes the security advisories drafted from the full-source review. 19 of 20 are code changes with regression tests; one is documented rather than patched, with the reason stated below.

## Critical

- **A box could redirect the mediated commit onto any ref.** `Repository::open($WORK)` trusted the `.git` pointer file and the worktree admin dir, both writable inside the box. `mediated_commit` then staged the box tree into whatever repository the pointer named and committed to that repository's HEAD, landing unreviewed work on the parent branch without `apply` running. New `open_env_worktree()` validates the object store and the branch before returning a handle; all eight host-side opens go through it.

## High

- **Repo-planted symlink bind-mounted an arbitrary host path into the box** (`.claude/settings.json` → `~/.ssh`). Resolved with `symlink_metadata` + canonicalize, shared by the container and microvm tiers.
- **`private_paths` followed a symlinked ancestor out of `$WORK`**, giving the box a writable directory on the operator's filesystem. Fixed on macOS (the advisory) and on Linux, which had the same primitive via the bind mountpoint.
- **The egress proxy never dialled the address it pinned.** Names matched, then `TcpStream::connect` re-resolved — so an allowlisted domain under attacker DNS control reached host loopback. Pins now live per entry and are what gets dialled; unpinnable destinations are filtered to globally routable addresses.
- **Receipt redaction was gated on a stoplist-bearing detector**, so `example config: ghp_<real>` was stored verbatim. Redaction is now unconditional; `redact_text` also stopped reframing payloads (CRLF, trailing newline) now that every receipt passes through it.
- **A box picked the host loopback port its next session was granted** (macOS). The reservations moved out of the box-writable `browser/state`.
- **`install.sh` left a user-writable binary in root's PATH** and never checked the published `.sha256`.

## Medium

- Secrets broker wrote credentials through a planted symlink (`O_NOFOLLOW` + `create_new` now).
- The nftables ruleset lived at a guessable `/tmp` path and is `execve`'d with CAP_NET_ADMIN — now an unguessable `mkdir(0700)` scratch dir.
- `env.pass` could shadow the proxy wiring and bypass the allowlist.
- The credential proxy failed *open* on a transient error, re-admitting the token into the box while widening its egress.
- An explicit `fs.write = []` was re-widened to the builtin base — a narrowing became a widening.
- The container allowlist parser silently turned `example.com:99999` into an any-port rule; the grammar is now parsed once, fail-closed, for every tier.
- Untrusted spool reads had no cap and a symlink TOCTOU.

## Low

- Keyed the audit fingerprint (HMAC under a per-repo key) instead of publishing a grindable `sha256(value)` prefix.
- Stopped widening permissions on the SBPL profile file and the per-env HOME copy.
- Refused the x32 ABI, which passed the arch guard and then matched no syscall comparison — bypassing both the socket gate and the deny-list.
- The `fs.deny` lint compared strings while Landlock follows symlinks; both sides are canonicalized now.

## Documented, not patched

The container tier's allowlist plan sets `slirp4netns:allow_host_loopback=true`, exposing every host loopback service — so choosing an allowlist *widens* the box's reach. An application-level token would cover the standard clients but not the browser tier, since the shim launches Chrome with `--proxy-server=$H5I_EGRESS_PROXY` and Chrome cannot present proxy credentials non-interactively. A gate that silently excluded the browser profile would read as fixed while leaving the hole, so it is not shipped as one. Closing it properly means the proxy living inside the box's network namespace. `announce_egress` now states the caveat where the operator sees it.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `h5i-sandbox` 295 passed, `h5i-core` 225 passed, `console_api` 8 passed
- `env_integration` 115 passed / 3 failed — `box_git_grants_stay_fail_closed_outside_env_namespace`, `box_git_status_and_commit_work_inside_process_tier`, `process_tier_confines_fs_and_network`. All three fail identically on clean `main` on this host (pre-existing process-tier drift), verified by checking out `main` and re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)