### PR TITLE
fix(env): unwind a half-built box when create fails

### DIFF
--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -1429,6 +1429,53 @@ fn init_detached_workspace(
     }
 }
 
+/// The registered worktree name for an env, matching `EnvManifest::worktree_name`
+/// before a manifest exists to ask.
+fn manifest_worktree_name(agent: &str, slug: &str) -> String {
+    format!("h5i-env-{agent}-{slug}")
+}
+
+/// Undo a half-built env if `create` fails before the manifest exists.
+///
+/// Only that window needs it: once `manifest.json` is on disk the env is
+/// resolvable by name and `h5i box rm` can finish the job.
+struct CreateRollback<'a> {
+    repo: &'a Repository,
+    h5i_root: &'a Path,
+    dir: PathBuf,
+    work: PathBuf,
+    worktree: String,
+    /// The env branch, when `create` made one (a detached box's repository
+    /// lives inside `work` and goes with the directory).
+    branch: Option<String>,
+    armed: bool,
+}
+
+impl Drop for CreateRollback<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Best effort throughout: this runs while another error is propagating,
+        // and a failed cleanup must not mask it.
+        if let Ok(wt) = self.repo.find_worktree(&self.worktree) {
+            let _ = wt.unlock();
+        }
+        let _ = std::fs::remove_dir_all(&self.work);
+        let _ = std::process::Command::new("git")
+            .args(["worktree", "prune", "--expire=now"])
+            .current_dir(self.repo.commondir())
+            .output();
+        if let Some(b) = &self.branch {
+            if let Ok(mut r) = self.repo.find_branch(b, git2::BranchType::Local) {
+                let _ = r.delete();
+            }
+        }
+        let _ = std::fs::remove_dir_all(&self.dir);
+        let _ = self.h5i_root;
+    }
+}
+
 pub fn create(
     repo: &Repository,
     h5i_root: &Path,
@@ -1600,6 +1647,26 @@ pub fn create(
         (base_commit.id(), base_tree, parent_branch)
     };
 
+    // From here on the worktree, the branch and `<env>/` all exist, but the
+    // manifest — the thing `list`/`find`/`rm` resolve an env *through* — does
+    // not yet. Several fail-closed steps sit in between (a malformed
+    // `[service.*]` table, a persona source missing at the base revision), and
+    // without a rollback their failure left a registered+locked worktree and a
+    // branch that `create` refuses to reuse and `rm` cannot see, recoverable
+    // only by hand with `git worktree prune` and `git branch -D`.
+    //
+    // `CreateRollback` undoes exactly what has been built so far unless it is
+    // disarmed once the manifest lands.
+    let mut rollback = CreateRollback {
+        repo,
+        h5i_root,
+        dir: dir.clone(),
+        work: work_path.clone(),
+        worktree: manifest_worktree_name(agent, slug),
+        branch: (!opts.source.is_detached()).then(|| branch_short.clone()),
+        armed: true,
+    };
+
     // Pin service declarations from the base worktree into an env-local,
     // box-immutable manifest, recording its digest (review #1). Always Some for
     // new envs (even pinned-empty), so the legacy fallback below never applies.
@@ -1645,6 +1712,9 @@ pub fn create(
     let policy_path = dir.join(POLICY_RESOLVED_FILE);
     std::fs::write(&policy_path, &policy_toml).map_err(|e| H5iError::with_path(e, &policy_path))?;
     save_manifest(h5i_root, &manifest)?;
+    // The env is resolvable now: `rm` and `gc` can clean up anything that fails
+    // after this point, so stop unwinding on drop.
+    rollback.armed = false;
     // Mirror the manifest AND the resolved policy into refs/h5i/env so the
     // whole environment is shareable from creation.
     append_env_commit(

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -246,6 +246,60 @@ fn append_synthetic_env_manifest(repo: &git2::Repository, m: &h5i_core::env::Env
 
 // ─── 1. create: the triple fusion ───────────────────────────────────────────
 
+/// A fail-closed step between the worktree and the manifest used to leave a
+/// registered+locked worktree and a branch that `create` refuses to reuse and
+/// `rm` cannot see — recoverable only with `git worktree prune` and
+/// `git branch -D` by hand.
+#[test]
+fn a_failed_create_leaves_nothing_behind_to_clean_up() {
+    let r = Repo::new();
+    // A malformed [service.*] table: parsed at create, *after* the worktree
+    // exists and *before* the manifest is written.
+    std::fs::create_dir_all(r.dir.join(".h5i")).unwrap();
+    std::fs::write(
+        r.dir.join(".h5i/env.toml"),
+        "[profile.default]\nisolation = \"workspace\"\n\n[service.web]\nport = 1\n",
+    )
+    .unwrap();
+    git(&r.dir, &["add", "."]);
+    git(&r.dir, &["commit", "-m", "add a broken service declaration"]);
+
+    let out = r.h5i(&["env", "create", "broken"]);
+    assert!(!out.status.success(), "create must fail closed: {}", out_str(&out));
+
+    // Nothing half-built survives: the box is not listed, and neither the
+    // branch nor the worktree registration is left over.
+    let listed = r.h5i(&["env", "list"]);
+    assert!(
+        !String::from_utf8_lossy(&listed.stdout).contains("broken"),
+        "a failed create must not leave a box behind: {}",
+        out_str(&listed)
+    );
+    let branches = git(&r.dir, &["branch", "--list", "h5i/env/*/broken"]);
+    assert!(
+        String::from_utf8_lossy(&branches.stdout).trim().is_empty(),
+        "the env branch must be gone: {}",
+        out_str(&branches)
+    );
+    let worktrees = git(&r.dir, &["worktree", "list"]);
+    assert!(
+        !String::from_utf8_lossy(&worktrees.stdout).contains("broken"),
+        "the worktree registration must be gone: {}",
+        out_str(&worktrees)
+    );
+
+    // And the name is genuinely free again once the declaration is fixed.
+    std::fs::write(
+        r.dir.join(".h5i/env.toml"),
+        "[profile.default]\nisolation = \"workspace\"\n",
+    )
+    .unwrap();
+    git(&r.dir, &["add", "."]);
+    git(&r.dir, &["commit", "-m", "fix the service declaration"]);
+    let retry = r.h5i(&["env", "create", "broken"]);
+    assert!(retry.status.success(), "retry after the fix must work: {}", out_str(&retry));
+}
+
 #[test]
 fn create_builds_worktree_branch_policy_and_event() {
     let r = Repo::new();


### PR DESCRIPTION
`create` registers and locks a worktree, creates the branch, and makes `<env>/` well before writing `manifest.json` — with several fail-closed steps in between (a malformed `[service.*]` table, a persona source missing at the base revision, the viewer token, the policy write, the CAS append).

When one fired, everything already built stayed, and the env became unreachable from both directions: `create` refuses the name, and `rm` cannot see it either, because the CLI resolves names through `find` → `list` → `load_manifest_at`, which skips a directory with no manifest. Recovery was `rm -rf` + `git worktree prune --expire=now` + `git branch -D` by hand.

`CreateRollback` is a drop guard covering exactly that window, disarmed once `save_manifest` lands — from there the env is resolvable and `rm` can finish the job. It is best-effort throughout, since it runs while another error is propagating and must not mask it.

**The test was verified to fail without the fix**, leaving `h5i/env/tester/broken` stranded:

```
the env branch must be gone: + h5i/env/tester/broken
```

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` clean
- h5i-core 231 passed
- env_integration 116 passed / 3 failed — the same three process-tier failures that fail on clean `main` on this host

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)