### PR TITLE
fix: open the UI in a Windows browser

### DIFF
--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -40,58 +40,126 @@ pub fn run(port: u16, open: bool) -> anyhow::Result<()> {
 /// Hand the URL to the desktop's browser. Best-effort and non-fatal: the URL
 /// is already on screen, so a host without a handler loses nothing.
 fn launch_browser(url: &str) {
-    let mut command = browser_command(url);
-    let opener = command.get_program().to_string_lossy().into_owned();
-    if let Err(e) = command
+    let (opener, mut command) = browser_command_for(url, std::env::consts::OS);
+    let child = command
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        eprintln!(
-            "{} could not run {opener}: {e} — open the URL above yourself",
+        .spawn();
+    let mut child = match child {
+        Ok(child) => child,
+        Err(e) => {
+            eprintln!(
+                "{} could not run {opener}: {e} — open the URL above yourself",
+                style("warning:").yellow()
+            );
+            return;
+        }
+    };
+
+    // Spawning is not the failure that matters. `start` runs behind a `cmd`
+    // that is always present, and `xdg-open` reports a missing handler in its
+    // exit status rather than at spawn — so the status is the only signal that
+    // the browser did not come up. Waiting happens off-thread because some
+    // `xdg-open` backends block until the browser itself exits, and the console
+    // has to start serving now; the thread doubles as the child's reaper.
+    std::thread::spawn(move || match child.wait() {
+        Ok(status) if !status.success() => eprintln!(
+            "{} {opener} failed ({status}) — open the URL above yourself",
             style("warning:").yellow()
-        );
-    }
+        ),
+        _ => {}
+    });
 }
 
-fn browser_command(url: &str) -> std::process::Command {
-    browser_command_for(url, std::env::consts::OS)
-}
-
-fn browser_command_for(url: &str, target_os: &str) -> std::process::Command {
-    let (program, args) = match target_os {
-        "macos" => ("open", vec![url]),
-        "windows" => ("cmd", vec!["/C", "start", "", url]),
-        _ => ("xdg-open", vec![url]),
+/// The opener for `target_os`, paired with the name to blame in a warning —
+/// which is not always the program, since Windows reaches the browser through
+/// `cmd`. Split from the host so every arm is reachable from one build.
+fn browser_command_for(url: &str, target_os: &str) -> (&'static str, std::process::Command) {
+    // `start` reads a lone quoted argument as the new window's title, so the
+    // empty title slot is what keeps it from swallowing the URL.
+    let (label, program, args) = match target_os {
+        "macos" => ("open", "open", vec![url]),
+        "windows" => ("cmd /C start", "cmd", vec!["/C", "start", "", url]),
+        _ => ("xdg-open", "xdg-open", vec![url]),
     };
     let mut command = std::process::Command::new(program);
     command.args(args);
-    command
+    (label, command)
 }
 
 #[cfg(test)]
 mod tests {
     use super::browser_command_for;
 
-    #[test]
-    fn browser_command_uses_platform_opener() {
-        let url = "http://127.0.0.1:8080/?token=test";
-        let cases = [
-            ("macos", "open", vec![url]),
-            ("windows", "cmd", vec!["/C", "start", "", url]),
-            ("linux", "xdg-open", vec![url]),
-        ];
+    /// Every target h5i releases for, plus one it does not, so the fallback arm
+    /// is exercised rather than assumed.
+    const TARGETS: [&str; 4] = ["macos", "windows", "linux", "freebsd"];
 
-        for (target_os, expected_program, expected_args) in cases {
-            let command = browser_command_for(url, target_os);
-            let program = command.get_program().to_string_lossy();
-            let args: Vec<_> = command
+    fn argv(url: &str, target_os: &str) -> (String, Vec<String>) {
+        let (_, command) = browser_command_for(url, target_os);
+        (
+            command.get_program().to_string_lossy().into_owned(),
+            command
                 .get_args()
-                .map(|arg| arg.to_string_lossy())
-                .collect();
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect(),
+        )
+    }
 
-            assert_eq!(program, expected_program);
-            assert_eq!(args, expected_args);
+    /// The token-bearing URL reaches the opener as one argv element, verbatim.
+    /// The Windows arm goes through `cmd`, which re-parses its command line, so
+    /// this is the guard that a URL is never assembled into a shell string.
+    #[test]
+    fn the_url_reaches_every_opener_as_a_single_untouched_argument() {
+        let url = "http://127.0.0.1:8080/?token=deadbeef&next=%2F";
+        for target_os in TARGETS {
+            let (program, args) = argv(url, target_os);
+            assert!(!program.is_empty(), "{target_os}: no opener");
+            assert_eq!(
+                args.iter().filter(|arg| arg.as_str() == url).count(),
+                1,
+                "{target_os}: url is not exactly one argument: {args:?}"
+            );
+            assert_eq!(
+                args.last().map(String::as_str),
+                Some(url),
+                "{target_os}: url is not the last argument: {args:?}"
+            );
         }
+    }
+
+    /// A host h5i was never built for still gets the freedesktop opener rather
+    /// than no opener at all.
+    #[test]
+    fn an_unrecognized_host_falls_back_to_the_freedesktop_opener() {
+        assert_eq!(argv("http://127.0.0.1:8080/", "freebsd").0, "xdg-open");
+        assert_eq!(argv("http://127.0.0.1:8080/", "").0, "xdg-open");
+    }
+
+    /// `start` treats a lone quoted argument as the window title. Without the
+    /// empty title slot it would consume the URL and open a console instead of
+    /// a browser, so the slot is the invariant worth pinning.
+    #[test]
+    fn the_windows_opener_keeps_starts_empty_title_slot() {
+        let (_, args) = argv("http://127.0.0.1:8080/", "windows");
+        let head: Vec<&str> = args.iter().take(3).map(String::as_str).collect();
+        assert_eq!(head, ["/C", "start", ""], "{args:?}");
+    }
+
+    /// The warning has to name something the user can act on. On Windows the
+    /// program is `cmd`, which says nothing about opening a browser.
+    #[test]
+    fn the_failure_label_names_the_opener_not_its_shell() {
+        for target_os in TARGETS {
+            let (label, command) = browser_command_for("http://127.0.0.1:8080/", target_os);
+            assert!(
+                label.contains(&*command.get_program().to_string_lossy()),
+                "{target_os}: label {label:?} does not name the program"
+            );
+        }
+        assert_eq!(
+            browser_command_for("http://127.0.0.1:8080/", "windows").0,
+            "cmd /C start"
+        );
     }
 }

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -40,13 +40,9 @@ pub fn run(port: u16, open: bool) -> anyhow::Result<()> {
 /// Hand the URL to the desktop's browser. Best-effort and non-fatal: the URL
 /// is already on screen, so a host without a handler loses nothing.
 fn launch_browser(url: &str) {
-    let opener = if cfg!(target_os = "macos") {
-        "open"
-    } else {
-        "xdg-open"
-    };
-    if let Err(e) = std::process::Command::new(opener)
-        .arg(url)
+    let mut command = browser_command(url);
+    let opener = command.get_program().to_string_lossy().into_owned();
+    if let Err(e) = command
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
@@ -55,5 +51,47 @@ fn launch_browser(url: &str) {
             "{} could not run {opener}: {e} — open the URL above yourself",
             style("warning:").yellow()
         );
+    }
+}
+
+fn browser_command(url: &str) -> std::process::Command {
+    browser_command_for(url, std::env::consts::OS)
+}
+
+fn browser_command_for(url: &str, target_os: &str) -> std::process::Command {
+    let (program, args) = match target_os {
+        "macos" => ("open", vec![url]),
+        "windows" => ("cmd", vec!["/C", "start", "", url]),
+        _ => ("xdg-open", vec![url]),
+    };
+    let mut command = std::process::Command::new(program);
+    command.args(args);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::browser_command_for;
+
+    #[test]
+    fn browser_command_uses_platform_opener() {
+        let url = "http://127.0.0.1:8080/?token=test";
+        let cases = [
+            ("macos", "open", vec![url]),
+            ("windows", "cmd", vec!["/C", "start", "", url]),
+            ("linux", "xdg-open", vec![url]),
+        ];
+
+        for (target_os, expected_program, expected_args) in cases {
+            let command = browser_command_for(url, target_os);
+            let program = command.get_program().to_string_lossy();
+            let args: Vec<_> = command
+                .get_args()
+                .map(|arg| arg.to_string_lossy())
+                .collect();
+
+            assert_eq!(program, expected_program);
+            assert_eq!(args, expected_args);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- I use `cmd /C start` to open the box console URL on Windows while preserving the existing macOS and XDG openers.
- I keep browser launching best-effort and retain the existing warning behavior when the platform opener cannot start.
- I added unit coverage for the macOS, Windows, and XDG command lines.

## Testing

- `H5I_SKIP_WEB_BUILD=1 cargo test --locked --bin h5i` (12 passed)
- `H5I_SKIP_WEB_BUILD=1 cargo clippy --locked --bin h5i -- -D warnings`
- `rustfmt --check src/cli/ui.rs`
- `git diff --check upstream/main...HEAD`

I left the full Windows cross-target build to CI because this environment does not have the MinGW C compiler required by `ring`.

Fixes #459
