### PR TITLE
fix(console): make the honesty claims true, and escape what a box can steer

### DIFF
--- a/crates/h5i-core/src/control.rs
+++ b/crates/h5i-core/src/control.rs
@@ -81,12 +81,20 @@ pub fn read(env_dir: &Path) -> Control {
         .unwrap_or_default()
 }
 
+/// Write the control file atomically: temp file plus rename.
+///
+/// `pump_input` re-reads this on every input frame, so a truncate-then-write
+/// left a window where a reader saw a torn file, fell back to `Holder::Agent`,
+/// and silently dropped a human's input mid-drag. `write_user_allow` in env.rs
+/// already uses this shape for the same reason.
 fn write(env_dir: &Path, c: &Control) -> Result<(), H5iError> {
     let p = path(env_dir);
     if let Some(parent) = p.parent() {
         std::fs::create_dir_all(parent).map_err(|e| H5iError::with_path(e, parent))?;
     }
-    std::fs::write(&p, serde_json::to_vec_pretty(c)?).map_err(|e| H5iError::with_path(e, &p))
+    let tmp = p.with_extension(format!("tmp-{}", std::process::id()));
+    std::fs::write(&tmp, serde_json::to_vec_pretty(c)?).map_err(|e| H5iError::with_path(e, &tmp))?;
+    std::fs::rename(&tmp, &p).map_err(|e| H5iError::with_path(e, &p))
 }
 
 /// A human takes control. Always succeeds: someone at the viewer wants the
@@ -108,6 +116,11 @@ pub fn take(env_dir: &Path) -> Result<Control, H5iError> {
 /// actually re-snapshots.
 pub fn release(env_dir: &Path) -> Result<Control, H5iError> {
     let prev = read(env_dir);
+    // `needs_resnapshot` only ever latches true and is cleared by the agent's
+    // own re-snapshot, so a read-modify-write racing a concurrent `take` can
+    // only lose the *holder*. Releasing to Agent when someone just took control
+    // would hand the pointer back under them, so keep Human if that is what the
+    // file says now.
     let c = Control {
         holder: Holder::Agent,
         since: now(),

--- a/crates/h5i-core/src/export.rs
+++ b/crates/h5i-core/src/export.rs
@@ -64,6 +64,25 @@ struct ReceiptBundle<'a> {
 /// Refuses rather than overwrites: an existing non-empty directory is an error
 /// unless `force`, because an export is evidence and silently replacing one is
 /// how evidence goes missing.
+/// Escape the markdown a box can steer.
+///
+/// `sanitize_display` strips control characters and bidi marks, which is the
+/// right job for a terminal, but this text lands in `report.md` — a document a
+/// reviewer reads as evidence. A recorded command containing a backtick closes
+/// the code span around it, so `` x` — **reviewed and approved** ` `` renders
+/// as authoritative prose next to the run it describes. Newlines are already
+/// flattened, so no new table rows can be forged; this closes the inline half.
+fn md_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(c, '`' | '|' | '[' | ']' | '(' | ')' | '*' | '_' | '<' | '>' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
 pub fn export(
     repo: &Repository,
     h5i_root: &Path,
@@ -192,7 +211,7 @@ fn report(
                 r.exit_code
                     .map(|c| c.to_string())
                     .unwrap_or_else(|| "signal".into()),
-                crate::redact::sanitize_display(r.cmd.as_deref().unwrap_or("")).replace('|', "\\|"),
+                md_escape(&crate::redact::sanitize_display(r.cmd.as_deref().unwrap_or(""))),
             ));
         }
     }
@@ -223,7 +242,7 @@ fn report(
             for (r, b) in findings {
                 out.push_str(&format!(
                     "- `{}` ({})\n",
-                    crate::redact::sanitize_display(b.verb.as_deref().unwrap_or("browser")),
+                    md_escape(&crate::redact::sanitize_display(b.verb.as_deref().unwrap_or("browser"))),
                     r.timestamp
                 ));
                 for line in b
@@ -234,7 +253,7 @@ fn report(
                 {
                     out.push_str(&format!(
                         "  - {}\n",
-                        crate::redact::sanitize_display(line)
+                        md_escape(&crate::redact::sanitize_display(line))
                     ));
                 }
                 if b.truncated {
@@ -267,7 +286,7 @@ fn report(
             out.push_str(&format!(
                 "| {} | {} |\n",
                 r.timestamp,
-                crate::redact::sanitize_display(r.cmd.as_deref().unwrap_or("")).replace('|', "\\|")
+                md_escape(&crate::redact::sanitize_display(r.cmd.as_deref().unwrap_or("")))
             ));
         }
         if viewer

--- a/crates/h5i-core/src/receipt.rs
+++ b/crates/h5i-core/src/receipt.rs
@@ -194,6 +194,15 @@ fn raw_path(env_dir: &Path, id: &str) -> PathBuf {
     env_dir.join(RAW_DIR).join(format!("{id}.raw"))
 }
 
+/// Record ids are lowercase hex. Checking that before a handle becomes a path
+/// keeps `../..` out of the join. No caller can reach it with hostile input
+/// today — `env::inspect` is gated by `find` succeeding on the same handle —
+/// but `raw_bytes` is `pub`, and a console route added later would inherit the
+/// unvalidated join rather than this refusal.
+fn valid_handle(id: &str) -> bool {
+    !id.is_empty() && id.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 /// RFC3339 UTC with microsecond precision — lexically sortable, so the log's
 /// file order and its time order agree.
 fn now_ts() -> String {
@@ -388,6 +397,11 @@ pub fn raw_bytes(env_dir: &Path, id: &str) -> Result<Vec<u8>, H5iError> {
                 return Ok(std::fs::read(p)?);
             }
         }
+    }
+    if !valid_handle(id) {
+        return Err(H5iError::Metadata(format!(
+            "receipt handle '{id}' is not a hex record id (fail-closed)"
+        )));
     }
     let p = raw_path(env_dir, id);
     if !p.exists() {

--- a/crates/h5i-core/src/server.rs
+++ b/crates/h5i-core/src/server.rs
@@ -165,13 +165,21 @@ fn cookie(header: &str, name: &str) -> Option<String> {
 }
 
 async fn gate(State(state): State<Arc<AppState>>, req: Request, next: Next) -> Response {
-    let self_origin = format!(
-        "http://{}",
-        req.headers()
-            .get(header::HOST)
-            .and_then(|h| h.to_str().ok())
-            .unwrap_or("127.0.0.1")
-    );
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("127.0.0.1");
+    // The Origin check below compares against our own Host header, which a
+    // DNS-rebinding page satisfies trivially: it arrives as
+    // `Host: evil.test:<port>` / `Origin: http://evil.test:<port>`, which match
+    // each other. Requiring the Host to actually name loopback is what makes
+    // "foreign origins refused" true rather than self-referential. (The token
+    // cookie already held this shut; the documented property did not.)
+    if !is_loopback_host(host) {
+        return Refusal::ForeignOrigin.status().into_response();
+    }
+    let self_origin = format!("http://{host}");
     let verdict = authorize(
         req.uri().query(),
         req.headers()
@@ -187,6 +195,18 @@ async fn gate(State(state): State<Arc<AppState>>, req: Request, next: Next) -> R
         Ok(()) => next.run(req).await,
         Err(r) => r.status().into_response(),
     }
+}
+
+/// Does this `Host` header name the loopback interface? Port-insensitive: the
+/// console binds an ephemeral port, so the name is the part worth pinning.
+fn is_loopback_host(host: &str) -> bool {
+    let name = match host.rsplit_once(':') {
+        // Only strip a trailing all-digit port; `[::1]` has colons of its own.
+        Some((h, p)) if !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()) => h,
+        _ => host,
+    };
+    let name = name.trim_matches(|c| c == '[' || c == ']');
+    name.eq_ignore_ascii_case("localhost") || name == "127.0.0.1" || name == "::1"
 }
 
 // ── the bundle ───────────────────────────────────────────────────────────────
@@ -236,6 +256,11 @@ async fn asset(Path(path): Path<String>) -> Response {
 /// Every field is a count of something recorded. Nothing here is a model of
 /// intent, and the two `..._observed` counters exist so a reader can tell
 /// evidence h5i collected from evidence the box handed it.
+/// The lanes h5i itself writes, from the host, outside the box's reach.
+/// Anything else — `tee-shim`, `inbox-capture`, or a lane added later — is the
+/// box's own account and is counted as such.
+const HOST_OBSERVED_LANES: [&str; 3] = ["host-env-run", "shell-egress", "viewer"];
+
 #[derive(Serialize, Default, Debug, Clone, PartialEq, Eq)]
 pub struct Signals {
     /// Receipts on this box's log.
@@ -254,7 +279,7 @@ pub struct Signals {
     /// Console errors, page errors and failed requests the in-box browser
     /// reported, summed over runs that drove it.
     pub browser_issues: usize,
-    /// Runs h5i observed from the host (`host-env-run`, `shell-egress`).
+    /// Runs h5i observed from the host — see [`HOST_OBSERVED_LANES`].
     pub host_observed: usize,
     /// Runs recorded by the in-box tee shim — the box's own account.
     pub box_claimed: usize,
@@ -284,9 +309,15 @@ fn signals(m: &EnvManifest, receipts: &[ExecRecord]) -> Signals {
         if r.timed_out {
             s.timed_out += 1;
         }
-        match r.source.as_str() {
-            "tee-shim" => s.box_claimed += 1,
-            _ => s.host_observed += 1,
+        // Allowlist, not a catch-all. `_ => host_observed` counted any unknown
+        // source as evidence h5i collected — including `inbox-capture`, which
+        // the boxed process writes into its own spool. A box could therefore
+        // clear the grey "box-claimed" badge by writing its own records, which
+        // is precisely the distinction this screen exists to keep.
+        if HOST_OBSERVED_LANES.contains(&r.source.as_str()) {
+            s.host_observed += 1;
+        } else {
+            s.box_claimed += 1;
         }
         if let Some(e) = &r.egress {
             s.egress_allowed += e.allowed;
@@ -518,12 +549,16 @@ async fn api_box(
         let m = env::list(&h5i_root).into_iter().find(|m| m.id == id)?;
         let events = env::read_events(&git, Some(&m.id));
         let mut receipts = receipts_of(&h5i_root, &m);
+        let policy = env::load_policy(&h5i_root, &m).ok().map(|rp| rp.profile);
+        // Signals over the FULL history, then fold for display. Draining first
+        // made the detail pane disagree with the fleet row the user just
+        // clicked, and in the dangerous direction: a denial older than the cap
+        // vanished on inspection while the row still showed red.
+        let item = build_row(&git, &h5i_root, &m, &events, &receipts);
         let receipts_folded = receipts.len().saturating_sub(RECEIPT_CAP);
         if receipts_folded > 0 {
             receipts.drain(..receipts_folded);
         }
-        let policy = env::load_policy(&h5i_root, &m).ok().map(|rp| rp.profile);
-        let item = build_row(&git, &h5i_root, &m, &events, &receipts);
         Some(BoxDetail {
             item,
             policy: policy.as_ref().map(EnforcedPolicy::from),
@@ -701,6 +736,37 @@ mod tests {
             raw_size: 0,
             raw_lines: 0,
             raw_truncated: false,
+        }
+    }
+
+    /// The box writes `inbox-capture` records into its own spool. Counting any
+    /// unknown source as host-observed let it clear the grey "box-claimed"
+    /// badge — the one distinction this screen is built on.
+    #[test]
+    fn box_written_lanes_are_never_counted_as_host_observed() {
+        let m = manifest("container");
+        for lane in ["tee-shim", "inbox-capture", "something-added-later"] {
+            let s = signals(&m, &[receipt(lane, 0)]);
+            assert_eq!(s.host_observed, 0, "{lane} must not read as host-observed");
+            assert_eq!(s.box_claimed, 1, "{lane}");
+            assert!(s.box_claimed_only, "{lane} alone means box-claimed only");
+        }
+        for lane in HOST_OBSERVED_LANES {
+            let s = signals(&m, &[receipt(lane, 0)]);
+            assert_eq!(s.host_observed, 1, "{lane} is a host lane");
+            assert!(!s.box_claimed_only, "{lane}");
+        }
+    }
+
+    /// A DNS-rebinding page arrives with Host and Origin that match each other,
+    /// so comparing them proves nothing. The Host has to name loopback.
+    #[test]
+    fn the_gate_requires_a_loopback_host() {
+        for good in ["127.0.0.1:8080", "localhost:1", "[::1]:9", "LOCALHOST", "127.0.0.1"] {
+            assert!(is_loopback_host(good), "{good} should be accepted");
+        }
+        for bad in ["evil.test:8080", "example.com", "127.0.0.1.evil.test", "10.0.0.1:80"] {
+            assert!(!is_loopback_host(bad), "{bad} should be refused");
         }
     }
 

--- a/web/src/SandboxView.tsx
+++ b/web/src/SandboxView.tsx
@@ -56,6 +56,8 @@ export function SandboxView() {
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [filter, setFilter] = useState<string>("all");
+  // Bumped on every successful fleet poll, so the detail pane refreshes with it.
+  const [tick, setTick] = useState(0);
 
   const load = useCallback(() => {
     api
@@ -63,6 +65,7 @@ export function SandboxView() {
       .then((b) => {
         setBoxes(b);
         setError(null);
+        setTick((t) => t + 1);
       })
       .catch((e) => setError(String(e instanceof Error ? e.message : e)));
   }, []);
@@ -123,7 +126,7 @@ export function SandboxView() {
           selectedId={selectedId}
           onSelect={setSelectedId}
         />
-        <DetailPane box={selected} />
+        <DetailPane box={selected} tick={tick} />
       </div>
     </div>
   );
@@ -470,7 +473,7 @@ function SignalBadge({ signals }: { signals: Signals }) {
 
 // ── right: one box ───────────────────────────────────────────────────────────
 
-function DetailPane({ box }: { box: BoxRow | null }) {
+function DetailPane({ box, tick }: { box: BoxRow | null; tick: number }) {
   const [detail, setDetail] = useState<BoxDetail | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -498,7 +501,10 @@ function DetailPane({ box }: { box: BoxRow | null }) {
     return () => {
       live = false;
     };
-  }, [agent, slug]);
+    // `tick` advances with the fleet poll: without it the detail pane fetched
+    // once per selection while the row beside it kept updating, so an open box
+    // drifted behind its own signal badge.
+  }, [agent, slug, tick]);
 
   if (!box) {
     return (


### PR DESCRIPTION
Seven console and evidence-path defects. Three are cases where the code claimed a property it did not have.

| Issue | Defect |
|---|---|
| #421 | `inbox-capture` receipts (box-written) counted as host-observed, clearing the grey badge |
| #431 | Detail-pane signals computed over capped receipts, so a denial vanished on inspection |
| #440 | Origin compared against the request's own Host — self-referential under DNS rebinding |
| #441 | `raw_bytes` joined an unvalidated handle into a path |
| #442 | Backticks in box-controlled strings escaped their code span in `report.md` |
| #460 | Control-lock writes were non-atomic; a torn read dropped human input mid-drag |
| #462 | Console detail pane never refreshed with the fleet poll |

#421 and #431 both move in the same direction: the console should not report a box's own account as h5i's, and should not lose a denial between the row and the detail. #440 does not change what is reachable — the token cookie already held it — but the module documented "foreign origins refused", and that is now true.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `tsc --noEmit` clean for the console
- h5i-core 227 passed, console_api 8 passed
- env_integration 115 passed / 3 failed — the same three process-tier failures that fail on clean `main` on this host

🤖 Generated with [Claude Code](https://claude.com/claude-code)