### PR TITLE
fix(auth,secrets): make declared grants work, and close two scrub gaps

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -621,7 +621,13 @@ socket is a filesystem-bound `AF_UNIX` listener.
   host           = "api.github.com"
   credential_env = "GITHUB_TOKEN"   # read on the host, never in the box
   base_url_var   = "GH_HOST"        # what the client reads
+  token_var      = "GH_TOKEN"       # where the box gets its per-run dummy
   ```
+
+  `token_var` is required. The proxy gates every request on a per-run token, so
+  the box has to be handed it in whatever variable its client already sends as
+  a credential. The real credential stays on the host; the box only ever holds
+  the dummy.
 
   The limit is real and worth knowing before you declare one: it binds clients
   you can point at another origin, so a plain `curl https://api.github.com`

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -3904,6 +3904,29 @@ fn announce_egress(policy: &sandbox::ResolvedPolicy) {
     }
 }
 
+/// Engage the profile's `[[auth]]` grants for a session, at the address this
+/// tier can actually reach. Shared by `run` and `shell` — `shell` did not call
+/// this at all, so an interactive agent silently lost the authenticated egress
+/// a captured `box run` was given, which is backwards: the interactive session
+/// is where the agent works.
+fn engage_grants_for(
+    policy: &sandbox::ResolvedPolicy,
+) -> Result<crate::container::AuthGrantEngagement, H5iError> {
+    if policy.profile.auth.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    match crate::container::grant_host_addr(policy.claim) {
+        Some(addr) => crate::container::engage_auth_grants(&policy.profile, true, addr),
+        None => Err(H5iError::Metadata(format!(
+            "profile '{}' declares an [[auth]] grant, but a box at isolation '{}' cannot reach \
+             a host-side grant proxy on this platform — the netns jail opens no port for it. \
+             Use isolation=container (or microvm), or drop the grant (fail-closed).",
+            policy.profile.name,
+            policy.claim.as_str()
+        ))),
+    }
+}
+
 /// Run `argv` inside the env's worktree under its pinned policy, and record
 /// the execution as evidence (a tagged capture). Every exec is captured —
 /// provenance is the point (§8) — regardless of output size.
@@ -4024,10 +4047,7 @@ fn run_inner(
     // Authenticated egress the profile declares (5.5). Host-side credentials
     // resolve here and stay here; the box only ever learns the proxy's origin.
     // Held for the run: dropping a handle shuts its proxy down.
-    let (_auth_handles, auth_env) = crate::container::engage_auth_grants(
-        &policy.profile,
-        policy.claim >= IsolationClaim::Supervised,
-    )?;
+    let (_auth_handles, auth_env) = engage_grants_for(&policy)?;
 
     let injected_env = merged_env(
         &merged_env(
@@ -4397,10 +4417,15 @@ pub fn shell(
         &crate::secrets_broker::fingerprint_key(h5i_root)?,
     )?;
     let protected_hook_configs = ProtectedHookConfigGuard::prepare(&work, policy.claim)?;
+    // The interactive session gets the profile's declared authenticated egress
+    // too — this is where the agent actually works, and `run` had it while
+    // `shell` silently did not. Held for the session: dropping a handle shuts
+    // its proxy down.
+    let (_auth_handles, auth_env) = engage_grants_for(&policy)?;
     let injected_env = merged_env(
         &merged_env(
             &merged_env(&merged_env(&brokered.env, &env_capture_env), &cargo_env),
-            &env_inbox_env,
+            &merged_env(&env_inbox_env, &auth_env),
         ),
         &merged_env(
             &team_identity_env(m, h5i_root),

--- a/crates/h5i-core/src/receipt.rs
+++ b/crates/h5i-core/src/receipt.rs
@@ -194,6 +194,37 @@ fn raw_path(env_dir: &Path, id: &str) -> PathBuf {
     env_dir.join(RAW_DIR).join(format!("{id}.raw"))
 }
 
+/// Redact the decodable runs of a non-UTF-8 payload, preserving every other
+/// byte exactly. Splitting on the invalid sequences is what keeps a credential
+/// from hiding behind one stray byte.
+fn redact_binary(raw: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(raw.len());
+    let mut rest = raw;
+    loop {
+        match std::str::from_utf8(rest) {
+            Ok(text) => {
+                out.extend_from_slice(crate::secrets::redact_text(text).as_bytes());
+                return out;
+            }
+            Err(e) => {
+                let good = e.valid_up_to();
+                if good > 0 {
+                    let text = std::str::from_utf8(&rest[..good]).unwrap_or_default();
+                    out.extend_from_slice(crate::secrets::redact_text(text).as_bytes());
+                }
+                // Copy the invalid sequence through untouched and carry on.
+                let skip = e.error_len().unwrap_or(rest.len() - good).max(1);
+                let end = (good + skip).min(rest.len());
+                out.extend_from_slice(&rest[good..end]);
+                if end >= rest.len() {
+                    return out;
+                }
+                rest = &rest[end..];
+            }
+        }
+    }
+}
+
 /// Record ids are lowercase hex. Checking that before a handle becomes a path
 /// keeps `../..` out of the join. No caller can reach it with hostile input
 /// today — `env::inspect` is gated by `find` succeeding on the same handle —
@@ -273,8 +304,15 @@ pub fn append(env_dir: &Path, input: RecordInput, raw: &[u8]) -> Result<ExecReco
             redacted_holder = crate::secrets::redact_text(text).into_bytes();
             &redacted_holder[..]
         }
-        // Binary payloads are left as-is: the secret scanner is line oriented.
-        Err(_) => raw,
+        // Binary payloads: the pattern scanner is line oriented and cannot run
+        // here, but leaving them wholly untouched meant a box could defeat the
+        // scrub by interleaving one invalid byte with a credential. Redact the
+        // valid UTF-8 runs and leave the rest byte-for-byte, so the payload
+        // stays faithful while known secret shapes still go.
+        Err(_) => {
+            redacted_holder = redact_binary(raw);
+            &redacted_holder[..]
+        }
     };
 
     let raw_truncated = raw.len() > RAW_CAP;
@@ -664,6 +702,25 @@ mod tests {
             let stored = String::from_utf8(raw_bytes(td.path(), &rec.id).unwrap()).unwrap();
             assert!(!stored.contains(&token), "stored verbatim: {stored}");
         }
+    }
+
+    /// One stray non-UTF-8 byte used to skip redaction for the whole payload,
+    /// so a box could smuggle a credential past the scrub by interleaving one.
+    #[test]
+    fn an_invalid_byte_does_not_disable_redaction_for_the_payload() {
+        let td = TempDir::new().unwrap();
+        let token = format!("ghp_{}", "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8");
+        let mut raw: Vec<u8> = Vec::new();
+        raw.extend_from_slice(b"before\xff\xfe binary\n");
+        raw.extend_from_slice(format!("token={token}\n").as_bytes());
+        let rec = append(td.path(), input(), &raw).unwrap();
+        let stored = raw_bytes(td.path(), &rec.id).unwrap();
+        assert!(
+            !String::from_utf8_lossy(&stored).contains(&token),
+            "credential survived behind an invalid byte"
+        );
+        // The undecodable bytes are still carried through untouched.
+        assert!(stored.windows(2).any(|w| w == [0xff, 0xfe]));
     }
 
     /// Redaction is unconditional now, so a payload with nothing to scrub must

--- a/crates/h5i-sandbox/src/auth_proxy.rs
+++ b/crates/h5i-sandbox/src/auth_proxy.rs
@@ -101,8 +101,18 @@ pub fn runtime_proxy(rt: AgentRuntime) -> RuntimeProxy {
 }
 
 /// A non-empty, non-whitespace host env var, or `None`.
+/// Read a credential from the host environment, **trimmed**.
+///
+/// Trimming is not cosmetic: `export TOKEN="$(cat ~/key)"` carries a trailing
+/// newline, `HeaderValue` rejects it, and `send()` then fails for every request
+/// — surfacing as a permanent 502 whose cause is deliberately not printed (the
+/// right call for an upstream error, wrong for a local one). The sibling
+/// `engage_grant_at` already trimmed; this path did not.
 fn nonempty_env(key: &str) -> Option<String> {
-    std::env::var(key).ok().filter(|v| !v.trim().is_empty())
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
 }
 
 /// Resolve the genuine upstream credential from *h5i's own* host environment,
@@ -255,6 +265,9 @@ pub fn engage_grant_at(
             grant.base_url_var.clone(),
             format!("http://{host}:{}", handle.port),
         ),
+        // The gate token. Without it the box presents no credential, every
+        // request is refused with 403, and the grant does nothing at all.
+        (grant.token_var.clone(), token.clone()),
         ("NO_PROXY".to_string(), no_proxy.clone()),
         ("no_proxy".to_string(), no_proxy),
     ];
@@ -924,6 +937,7 @@ mod tests {
             host: "api.example.com".into(),
             credential_env: "H5I_TEST_ABSENT_CREDENTIAL".into(),
             base_url_var: "EXAMPLE_BASE_URL".into(),
+            token_var: "EXAMPLE_TOKEN".into(),
         };
         std::env::remove_var("H5I_TEST_ABSENT_CREDENTIAL");
         let err = match engage_grant(&grant, true) {
@@ -943,6 +957,7 @@ mod tests {
             host: "api.example.com".into(),
             credential_env: "H5I_TEST_ABSENT_CREDENTIAL".into(),
             base_url_var: "EXAMPLE_BASE_URL".into(),
+            token_var: "EXAMPLE_TOKEN".into(),
         };
         // No proxy path from the box → no engagement, and notably no error
         // about the missing credential: there was nothing to authenticate.

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -1460,16 +1460,39 @@ pub type AuthGrantEngagement = (Vec<crate::auth_proxy::AuthProxyHandle>, Vec<(St
 pub fn engage_auth_grants(
     profile: &Profile,
     tier_ok: bool,
+    host_addr: &str,
 ) -> Result<AuthGrantEngagement, H5iError> {
     let mut handles = Vec::new();
     let mut env = Vec::new();
     for grant in &profile.auth {
-        if let Some(e) = crate::auth_proxy::engage_grant_at(grant, tier_ok, HOST_ROUTE.host_addr)? {
+        if let Some(e) = crate::auth_proxy::engage_grant_at(grant, tier_ok, host_addr)? {
             handles.push(e.handle);
             env.extend(e.box_env);
         }
     }
     Ok((handles, env))
+}
+
+/// Where a box on `claim` reaches a host-side grant proxy, or `None` when it
+/// cannot reach one at all.
+///
+/// This used to be hard-wired to [`HOST_ROUTE`], which is the *container*
+/// answer. On macOS that is `host.containers.internal`, a podman-machine name
+/// that does not resolve inside a Seatbelt box sharing host loopback; and on
+/// Linux `supervised` the box lives in its own netns whose nftables set only
+/// ever opens the runtime auth-proxy port or `net.egress` — never a grant's
+/// port — so the connection is dropped whatever address it names. Saying so is
+/// better than engaging a proxy nothing can dial.
+pub fn grant_host_addr(claim: crate::sandbox_policy::IsolationClaim) -> Option<&'static str> {
+    use crate::sandbox_policy::IsolationClaim;
+    match claim {
+        IsolationClaim::Container | IsolationClaim::Microvm => Some(HOST_ROUTE.host_addr),
+        // macOS supervised/process share the host's loopback.
+        IsolationClaim::Supervised | IsolationClaim::Process if cfg!(target_os = "macos") => {
+            Some("127.0.0.1")
+        }
+        _ => None,
+    }
 }
 
 // ─── run ─────────────────────────────────────────────────────────────────────

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -583,6 +583,21 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
         }
     }
 
+    // An [[auth]] grant that cannot hand the box its gate token is inert: the
+    // proxy refuses every request with 403 and the agent sees a broken client
+    // with no explanation. Refuse at load instead.
+    for g in &p.auth {
+        if g.token_var.trim().is_empty() {
+            return Err(H5iError::Metadata(format!(
+                "profile '{}': auth grant for '{}' has no `token_var`. The proxy gates each \
+                 request on a per-run token, so the box must be given it in the variable its \
+                 client already sends as a credential (e.g. token_var = \"GH_TOKEN\"). \
+                 Refusing rather than running a grant that answers 403 forever (fail-closed).",
+                p.name, g.host
+            )));
+        }
+    }
+
     // Secret grants are brokered (docs/secrets-broker-design.md). Validate the
     // *config* here (names + source/inject syntax); values are resolved
     // fail-closed at run time, never at policy-load time.

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -353,6 +353,16 @@ pub struct AuthGrant {
     pub credential_env: String,
     /// Environment variable the box is given, pointing at the proxy.
     pub base_url_var: String,
+    /// Environment variable the box is given the **per-run dummy token** in —
+    /// whatever variable its client already sends as a credential (`GH_TOKEN`
+    /// for `gh`, and so on).
+    ///
+    /// The proxy gates every request on that token, so without this the box has
+    /// nothing to present and each request is refused: the grant was inert.
+    /// Validated non-empty at policy load rather than defaulted, because only
+    /// the profile author knows which variable their client reads.
+    #[serde(default)]
+    pub token_var: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/h5i-sandbox/src/secrets.rs
+++ b/crates/h5i-sandbox/src/secrets.rs
@@ -234,6 +234,32 @@ const RULES: &[SecretRule] = &[
         min_entropy: 3.5,
         keywords: &[],
     },
+    // The two shapes credentials most often take in *captured evidence*, as
+    // opposed to in source. A receipt records `argv.join(" ")` and the command's
+    // output, so an opaque token that matches no vendor prefix reached the
+    // store verbatim: it is not a JWT, not `sk-`/`ghp_`/`AKIA`, and not a
+    // quoted assignment, so nothing above fires on it.
+    SecretRule {
+        id: "AUTHORIZATION_HEADER",
+        description: "credential in an Authorization/Proxy-Authorization header",
+        // Covers both the header line and the `-H "Authorization: …"` argv form.
+        pattern: r#"(?i)(?:proxy-)?authorization\s*:\s*(?:bearer|token|basic|digest)\s+([A-Za-z0-9+/=_.\-]{12,})"#,
+        entropy_group: Some(1),
+        min_entropy: 3.0,
+        keywords: &["authorization"],
+    },
+    SecretRule {
+        id: "GENERIC_HIGH_ENTROPY_UNQUOTED",
+        description: "high-entropy credential-like assignment (unquoted)",
+        // Same keyword anchor as GENERIC_HIGH_ENTROPY, without the quotes:
+        // `export TOKEN=<opaque>` and `password=<opaque>` are ordinary in a
+        // shell command and were previously stored as written. Terminated by
+        // whitespace so a following argument is not swallowed.
+        pattern: r#"(?i)(?:api[_-]?key|secret[_-]?key|access[_-]?token|auth[_-]?token|client[_-]?secret|password|passwd|token)\s*[:=]\s*([A-Za-z0-9+/=_\-]{20,})(?:\s|$)"#,
+        entropy_group: Some(1),
+        min_entropy: 3.5,
+        keywords: &[],
+    },
 ];
 
 /// Per-line allowlist substrings. If any of these (case-insensitive) appears
@@ -646,6 +672,34 @@ mod tests {
         assert_eq!(lines[0], "key = your-key-here");
         assert!(!lines[1].contains("AKIAZZZZZZZZZZZZZZZZ"));
         assert!(lines[1].contains(REDACTION_MARKER));
+    }
+
+    #[test]
+    fn opaque_credentials_in_captured_commands_are_caught() {
+        // A receipt records `argv.join(" ")`. An opaque token matches no vendor
+        // prefix, is not a JWT, and is not a quoted assignment, so nothing in
+        // the pack used to fire and it was stored verbatim.
+        let tok = "9f3c1b7ae2d84f0c9a5e77b1c4d9";
+        for line in [
+            format!("curl -H \"Authorization: Bearer {tok}\" https://internal.api/x"),
+            format!("export ACCESS_TOKEN={tok}"),
+            format!("password={tok}"),
+        ] {
+            let out = redact_text(&line);
+            assert!(!out.contains(tok), "not redacted: {out}");
+        }
+    }
+
+    #[test]
+    fn the_new_rules_do_not_fire_on_ordinary_prose() {
+        for line in [
+            "authorization: required for this endpoint",
+            "token = 12",
+            "password: see the vault",
+            "the access_token field is documented above",
+        ] {
+            assert_eq!(redact_text(line), line, "false positive on {line:?}");
+        }
     }
 
     #[test]

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -827,7 +827,12 @@ socket is a filesystem-bound <code>AF_UNIX</code> listener.</p>
   [[profile.review.auth]]
   host           = "api.github.com"
   credential_env = "GITHUB_TOKEN"   # read on the host, never in the box
-  base_url_var   = "GH_HOST"        # what the client reads</code></p>
+  base_url_var   = "GH_HOST"        # what the client reads
+  token_var      = "GH_TOKEN"       # where the box gets its per-run dummy</code></p>
+<p><code>token_var</code> is required. The proxy gates every request on a per-run token, so
+  the box has to be handed it in whatever variable its client already sends as
+  a credential. The real credential stays on the host; the box only ever holds
+  the dummy.</p>
 <p>The limit is real and worth knowing before you declare one: it binds clients
   you can point at another origin, so a plain <code>curl https://api.github.com</code>
   still goes nowhere. A TLS-terminating forward proxy would lift that, at the


### PR DESCRIPTION
Five defects in the credential and evidence paths. The headline one is a shipped feature that could never have worked.

| Issue | Defect |
|---|---|
| #418 | `[[auth]]` grants answered 403 forever — the box was never handed the token its proxy gates on |
| #428 | Grant proxies were unreachable on the supervised tiers and addressed wrongly on macOS; `shell` never engaged them at all |
| #434 | Scanner missed `Authorization: Bearer` and unquoted assignments — the shapes credentials take in captured evidence |
| #438 | One non-UTF-8 byte disabled redaction for the whole payload |
| #439 | An untrimmed host credential produced a permanent, undiagnosable 502 |

**#418 is a breaking policy change, deliberately.** `AuthGrant` gains a required `token_var`. Nothing is broken by requiring it, because no grant could function before: the proxy refused every request. Refusing at policy load with a message naming the fix beats shipping a component that 403s in silence. MANUAL.md documents it.

**#428** splits "which tier can reach a host proxy" out of the container module's `HOST_ROUTE` assumption, and refuses rather than engaging a proxy the box provably cannot dial.

**#434** the two new rules are entropy-gated and keyword-anchored, with a false-positive test over ordinary prose (`token = 12`, `password: see the vault`).

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- h5i-sandbox 299 passed, h5i-core 229 passed, console_api 8 passed
- env_integration 115 passed / 3 failed — the same three process-tier failures that fail on clean `main` on this host
- Manuals regenerated with Python 3.12 (matching CI); only the HTML changed, since the man page derives from the clap tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)