### PR TITLE
fix: bound the waits, threads and disk a box can drive unboundedly

### DIFF
--- a/crates/h5i-core/src/view.rs
+++ b/crates/h5i-core/src/view.rs
@@ -856,12 +856,23 @@ impl Forward {
 
         // Out: frames to the human, unconditionally. Watching never collides,
         // so this direction has no policy at all.
+        //
+        // When the BOX's stream ends first (its browser exits, or `stream
+        // disable` runs), this copy returns and the client must be shut down
+        // too — the page has no way to learn the stream is gone, so it holds
+        // the socket open and `pump_input` below blocks on a peer that will
+        // never close. `serve()` takes one connection at a time, so that
+        // stopped the forward serving anything until the human closed the tab.
+        let client_shutdown = client.try_clone()?;
         let out = std::thread::spawn(move || {
-            std::io::copy(&mut upstream, &mut client_out).unwrap_or(0)
+            let n = std::io::copy(&mut upstream, &mut client_out).unwrap_or(0);
+            let _ = client_shutdown.shutdown(std::net::Shutdown::Read);
+            n
         });
         // In: gated by the control lock.
         let pumped = pump_input(&mut client, &mut upstream_out, &env_dir);
-        // Closing our end unblocks the outbound copy so the thread can finish.
+        // And the mirror image: closing our end unblocks the outbound copy when
+        // the HUMAN disconnects first.
         let _ = upstream_out.shutdown(std::net::Shutdown::Both);
         let bytes_out = out.join().unwrap_or(0);
 
@@ -1006,6 +1017,18 @@ pub fn record_session(
 
 /// Read up to the end of the HTTP headers.
 fn read_head(s: &mut TcpStream) -> std::io::Result<String> {
+    // Bounded in time as well as size. `serve()` handles one connection at a
+    // time, so a peer that connects and sends nothing — a browser's speculative
+    // preconnect is the ordinary case — used to stall every later viewer until
+    // it went away on its own.
+    let prev = s.read_timeout()?;
+    s.set_read_timeout(Some(std::time::Duration::from_secs(10)))?;
+    let out = read_head_inner(s);
+    let _ = s.set_read_timeout(prev);
+    out
+}
+
+fn read_head_inner(s: &mut TcpStream) -> std::io::Result<String> {
     let mut buf = Vec::new();
     let mut byte = [0u8; 1];
     // Bounded: a header block this large is a client we do not want to serve.

--- a/crates/h5i-sandbox/src/auth_proxy.rs
+++ b/crates/h5i-sandbox/src/auth_proxy.rs
@@ -538,9 +538,23 @@ fn client_authorized(head: &[u8], client_token: &str) -> bool {
 
 /// Read the request head (request line + headers) up to the blank line, capped.
 fn read_head(s: &mut TcpStream) -> std::io::Result<Vec<u8>> {
+    // Bounded overall, not just per read(). The socket's read timeout bounds a
+    // single syscall, so a client dribbling one header byte just under that
+    // interval held its in-flight slot indefinitely. Sixty-four such clients
+    // — any local process, which is the actor the token gate exists for —
+    // exhausted MAX_IN_FLIGHT and the agent's own API call got a 503 for the
+    // life of the box, with no fallback because its only credential is the
+    // dummy.
+    let deadline = std::time::Instant::now() + HEAD_DEADLINE;
     let mut buf = Vec::with_capacity(512);
     let mut byte = [0u8; 1];
     loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "request head exceeded its deadline",
+            ));
+        }
         let n = s.read(&mut byte)?;
         if n == 0 {
             break;
@@ -552,6 +566,10 @@ fn read_head(s: &mut TcpStream) -> std::io::Result<Vec<u8>> {
     }
     Ok(buf)
 }
+
+/// Whole-head deadline. Generous for a real client on a slow link, short enough
+/// that a stalled connection cannot hold an in-flight slot for a session.
+const HEAD_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
 
 fn write_status(client: &mut TcpStream, code: u16, reason: &str) {
     let _ = client.write_all(format!("HTTP/1.1 {code} {reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n").as_bytes());

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -559,6 +559,16 @@ impl AllowList {
     }
 }
 
+/// Most bytes the tee shim records per stream, per command. The box decides how
+/// much it writes, so this is a disk bound on the host, not a display limit —
+/// the command's own output still passes through in full.
+const SPOOL_STREAM_CAP: u64 = 4 * 1024 * 1024;
+
+/// Most connections the egress proxy will serve at once. Generous for real
+/// tooling (parallel `cargo`/`npm` fetches) and far below what it takes to
+/// exhaust host threads.
+const MAX_PROXY_CONNECTIONS: usize = 64;
+
 /// A running egress proxy: a localhost TCP listener gating CONNECT/HTTP by the
 /// allowlist. Dropping the handle shuts the accept loop down.
 pub struct ProxyHandle {
@@ -635,20 +645,36 @@ pub fn spawn_proxy_on(allow: AllowList, want: Option<u16>) -> Result<ProxyHandle
     let tally = Arc::new(Mutex::new(EgressTally::default()));
     let tally_thread = tally.clone();
 
+    // Bounded concurrency. One unbounded thread per accepted connection let a
+    // box open thousands of proxy connections and exhaust host threads; the
+    // proxy is the box's only route out, so the box is also the only thing that
+    // benefits from unbounded parallelism here.
+    let live = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let join = std::thread::spawn(move || {
         while !stop_thread.load(Ordering::SeqCst) {
             match listener.accept() {
-                Ok((client, _)) => {
+                Ok((mut client, _)) => {
                     if stop_thread.load(Ordering::SeqCst) {
                         break;
+                    }
+                    if live.load(Ordering::SeqCst) >= MAX_PROXY_CONNECTIONS {
+                        // Refuse rather than queue: a queued connection still
+                        // holds an fd, and the client sees a clear 503.
+                        let _ = client.write_all(
+                            b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n",
+                        );
+                        continue;
                     }
                     // The accepted socket may arrive non-blocking (see
                     // `handle_proxy_client`, which is where that is corrected —
                     // at the point the blocking reads are actually made).
                     let allow = allow.clone();
                     let tally = tally_thread.clone();
+                    let live_slot = live.clone();
+                    live_slot.fetch_add(1, Ordering::SeqCst);
                     std::thread::spawn(move || {
                         let _ = handle_proxy_client(client, &allow, &tally, HEAD_READ_TIMEOUT);
+                        live_slot.fetch_sub(1, Ordering::SeqCst);
                     });
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
@@ -966,19 +992,35 @@ while [ -e "$d/cmd-$$-$n.cmd" ] && [ "$n" -lt 1000 ]; do n=$((n+1)); done
 b="$d/cmd-$$-$n"
 {{ printf '%s' "$cmd" > "$b.cmd"; }} 2>/dev/null || exec "$real" "$@"
 mkfifo "$b.po" "$b.pe" 2>/dev/null || {{ rm -f "$b.cmd"; exec "$real" "$@"; }}
-tee "$b.out" < "$b.po" &
+# Cap what lands in the host-side spool. The box chooses how much it writes
+# here, so an uncapped `tee` let `yes > /dev/stdout` fill the operator's disk —
+# the ingest side caps what it READS, which is a different thing.
+#
+# POSIX sh, so no process substitution: tee's file target is a second fifo whose
+# reader keeps only the first $cap bytes and then drains the rest to /dev/null.
+# Draining matters — without it tee would take EPIPE once the cap was hit and
+# the command's passthrough output would stop with it.
+cap={spool_cap}
+mkfifo "$b.oc" "$b.ec" 2>/dev/null || {{ rm -f "$b.cmd" "$b.po" "$b.pe"; exec "$real" "$@"; }}
+{{ head -c "$cap" > "$b.out"; cat > /dev/null; }} < "$b.oc" &
+oc=$!
+{{ head -c "$cap" > "$b.err"; cat > /dev/null; }} < "$b.ec" &
+ec=$!
+tee "$b.oc" < "$b.po" &
 po=$!
-tee "$b.err" < "$b.pe" >&2 &
+tee "$b.ec" < "$b.pe" >&2 &
 pe=$!
 "$real" "$@" > "$b.po" 2> "$b.pe"
 rc=$?
 wait "$po" "$pe" 2>/dev/null
-rm -f "$b.po" "$b.pe"
+wait "$oc" "$ec" 2>/dev/null
+rm -f "$b.po" "$b.pe" "$b.oc" "$b.ec"
 printf '%s' "$rc" > "$b.exit" 2>/dev/null
 exit "$rc"
 "#,
         orig = orig_prefix,
         spool = spool_dir,
+        spool_cap = SPOOL_STREAM_CAP,
     )
 }
 

--- a/crates/h5i-sandbox/src/microvm.rs
+++ b/crates/h5i-sandbox/src/microvm.rs
@@ -688,22 +688,93 @@ struct SandboxGuard {
 
 impl SandboxGuard {
     fn new(bin: &str) -> Self {
-        SandboxGuard {
+        let g = SandboxGuard {
             bin: bin.to_string(),
             name: format!(
                 "h5i-{}-{}",
                 std::process::id(),
                 RUN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             ),
+        };
+        // Drop alone cannot cover SIGKILL, SIGTERM, or a panic=abort build, and
+        // a *named* msb sandbox survives us — unlike the container tier, which
+        // has `--rm` as a backstop. Leave a marker so a later run can reap what
+        // an abnormal exit left behind.
+        if let Some(m) = marker_path(&g.name) {
+            if let Some(d) = m.parent() {
+                let _ = std::fs::create_dir_all(d);
+            }
+            let _ = std::fs::write(&m, b"");
         }
+        g
     }
 
     fn remove(&self) {
-        let _ = std::process::Command::new(&self.bin)
-            .args(["remove", "--force", &self.name])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
+        remove_named(&self.bin, &self.name);
+        if let Some(m) = marker_path(&self.name) {
+            let _ = std::fs::remove_file(m);
+        }
+    }
+}
+
+fn remove_named(bin: &str, name: &str) {
+    let _ = std::process::Command::new(bin)
+        .args(["remove", "--force", name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Where the marker for a live named sandbox lives.
+fn marker_path(name: &str) -> Option<PathBuf> {
+    Some(std::env::temp_dir().join("h5i-msb-live").join(name))
+}
+
+/// Reap named sandboxes an earlier h5i left behind.
+///
+/// Keyed on the pid embedded in the name (`h5i-<pid>-<seq>`): a marker whose
+/// process is gone can only be a leftover, because a live run holds its own
+/// marker until Drop removes it. Best-effort throughout — a failed sweep must
+/// never turn a good run into an error.
+pub fn reap_orphaned_sandboxes(bin: &str) {
+    let Some(dir) = marker_path("").and_then(|p| p.parent().map(PathBuf::from)) else {
+        return;
+    };
+    let Ok(rd) = std::fs::read_dir(&dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        let name = e.file_name().to_string_lossy().into_owned();
+        let Some(pid) = name
+            .strip_prefix("h5i-")
+            .and_then(|r| r.split('-').next())
+            .and_then(|p| p.parse::<i32>().ok())
+        else {
+            continue;
+        };
+        if pid == std::process::id() as i32 || pid_alive(pid) {
+            continue;
+        }
+        remove_named(bin, &name);
+        let _ = std::fs::remove_file(e.path());
+    }
+}
+
+/// Is `pid` still around? `kill(pid, 0)` reports EPERM for a live process we do
+/// not own, which still means "do not reap".
+fn pid_alive(pid: i32) -> bool {
+    #[cfg(unix)]
+    {
+        if pid <= 0 {
+            return true; // never interpret a bad pid as reapable
+        }
+        let rc = unsafe { libc::kill(pid, 0) };
+        rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        true
     }
 }
 
@@ -745,6 +816,8 @@ pub fn run(
 
     let net = net_plan(policy)?;
     let preload = write_preload(work, &guest_env(policy, injected_env))?;
+    // Sweep leftovers from an h5i that died without running Drop.
+    reap_orphaned_sandboxes(&rt.bin);
     let sandbox = SandboxGuard::new(&rt.bin);
     let full = build_run_argv(
         &rt,
@@ -801,6 +874,8 @@ pub fn run_interactive(
     // Only ask for a pseudo-TTY when we have one on both ends — msb rejects
     // `--tty` under a pipe, which would turn a CI `env shell` into a hard error.
     let tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+    // Sweep leftovers from an h5i that died without running Drop.
+    reap_orphaned_sandboxes(&rt.bin);
     let sandbox = SandboxGuard::new(&rt.bin);
     let full = build_run_argv(
         &rt,
@@ -954,6 +1029,32 @@ mod tests {
     }
 
     // ─── version parsing ────────────────────────────────────────────────────
+
+    /// A named msb sandbox outlives us, and Drop cannot run on SIGKILL. The
+    /// sweep reaps a marker whose pid is gone and leaves a live one alone.
+    #[test]
+    fn orphan_sweep_only_targets_dead_pids() {
+        // Our own pid is alive, so it must never be swept.
+        assert!(pid_alive(std::process::id() as i32));
+        // pid 1 always exists; kill(1,0) is EPERM for a normal user, which the
+        // helper must read as "alive" rather than "reapable".
+        assert!(pid_alive(1));
+        // A bad pid is never treated as reapable.
+        assert!(pid_alive(0));
+        assert!(pid_alive(-1));
+        // A pid that cannot exist is reapable.
+        assert!(!pid_alive(0x7fff_fffe));
+    }
+
+    #[test]
+    fn a_guard_leaves_a_marker_and_clears_it() {
+        let g = SandboxGuard::new("true");
+        let m = marker_path(&g.name).unwrap();
+        assert!(m.exists(), "a live sandbox records a marker");
+        assert!(g.name.starts_with(&format!("h5i-{}-", std::process::id())));
+        drop(g);
+        assert!(!m.exists(), "Drop clears the marker");
+    }
 
     #[test]
     fn version_is_parsed_from_the_banner_shapes_msb_prints() {

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -696,6 +696,7 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
 /// on top. Without a deadline a helper that exits without signalling wedges the
 /// run forever, because the pipe's write end is held by the live `EgressNetns`
 /// and the wall clock is not armed until `spawn()` returns.
+#[cfg(target_os = "linux")]
 pub(crate) const EGRESS_READY_TIMEOUT_MS: libc::c_int = 15_000;
 
 /// 16 hex chars of OS entropy — enough that no other local user can guess or

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -691,6 +691,13 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
     Ok(())
 }
 
+/// How long a confined child waits for the slirp4netns uplink before failing
+/// closed. The helper polls for `tap0` for 6s; this leaves room for the spawn
+/// on top. Without a deadline a helper that exits without signalling wedges the
+/// run forever, because the pipe's write end is held by the live `EgressNetns`
+/// and the wall clock is not armed until `spawn()` returns.
+pub(crate) const EGRESS_READY_TIMEOUT_MS: libc::c_int = 15_000;
+
 /// 16 hex chars of OS entropy — enough that no other local user can guess or
 /// pre-plant a scratch path before we create it.
 fn random_suffix() -> Result<String, H5iError> {
@@ -2551,8 +2558,29 @@ pub(crate) fn build_confined_command(
                 if !(libc::WIFEXITED(st) && libc::WEXITSTATUS(st) == 0) {
                     return Err(Error::other("nft egress ruleset failed to apply (fail-closed)"));
                 }
-                // (d) Block until slirp4netns has configured the uplink, so the
-                //     program never races a not-yet-ready interface.
+                // (d) Wait for slirp4netns to configure the uplink, so the
+                //     program never races a not-yet-ready interface — but with
+                //     a DEADLINE. A bare read here hung forever whenever the
+                //     helper exited without signalling (slirp failed to spawn,
+                //     or tap0 never appeared within its poll budget): the write
+                //     end lives on the parent's live `EgressNetns`, so no EOF
+                //     ever arrives, and `spawn()` blocks the caller with it —
+                //     before the run's wall clock has been armed.
+                //
+                //     `poll` is async-signal-safe and allocates nothing, which
+                //     is what this closure needs. The budget is the helper's own
+                //     (6s of tap0 polling) plus slack for the spawn itself.
+                let mut pfd = libc::pollfd {
+                    fd: eg.ready_read_fd,
+                    events: libc::POLLIN,
+                    revents: 0,
+                };
+                let ready = libc::poll(&mut pfd, 1, EGRESS_READY_TIMEOUT_MS);
+                if ready != 1 {
+                    return Err(Error::other(
+                        "slirp4netns uplink did not become ready in time (fail-closed)",
+                    ));
+                }
                 let mut rb = [0u8; 1];
                 if libc::read(eg.ready_read_fd, rb.as_mut_ptr().cast(), 1) != 1 {
                     return Err(Error::other("slirp4netns uplink did not become ready"));

--- a/crates/h5i-sandbox/src/supervisor.rs
+++ b/crates/h5i-sandbox/src/supervisor.rs
@@ -614,17 +614,27 @@ impl EgressNetns {
 #[cfg(all(target_os = "linux", any(target_arch = "x86_64", target_arch = "aarch64")))]
 impl Drop for EgressNetns {
     fn drop(&mut self) {
-        // Stop the uplink, then reap the helper and close every pipe end.
+        // Stop the uplink first, so the helper has nothing left to supervise.
         if let Ok(mut g) = self.slirp.lock() {
             if let Some(mut c) = g.take() {
                 let _ = c.kill();
                 let _ = c.wait();
             }
         }
+        // Close the pid pipe's WRITE ends BEFORE joining. The helper parks in
+        // `read(pid_r, .., 4)` waiting for the child to report its pid, and its
+        // only early exit is a short read — which needs every writer gone. The
+        // child's copy closes when it `_exit`s, but ours did not until after
+        // the join, so any pre_exec failure before the pid write (a userns
+        // ENOSPC from concurrent boxes, a uid_map write failure) deadlocked
+        // teardown permanently.
+        for fd in [self.child_pid_write_fd, self.pid_read_fd] {
+            unsafe { libc::close(fd) };
+        }
         if let Some(h) = self.helper.take() {
             let _ = h.join();
         }
-        for fd in [self.pid_read_fd, self.ready_write_fd, self.child_pid_write_fd, self.child_ready_read_fd] {
+        for fd in [self.ready_write_fd, self.child_ready_read_fd] {
             unsafe { libc::close(fd) };
         }
         let _ = std::fs::remove_dir_all(&self.tmp_dir);


### PR DESCRIPTION
Six lifecycle defects where h5i could be wedged or a host resource exhausted, with the box choosing when.

| Issue | Defect |
|---|---|
| #419 | Supervised egress run hung forever when the slirp uplink failed — the comment claimed a `poll()` timeout that did not exist |
| #420 | `EgressNetns::drop` joined the helper before closing the pipe it was blocked reading |
| #432 | Web forward hung and stopped serving when the box's stream closed first; `read_head` had no timeout |
| #435 | Auth proxy bounded each `read()` but not the head, so a slowloris starved the agent's own credentialed egress |
| #437 | Unbounded thread per proxy connection; uncapped tee-shim writes into the host spool |
| #444 | A named microVM survived an abnormal h5i exit with no backstop |

Notes on two of them:

**#437, the tee shim.** The shim is POSIX `sh` (`#!/.h5i/orig/bin/sh`), so process substitution is unavailable. The cap is a second fifo whose reader keeps the first N bytes and then drains the remainder to /dev/null — the drain is load-bearing, since without it `tee` takes EPIPE once the cap is hit and the command's passthrough output stops with it. Verified as a standalone shell script: 5500/6000 bytes passed through, 100/100 recorded at a 100-byte cap, exit code preserved, no hang.

**#444.** Reaping is keyed on the pid embedded in the sandbox name; `kill(pid, 0)` returning EPERM counts as alive, so a sandbox belonging to another user is never reaped.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- h5i-sandbox 297 passed, h5i-core 225 passed, console_api 8 passed
- env_integration 115 passed / 3 failed — the same three process-tier failures that fail on clean `main` on this host

🤖 Generated with [Claude Code](https://claude.com/claude-code)