### PR TITLE
fix: honour the guards, limits and contracts that were declared but not applied

### DIFF
--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -1930,7 +1930,6 @@ fn box_git_plumbing(repo: &Repository, m: &EnvManifest) -> Result<Vec<BoxGitPath
         git_dir.join("objects"),
         git_dir.join(&branch_parent),
         git_dir.join("logs").join(&branch_parent),
-        git_dir.join("refs/h5i/context"),
     ];
     for d in &rw {
         std::fs::create_dir_all(d).map_err(|e| H5iError::with_path(e, d))?;
@@ -3238,6 +3237,14 @@ fn prepare_browser_shim(
     if policy.profile.name != "browser" {
         return Ok(None);
     }
+    // Not on an image-backed tier. The shim lives host-side and is not mounted
+    // into the image, and `browser_env` prepends the *host* PATH, whose entries
+    // do not exist in the guest — so a container browser box started with dead
+    // leading PATH entries and a shim it could not execute. `create` allows
+    // this configuration, so it has to be handled rather than assumed away.
+    if policy.claim.image_backed() {
+        return Ok(None);
+    }
     let Some(real) = sandbox::agent_browser_binary() else {
         return Ok(None);
     };
@@ -3861,6 +3868,18 @@ fn apply_user_egress(policy: &mut sandbox::ResolvedPolicy) {
 /// holes, *how* it is enforced. A `403` from a proxy and a dropped packet are
 /// diagnosed differently, and the line is the only place the box's operator is
 /// told which one to expect.
+/// Say which declared resource caps this tier cannot apply. h5i's rule is that
+/// it never silently downgrades; a profile written to bound a runaway build
+/// should not discover at 3am that the bound was dropped on this backend.
+fn announce_unmapped_resources(policy: &sandbox::ResolvedPolicy) {
+    if policy.claim != IsolationClaim::Container {
+        return;
+    }
+    for note in crate::container::unmapped_resources(&policy.profile) {
+        eprintln!("⦿ note: {note} is not enforceable at isolation=container and was not applied");
+    }
+}
+
 fn announce_egress(policy: &sandbox::ResolvedPolicy) {
     const SHOW: usize = 8;
     let profile = &policy.profile.net_egress;
@@ -4029,6 +4048,7 @@ fn run_inner(
     let cargo_env = prepare_cargo_env(&work, &policy)?;
     // Host-side `h5i box allow` extras + the explained-egress line.
     apply_user_egress(&mut policy);
+    announce_unmapped_resources(&policy);
 
     // Broker any declared secrets BEFORE marking the env running, so a
     // fail-closed grant (missing source, unsupported inject) aborts cleanly
@@ -4438,6 +4458,7 @@ pub fn shell(
     );
     // Host-side `h5i box allow` extras + the explained-egress line.
     apply_user_egress(&mut policy);
+    announce_unmapped_resources(&policy);
 
     // No command given → launch an interactive shell. Rather than inherit the
     // host `~/.bashrc` (which, under confinement, routinely references tools the
@@ -7307,7 +7328,7 @@ pub fn propose(
     brief.push_str(&format!("── Proposal: {} ──\n", m.id));
     brief.push_str(&format!(
         "  base    : {} (from {})\n",
-        &m.base_commit[..12],
+        &m.base_commit[..12.min(m.base_commit.len())],
         m.parent_branch
     ));
     brief.push_str(&format!("  branch  : {}\n", m.branch));
@@ -7729,6 +7750,16 @@ pub fn gc(repo: &Repository, h5i_root: &Path) -> Result<Vec<String>, H5iError> {
         // the prune must not yank the directory out from under it. Non-blocking:
         // if observers are attached we skip this env and reclaim it on a later
         // sweep, exactly as we do on a failed prune.
+        //
+        // Both locks, in the documented order (run.lock then observers.lock) —
+        // see the invariant at the top of this module. `gc` took only the
+        // teardown lock, so it could prune and `remove_dir_all` an env while a
+        // writer held `run.lock` for it. The window was narrow (only applied or
+        // aborted envs are swept) but that was incidental, not designed.
+        let _run_lock = match RunLock::acquire(&m.dir(h5i_root)) {
+            Ok(g) => g,
+            Err(_) => continue,
+        };
         #[cfg(unix)]
         let _teardown = match RunLock::acquire_teardown(&m.dir(h5i_root)) {
             Ok(g) => g,
@@ -7757,9 +7788,14 @@ pub fn gc(repo: &Repository, h5i_root: &Path) -> Result<Vec<String>, H5iError> {
 }
 
 /// Permanently remove an environment from this clone: prune its worktree,
-/// delete its code branch (`refs/heads/h5i/env/…`) and reasoning branch
-/// (`refs/h5i/context/env/…`), and erase its on-disk dir (manifest, policy,
-/// status). Unlike `gc` (workspace only) and `abort` (status only), this
+/// delete its code branch (`refs/heads/h5i/env/…`), and erase its on-disk dir
+/// (manifest, policy, status).
+///
+/// There is no reasoning branch to delete. `refs/h5i/context/*` was a pre-pivot
+/// namespace; nothing in the workspace reads or writes it any more, and the
+/// structural grant that still handed the box rw on it (letting a box create
+/// arbitrary refs in the host repo, pinning objects against gc, for a feature
+/// that no longer exists) is gone with this change. Unlike `gc` (workspace only) and `abort` (status only), this
 /// destroys the *local* provenance — the env's manifest + policy lines are
 /// stripped from `refs/h5i/env` (otherwise [`materialize_from_ref`], run at the
 /// top of every `env` command, would rewrite the on-disk manifest right back),
@@ -8536,9 +8572,12 @@ mod tests {
             .iter()
             .position(|p| !p.rw && p.host.ends_with("refs"))
             .unwrap();
+        // The env's own branch namespace is the rw entry nested under `refs`.
+        // (`refs/h5i/context` used to be a second one; that grant is gone —
+        // nothing reads or writes the namespace any more.)
         let nested_pos = paths
             .iter()
-            .position(|p| p.host.ends_with("refs/h5i/context"))
+            .position(|p| p.rw && p.host.to_string_lossy().contains("refs/heads/h5i/env/"))
             .unwrap();
         assert!(
             refs_pos < nested_pos,
@@ -8560,10 +8599,16 @@ mod tests {
             "/objects",
             "/refs/heads/h5i/env/claude",
             "/logs/refs/heads/h5i/env/claude",
-            "/refs/h5i/context",
         ] {
             assert!(has(&rw, want), "rw grant {want} missing: {rw:?}");
         }
+        // And the pre-pivot reasoning namespace is granted no longer: nothing
+        // reads or writes it, and rw there let a box create arbitrary refs in
+        // the host repository.
+        assert!(
+            !rw.iter().any(|p| p.contains("refs/h5i/context")),
+            "the dead refs/h5i/context grant must be gone: {rw:?}"
+        );
         // Protected surfaces stay out of every grant.
         for never in ["hooks", "refs/h5i/env", "manifest", "policy"] {
             assert!(

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -7756,6 +7756,7 @@ pub fn gc(repo: &Repository, h5i_root: &Path) -> Result<Vec<String>, H5iError> {
         // teardown lock, so it could prune and `remove_dir_all` an env while a
         // writer held `run.lock` for it. The window was narrow (only applied or
         // aborted envs are swept) but that was incidental, not designed.
+        #[cfg(unix)]
         let _run_lock = match RunLock::acquire(&m.dir(h5i_root)) {
             Ok(g) => g,
             Err(_) => continue,

--- a/crates/h5i-core/src/source.rs
+++ b/crates/h5i-core/src/source.rs
@@ -69,7 +69,9 @@ pub fn resolve_pr_base(workdir: &Path, spec: &str, remote: &str) -> Result<PrBas
     let tmp_ref = format!("refs/h5i/_incoming/pr-{number}");
     let refspec = format!("+refs/pull/{number}/head:{tmp_ref}");
     let out = Command::new("git")
-        .args(["fetch", "--no-write-fetch-head", remote, &refspec])
+        // `--end-of-options` before the remote: `--remote` is user-supplied, and
+        // git would otherwise read `--upload-pack=<cmd>` as an option and run it.
+        .args(["fetch", "--no-write-fetch-head", "--end-of-options", remote, &refspec])
         .current_dir(workdir)
         .output()
         .map_err(|e| H5iError::Metadata(format!("failed to invoke git fetch: {e}")))?;

--- a/crates/h5i-sandbox/src/container.rs
+++ b/crates/h5i-sandbox/src/container.rs
@@ -559,6 +559,19 @@ impl AllowList {
     }
 }
 
+/// Resource caps this tier cannot apply, named so a run can say so instead of
+/// silently dropping them. Mirrors the honesty machinery Seatbelt already uses
+/// for the same situation.
+pub fn unmapped_resources(profile: &Profile) -> Vec<String> {
+    let mut out = Vec::new();
+    if profile.cpu_secs.is_some() {
+        out.push(
+            "resources.cpu (a CPU-seconds budget; podman caps CPU rate, not total)".to_string(),
+        );
+    }
+    out
+}
+
 /// Most bytes the tee shim records per stream, per command. The box decides how
 /// much it writes, so this is a disk bound on the host, not a display limit —
 /// the command's own output still passes through in full.
@@ -1321,6 +1334,15 @@ pub fn build_run_argv(
     if let Some(n) = profile.max_procs {
         a.push("--pids-limit".into());
         a.push(n.to_string());
+    }
+    // `resources.cpu` as a CPU-seconds budget has no podman equivalent (podman
+    // caps *rate*, not total), and `--ulimit fsize` is the file-size cap. Map
+    // what maps; the caller reports the rest through `unmapped_resources`
+    // rather than letting a profile written to bound a runaway build quietly
+    // get no bound at all.
+    if let Some(bytes) = profile.fsize_bytes {
+        a.push("--ulimit".into());
+        a.push(format!("fsize={bytes}"));
     }
 
     // Network.

--- a/crates/h5i-sandbox/src/supervisor.rs
+++ b/crates/h5i-sandbox/src/supervisor.rs
@@ -846,6 +846,19 @@ fn run_supervised(
     use std::io::Read;
     use std::process::Stdio;
 
+    // Check the notify ABI *before* committing to this tier. The module doc
+    // promises the `seccomp_notif` structs are validated against
+    // SECCOMP_GET_NOTIF_SIZES and refused on mismatch, but nothing called the
+    // validator on any production path — so on a kernel with a different layout
+    // the listener installed fine and then `ioctl(NOTIF_RECV)`, whose request
+    // number embeds our struct size, failed with an unexpected errno. The serve
+    // loop broke on the first notification and the box's first socket() blocked
+    // unanswered: a hang where a refusal was documented.
+    //
+    // Here rather than at `install_listener`, which runs in the forked child
+    // and must not allocate an error.
+    crate::seccomp_notify::validate_notif_sizes()?;
+
     // A CLOEXEC socketpair for the SCM_RIGHTS listener handoff: the child sends
     // its seccomp listener fd over `sv[1]`; we receive it on `sv[0]`. CLOEXEC so
     // neither end leaks into the exec'd (untrusted) program.
@@ -1126,7 +1139,13 @@ fn run_supervised(
     // narrows the nftables ruleset to the auth proxy alone in that case).
     let mut env = effective_env;
     let (_egress_proxy, egress_port) = if has_egress && auth_port.is_none() {
-        let mut allow = crate::container::AllowList::parse(&policy.profile.net_egress)?;
+        // Through `effective_egress`, like every other tier: parsing the profile
+        // list directly meant `h5i box allow` extras applied on container and
+        // microvm but silently did nothing here.
+        let mut allow = crate::container::AllowList::parse(&crate::container::effective_egress(
+            &policy.profile.net_egress,
+            &policy.user_egress_allow,
+        ))?;
         // Pin now, so a later DNS answer cannot move the allowlist under us.
         allow.pin_dns();
         // On the pinned port when the box has one: a `browser` box's Chrome


### PR DESCRIPTION
Eight defects sharing a shape: something the code documents, that it did not actually do.

| Issue | Declared | Actual |
|---|---|---|
| #423 | notify ABI validated, refused on mismatch | validator only ever called from tests; mismatch became a hang |
| #429 | `resources.cpu`/`fsize` enforced | container tier dropped both silently |
| #430 | `h5i box allow` applies | ignored on macOS supervised |
| #436 | short base_commit errors | panicked |
| #443 | — | `--remote` reached `git fetch` as a positional |
| #446 | teardown takes both locks, in order | `gc` took one |
| #448 | `rm` deletes the reasoning branch | no such branch; but its rw grant survived |
| #450 | browser shim on browser boxes | injected on image tiers where it cannot work |

Two worth a second look:

**#423** the check has to run before the fork. `install_listener` executes in the forked child, where building an error would allocate — the file is explicit about why that matters.

**#448** the grant is the real finding. `refs/h5i/context` has had no reader or writer since the pivot, but every box still got rw on it, which is enough to create arbitrary refs in the host repository and pin objects against gc.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- h5i-sandbox 299 passed, h5i-core 228 passed, console_api 8 passed
- env_integration 115 passed / 3 failed — the same three process-tier failures that fail on clean `main` on this host

🤖 Generated with [Claude Code](https://claude.com/claude-code)