### PR TITLE
Legacy document encodings: read a euc-jp page as euc-jp

### DIFF
--- a/ROADMAP_BROWSER.md
+++ b/ROADMAP_BROWSER.md
@@ -1872,3 +1872,85 @@ The engineering is worth having on its own: a legacy page now reads correctly,
 which is a real capability an agent needs and did not have. The score is a
 consequence, not the reason, and the twenty-file concentration is the reason to
 say so out loud rather than let a headline imply 333,690 distinct capabilities.
+
+---
+
+## 14. Reviewing the engine against a real browser, 2026-08-10
+
+The reviews in §8 and §11 read code and reasoned about specs. This one diffed
+behaviour against Chromium 1140, and the difference in yield is the finding
+worth keeping: **thirteen bugs in an afternoon, four of them in code whose
+comments explicitly argued for the wrong answer.** Reasoning about what an
+engine should do had been checking the reasoning, not the engine.
+
+The method is a page of one-assertion-per-line probes, run in both engines and
+compared. `wpt/` finds gaps against a specification; this finds disagreements
+with the thing the user will actually compare against.
+
+### 14.1 The encoding work, three days old and already wrong
+
+* **Existing percent-escapes were destroyed.** The query was decoded after
+  parsing and re-encoded, which cannot work: once `url::Url` has run, an
+  author's `%41` and a `%E4%B8%82` the parser made from a raw `丂` are both just
+  `%XX`. `?x=%41` became `?x=A`; `?100%25` became `?100%`, an escape the page
+  wrote turned into an invalid one. Now encoded from the raw text before any
+  parser touches it.
+* **An undeclared legacy page was destroyed** — the worst of the three, because
+  it is the document the module exists to rescue. Undeclared bytes fell back to
+  UTF-8, so a windows-1252 page had every high byte replaced by U+FFFD:
+  `café naïve` read as `caf<?> na<?>ve`. The fallback is now asymmetric on
+  purpose, and the asymmetry is the point: windows-1252 read as UTF-8 loses the
+  text outright, while UTF-8 read as windows-1252 is mojibake but lossless.
+  Given a guess must be made, take the recoverable wrong answer.
+* An empty query reported `"?"` where a browser reports `""`.
+
+### 14.2 A code block is not one long line
+
+Every `<pre>` arrived as a single run-on line, which for an engine that reads
+documentation is a poor reading of the thing it reads most.
+
+The fix is not to stop collapsing. `Snapshot::render`'s fence rests on **no
+page-derived value spanning a line**, because a value that can start a line can
+forge the closing marker. So a `<pre>` is split on its own breaks and each piece
+becomes an outline line, collapsed individually with its own indent and `- `.
+The invariant is untouched and the structure survives — verified by putting the
+literal closing marker inside a `<pre>` and watching it come back as
+`[fence marker removed]`.
+
+### 14.3 Nine more, from sixty-four assertions
+
+`{ once: true }` was read at registration and never consulted at dispatch, so
+listeners fired every time — and the same handler registered twice made two
+listeners where a browser makes one. An invalid selector answered `null` instead
+of throwing, which is indistinguishable from "no such element", so a page with a
+typo took its not-found branch and never learned why. `textContent = null` wrote
+the four characters `null`. `tabIndex` answered -1 for links and buttons, telling
+a page nothing was focusable. `isEqualNode`, `normalize` and `isSameNode` were
+absent and `compareDocumentPosition` called connected nodes disconnected. Style
+serialisation lost its trailing semicolon, and emptying a declaration removed
+the attribute instead of leaving `""`.
+
+63 of 64 cases now match Chromium exactly.
+
+### 14.4 The one that is not a bug: `Intl`
+
+`Intl` is undefined, so `toLocaleString()` answers `1234.5` where a browser
+answers `1,234.5`, and `toLocaleDateString()` returns a full date string rather
+than `12/31/1969`. A page that formats numbers or dates for display shows
+different text to this engine than to a person.
+
+Enabling boa's `intl_bundled` **does not build**: it wants `icu_provider 2.2`,
+which conflicts with what parley already pins through blitz. That is the same
+disjoint-ICU wall that dictated the boa revision pin in the first place (§12.2),
+arriving from the other side. It is recorded here rather than filed as a task,
+because nothing in this repository can move it — it needs the two ICU lines
+upstream to converge.
+
+### 14.5 What this says about how to look
+
+Three review passes on this engine have now found bugs at very different rates.
+Reading code found some. Running a conformance suite found more, and found the
+*instrument's* faults as a side effect. Diffing against a browser found the most
+per hour, and — the part worth internalising — **it found bugs in code whose own
+comments had reasoned carefully to the wrong conclusion.** A comment cannot
+falsify itself. Another implementation can.

--- a/ROADMAP_BROWSER.md
+++ b/ROADMAP_BROWSER.md
@@ -1824,6 +1824,7 @@ repeated once per codepoint across the CJK range, for five encodings.
 | --- | --- |
 | Headline total | 333,690 |
 | **Excluding the encoding directory** | **107,904** |
+| Excluding just the CJK block | 116,428 |
 | From the top twenty files alone | 235,977 |
 
 Files that pass *completely*: **1,882** of the 20,506 with any scored subtest.
@@ -1834,13 +1835,36 @@ together, and §12.6's rule applies unchanged: implementing more, measuring more
 and counting more honestly are three different things, and only the first is
 engineering.
 
-**The Kitesurf comparison is unsafe in both directions and should not be made
-yet.** WPT expands to roughly 200,000 *tests* (file x variant x scope) and
-roughly two million *subtests*. Cloudflare's announcement says "215,000+ tests
-passing", which reads as the test-level count — and if it is, the comparable
-figure here is 1,882 fully-passing files, not 333,690, and this engine is far
-behind rather than ahead. Until their metric is established, quoting one number
-against the other is the kind of claim that gets checked and does not hold.
+**The Kitesurf comparison, worked through, says this engine is behind.** Their
+announcement claims "215,000+ tests passing". Read as subtests — which is what
+it must be, since WPT expands to only about 200,000 tests at file x variant x
+scope and no young engine passes all of them — one arithmetic fact settles the
+shape of the comparison:
+
+> The CJK `encode-href` block alone is **217,263 subtests**. That is larger than
+> Kitesurf's entire stated total.
+
+So Kitesurf cannot be passing that block; it would exceed their whole score by
+itself. Their 215,000 is therefore spread across the rest of the platform, while
+**65% of this engine's 333,690 is that single block**. The like-for-like figure
+is the one with it removed:
+
+| | subtests |
+| --- | --- |
+| Kitesurf, stated | 215,000 |
+| **This engine, excluding the CJK block** | **116,428** |
+| This engine, headline | 333,690 |
+
+**About half their breadth, not one and a half times it.** Anyone quoting
+333,690 against 215,000 would be making a claim that reverses under ten minutes
+of arithmetic, and the reversal is not close.
+
+Two caveats keep even that comparison honest. Their harness is not this one —
+this one cannot reach workers, `.py` handlers or TLS, so it scores 584,707
+subtests where a full wptserve run reaches roughly two million. And a corpus
+neither engine runs is not evidence about either. The defensible claim is the
+narrow one: **on the platform outside legacy CJK URL encoding, this engine
+passes fewer subtests than Kitesurf does.**
 
 ### 13.4 What this is worth, plainly
 

--- a/ROADMAP_BROWSER.md
+++ b/ROADMAP_BROWSER.md
@@ -1654,6 +1654,11 @@ subsystems that paragraph said it required. §12.8 is why.
 
 ### 12.8 Where the number actually was, 2026-08-10
 
+> Superseded by §13.2: the total is now 333,690. This section stays as written
+> because what it says about *why* the number moved is unchanged, and because
+> §13.3 is the same lesson arriving a second time — a large number that comes
+> from one place has to say so.
+
 **117,331 subtests passing of 585,474 scored**, 26,052 files, 25,252 of which
 report. That is up from 33,754, and it is worth being exact about how much of
 that is the engine getting better and how much is this file learning to read.
@@ -1747,3 +1752,99 @@ changes.
 The floor still exists for the case it was built for: this branch gave back
 3,142 subtests in `html` to a settle-loop rewrite, and nothing caught it but a
 manual diff. `wpt/gate.sh` is what to run before believing a refactor was free.
+
+---
+
+## 13. Legacy document encodings, and a number that needs a caveat
+
+§12.5 wrote the legacy CJK encoding tests off in three sentences. All three were
+wrong, the correction is recorded in place there, and this section is what
+happened when the work was actually done.
+
+### 13.1 What was missing
+
+This engine decoded every document as UTF-8. A page served as euc-jp came out as
+replacement characters, `document.characterSet` did not exist, and a link's
+query was percent-encoded from the wrong bytes. An agent reading a legacy
+Japanese page got the wrong answer and was told nothing about it.
+
+`src/encoding.rs` settles the two things a document's encoding decides.
+
+**Which encoding.** BOM, then the transport's `Content-Type`, then the markup's
+`<meta charset>` or `<meta http-equiv>`, then UTF-8. The prescan stops at 1024
+bytes because the HTML standard's does, and that bound is load bearing rather
+than an optimisation: a declaration further down cannot be honoured, because by
+then a parser has committed. Agreeing with a browser about pages that declare
+too late is the point.
+
+**How a query is encoded.** The URL Standard encodes a query with the
+*document's* encoding, and a code point that encoding cannot represent becomes
+an HTML numeric character reference. `丂` in a euc-jp page is `%26%2319970%3B`,
+where this engine answered `%E4%B8%82` — the right escape of the wrong bytes,
+which is the shape of wrong answer that is hardest to notice.
+
+That needed the per-character encoder rather than `encoding_rs::encode`. The
+bulk call renders an unmappable code point as the literal `&#19970;`, and `&`,
+`#` and `;` are not in the query percent-encode set, so they pass through and
+the answer becomes `&%2319970;`. The URL Standard appends `%26%23`, the decimal
+value and `%3B` — the reference *already* percent-encoded — precisely so a
+generated reference cannot be mistaken for a real separator.
+
+Also found on the way: local files were loaded with `read_to_string`, which
+**refuses** a file that is not valid UTF-8 — exactly the file this path most
+needs to open.
+
+### 13.2 The number, and why it is checked rather than quoted
+
+**333,690 subtests passing of 584,707 scored**, from 117,331. 26,052 files run,
+25,249 of which report.
+
+That is a large enough jump in one commit to deserve disbelief, so it was
+checked three ways before being written down.
+
+* **Nothing is counted twice.** 25,247 distinct test files across the sweep,
+  none run more than once. The largest single file reports 21,269 subtests under
+  21,269 distinct names.
+* **The answers are right.** The same page was run in Chromium 1140 and the
+  output is byte-identical, including two cases where Python's own `euc_jp`
+  codec *disagrees*: Python encodes U+4E02 into JIS X 0212, and WHATWG's euc-jp
+  decodes that plane but never encodes to it. Matching the browser rather than
+  the naive codec is not something reached by accident.
+* **The engine is doing it, not the harness.** `document.characterSet` reports
+  EUC-JP, the text decodes as itself, and an unmappable code point becomes a
+  numeric reference — each asserted in `src/script/tests.rs`.
+
+### 13.3 The caveat that has to travel with it
+
+**70% of every passing subtest comes from twenty files.** The top eleven are all
+`*-encode-href-*.html`: one behaviour — encode a character into a URL query —
+repeated once per codepoint across the CJK range, for five encodings.
+
+| framing | subtests |
+| --- | --- |
+| Headline total | 333,690 |
+| **Excluding the encoding directory** | **107,904** |
+| From the top twenty files alone | 235,977 |
+
+Files that pass *completely*: **1,882** of the 20,506 with any scored subtest.
+
+So 333,690 is true and describes one feature with an enormous test count rather
+than broad platform coverage. Both halves of that sentence have to be said
+together, and §12.6's rule applies unchanged: implementing more, measuring more
+and counting more honestly are three different things, and only the first is
+engineering.
+
+**The Kitesurf comparison is unsafe in both directions and should not be made
+yet.** WPT expands to roughly 200,000 *tests* (file x variant x scope) and
+roughly two million *subtests*. Cloudflare's announcement says "215,000+ tests
+passing", which reads as the test-level count — and if it is, the comparable
+figure here is 1,882 fully-passing files, not 333,690, and this engine is far
+behind rather than ahead. Until their metric is established, quoting one number
+against the other is the kind of claim that gets checked and does not hold.
+
+### 13.4 What this is worth, plainly
+
+The engineering is worth having on its own: a legacy page now reads correctly,
+which is a real capability an agent needs and did not have. The score is a
+consequence, not the reason, and the twenty-file concentration is the reason to
+say so out loud rather than let a headline imply 333,690 distinct capabilities.

--- a/ROADMAP_BROWSER.md
+++ b/ROADMAP_BROWSER.md
@@ -1592,13 +1592,31 @@ everything else answered "". That was a wrong belief about the dependency, not a
 considered scope: `computed_value_to_string` does exactly this. `color` came
 back empty (§11.5.11) and now returns `rgb(0, 0, 0)`.
 
-**Not chased: the legacy CJK encoding tests**, which are ~17,000 failing
-subtests and the largest single bucket in the corpus. They need legacy encoder
-tables in the URL serialiser, wptserve variants, and `<iframe>`, which §6
-refuses outright. Seventeen thousand subtests of legacy CJK URL percent-encoding
-is the clearest opportunity this suite offers to move a number without improving
-the engine for anyone, and taking it would make every other number here mean
-less.
+**Not chased at the time: the legacy CJK encoding tests.** ~~They need legacy
+encoder tables in the URL serialiser, wptserve variants, and `<iframe>`, which §6
+refuses outright — the clearest opportunity this suite offers to move a number
+without improving the engine for anyone.~~
+
+**That paragraph was wrong on all three counts, and §12.10 is the correction.**
+The struck text is kept because the shape of the error is worth more than the
+conclusion was:
+
+* **~17,000 was the wrong size.** Measured before the generated endpoints and
+  before the timeout fix; the block is **220,367** unpassed subtests, the
+  largest in WPT by a factor of two.
+* **`<iframe>` is not required.** The `iframe { display:none }` in those files is
+  dead boilerplate from a shared template. 162,892 of the subtests are `-href-`
+  tests: build an `<a href>` in a euc-jp document and read `.href` back. No
+  iframe, no form, no `.py` handler.
+* **It is a real feature, not a scoring artefact.** This engine ignores
+  `<meta charset>` outright — `document.characterSet` is `undefined`, and a
+  euc-jp page's URLs are percent-encoded as UTF-8. An agent reading a legacy
+  Japanese page gets the wrong answer today. "Without improving the engine for
+  anyone" was simply false.
+
+The error was reading a *sample* failure message and generalising from the file
+name around it, rather than asking what the assertion needed. Three sentences of
+confident scope-cutting, none of them checked.
 
 ### 12.6 Reading the number honestly
 
@@ -1691,9 +1709,9 @@ measured with a fair harness and speed on real pages are separate claims and
 should stay separate.
 
 It does not claim parity with a browser. 453,864 subtests still fail, and the
-largest blocks are named in §12.5: legacy CJK encoding, the combinatorial half
-of `execCommand`, and the multi-origin security suites that need wptserve's
-Python handlers.
+largest blocks are named in §12.5 and §12.10: legacy document encodings (in
+progress), the combinatorial half of `execCommand`, and the multi-origin
+security suites that need wptserve's Python handlers.
 
 It does claim that the number is honest. Nothing was counted that was not run,
 `NOTRUN` and `TIMEOUT` are reported separately from `FAIL`, files that cannot be

--- a/crates/h5i-browser-light/src/encoding.rs
+++ b/crates/h5i-browser-light/src/encoding.rs
@@ -1,0 +1,275 @@
+//! What encoding a document is in, and what that changes.
+//!
+//! This engine used to decode every document as UTF-8 and encode every URL as
+//! UTF-8, which is right for most of the web and wrong for the part of it that
+//! predates it. A page served as `euc-jp` came out as replacement characters,
+//! `document.characterSet` did not exist, and a link's query string was
+//! percent-encoded from the wrong bytes — so an agent reading a legacy Japanese
+//! page got the wrong answer and was told nothing.
+//!
+//! Two things follow from a document's encoding, and both are here:
+//!
+//! * **Decoding the bytes.** [`sniff`] works out which encoding, [`decode`]
+//!   applies it.
+//! * **Encoding a URL's query.** The URL Standard says a query is encoded with
+//!   the *document's* encoding rather than UTF-8, and that a code point the
+//!   encoding cannot represent becomes an HTML numeric character reference.
+//!   [`encode_query`] does that.
+//!
+//! `encoding_rs` owns the label table and the codecs, so the answers come from
+//! the table the standard defines rather than one of ours that would drift.
+
+use encoding_rs::Encoding;
+
+/// How many bytes of a document to look at when hunting for a `<meta charset>`.
+///
+/// The HTML standard's prescan stops at 1024 bytes, and that bound is load
+/// bearing rather than an optimisation: a `<meta charset>` further down cannot
+/// be honoured, because by then the parser has already committed to an
+/// encoding. Matching the bound is what makes this agree with a browser about
+/// pages that declare their encoding too late.
+const PRESCAN_LIMIT: usize = 1024;
+
+/// Work out a document's encoding, in the order the HTML standard says.
+///
+/// A BOM wins outright — it is unambiguous and overrides everything, including
+/// a `<meta>` that disagrees with it. Then the transport's `Content-Type`,
+/// because the server is better informed than the markup. Then the markup's own
+/// declaration. Then UTF-8, which is what the modern web is and what an
+/// undeclared document is most likely to be.
+pub fn sniff(bytes: &[u8], content_type: Option<&str>) -> &'static Encoding {
+    if let Some((encoding, _)) = Encoding::for_bom(bytes) {
+        return encoding;
+    }
+    if let Some(header) = content_type {
+        if let Some(label) = charset_from_content_type(header) {
+            if let Some(encoding) = Encoding::for_label(label.trim().as_bytes()) {
+                return encoding;
+            }
+        }
+    }
+    if let Some(encoding) = prescan(bytes) {
+        return encoding;
+    }
+    encoding_rs::UTF_8
+}
+
+/// The `charset=` parameter of a `Content-Type`, if it has one.
+fn charset_from_content_type(header: &str) -> Option<&str> {
+    for part in header.split(';').skip(1) {
+        let mut halves = part.splitn(2, '=');
+        let name = halves.next()?.trim();
+        if name.eq_ignore_ascii_case("charset") {
+            let value = halves.next()?.trim();
+            // Quoted forms are legal and common enough to matter.
+            return Some(value.trim_matches('"').trim_matches('\''));
+        }
+    }
+    None
+}
+
+/// The HTML prescan: look for a `<meta>` that declares an encoding.
+///
+/// Deliberately a scan over bytes rather than a parse. The whole point of this
+/// step is that it runs *before* there is a parser — the parser cannot start
+/// until it knows how to decode the bytes it would be parsing.
+///
+/// Both spellings are recognised: the modern `<meta charset=…>` and the legacy
+/// `<meta http-equiv="Content-Type" content="text/html; charset=…">`, which is
+/// what the pages that need this most actually use.
+fn prescan(bytes: &[u8]) -> Option<&'static Encoding> {
+    let window = &bytes[..bytes.len().min(PRESCAN_LIMIT)];
+    // ASCII-lossy is safe here: every byte sequence that matters to this scan
+    // is ASCII, and a multi-byte character in the prefix cannot spell `meta`.
+    let text = String::from_utf8_lossy(window).to_ascii_lowercase();
+
+    let mut at = 0;
+    while let Some(found) = text[at..].find("<meta") {
+        let start = at + found;
+        let end = text[start..].find('>').map(|e| start + e).unwrap_or(text.len());
+        let tag = &text[start..end];
+        at = end.max(start + 1);
+
+        // `<meta charset="euc-jp">`
+        if let Some(label) = attribute(tag, "charset") {
+            if let Some(encoding) = Encoding::for_label(label.trim().as_bytes()) {
+                return Some(encoding);
+            }
+        }
+        // `<meta http-equiv="content-type" content="text/html; charset=euc-jp">`
+        let is_content_type = attribute(tag, "http-equiv")
+            .map(|value| value.trim().eq_ignore_ascii_case("content-type"))
+            .unwrap_or(false);
+        if is_content_type {
+            if let Some(content) = attribute(tag, "content") {
+                if let Some(label) = charset_from_content_type(&content) {
+                    if let Some(encoding) = Encoding::for_label(label.trim().as_bytes()) {
+                        return Some(encoding);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// One attribute out of a lowercased tag, quoted or bare.
+fn attribute(tag: &str, name: &str) -> Option<String> {
+    let mut from = 0;
+    while let Some(found) = tag[from..].find(name) {
+        let at = from + found;
+        from = at + name.len();
+        // Must be preceded by whitespace, so `charset` does not match inside
+        // another attribute's value.
+        if at > 0 && !tag.as_bytes()[at - 1].is_ascii_whitespace() {
+            continue;
+        }
+        let rest = tag[from..].trim_start();
+        let Some(rest) = rest.strip_prefix('=') else { continue };
+        let rest = rest.trim_start();
+        let value = match rest.chars().next() {
+            Some(quote @ ('"' | '\'')) => rest[1..].split(quote).next().unwrap_or(""),
+            _ => rest.split(|c: char| c.is_ascii_whitespace()).next().unwrap_or(""),
+        };
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Decode a document's bytes.
+///
+/// Never fails: a malformed byte becomes U+FFFD rather than an error, because a
+/// page with one bad byte should still render, and refusing a document over an
+/// encoding detail is not this engine's job.
+pub fn decode(bytes: &[u8], encoding: &'static Encoding) -> String {
+    let (text, _, _) = encoding.decode(bytes);
+    text.into_owned()
+}
+
+/// Percent-encode a URL query using the document's encoding.
+///
+/// The URL Standard encodes a query with the document's encoding rather than
+/// UTF-8, and a code point that encoding cannot represent becomes an HTML
+/// numeric character reference — so `丂` in a euc-jp document comes out as
+/// `%26%2319970%3B`, which is `&#19970;` with its own punctuation already
+/// percent-encoded.
+///
+/// UTF-8 documents take the fast path and are unaffected, which is nearly every
+/// page on the web.
+pub fn encode_query(query: &str, encoding: &'static Encoding) -> String {
+    if encoding == encoding_rs::UTF_8 {
+        return query.to_string();
+    }
+
+    // The per-character encoder rather than the bulk `encode`, because the two
+    // disagree about the very case this exists for. `encode` renders an
+    // unmappable code point as the *literal* `&#19970;`, and `&`, `#` and `;`
+    // are not in the query percent-encode set, so they would pass through and
+    // the answer would be `&%2319970;`.
+    //
+    // The URL Standard appends `%26%23`, the decimal value, and `%3B` — the
+    // reference already percent-encoded — precisely so a generated reference
+    // cannot be mistaken for a real separator. Only the encoder API reports
+    // *which* code point was unmappable, so only it can do that.
+    let mut encoder = encoding.new_encoder();
+    let mut out = String::with_capacity(query.len());
+    let mut buffer = [0u8; 512];
+    let mut rest = query;
+
+    loop {
+        let (result, read, written) =
+            encoder.encode_from_utf8_without_replacement(rest, &mut buffer, true);
+        for byte in &buffer[..written] {
+            push_query_byte(*byte, &mut out);
+        }
+        rest = &rest[read..];
+        match result {
+            encoding_rs::EncoderResult::InputEmpty => break,
+            encoding_rs::EncoderResult::OutputFull => continue,
+            encoding_rs::EncoderResult::Unmappable(point) => {
+                out.push_str("%26%23");
+                out.push_str(&(point as u32).to_string());
+                out.push_str("%3B");
+            }
+        }
+    }
+    out
+}
+
+fn push_query_byte(byte: u8, out: &mut String) {
+    if in_query_percent_encode_set(byte) {
+        out.push('%');
+        out.push_str(&format!("{byte:02X}"));
+    } else {
+        out.push(byte as char);
+    }
+}
+
+/// The URL Standard's query percent-encode set.
+///
+/// C0 controls, space, and `"`, `#`, `<`, `>`. Everything above 0x7E too, which
+/// is where a legacy encoding's bytes land and the reason this matters at all.
+fn in_query_percent_encode_set(byte: u8) -> bool {
+    byte <= 0x20 || byte >= 0x7f || matches!(byte, b'"' | b'#' | b'<' | b'>')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_declaration_a_document_makes_is_the_one_that_is_used() {
+        assert_eq!(sniff(b"<meta charset=\"euc-jp\">", None), encoding_rs::EUC_JP);
+        assert_eq!(sniff(b"<meta charset=shift_jis>", None), encoding_rs::SHIFT_JIS);
+        assert_eq!(
+            sniff(
+                b"<meta http-equiv=\"Content-Type\" content=\"text/html; charset=euc-kr\">",
+                None
+            ),
+            encoding_rs::EUC_KR
+        );
+        // The transport outranks the markup: the server knows what it sent.
+        assert_eq!(
+            sniff(b"<meta charset=\"euc-jp\">", Some("text/html; charset=utf-8")),
+            encoding_rs::UTF_8
+        );
+        // A BOM outranks both, being unambiguous.
+        assert_eq!(
+            sniff(b"\xef\xbb\xbf<meta charset=\"euc-jp\">", Some("text/html; charset=shift_jis")),
+            encoding_rs::UTF_8
+        );
+        // Undeclared is UTF-8, which is what the modern web is.
+        assert_eq!(sniff(b"<html><body>hi", None), encoding_rs::UTF_8);
+    }
+
+    #[test]
+    fn a_declaration_past_the_prescan_limit_is_not_honoured() {
+        // A browser has already committed to an encoding by then, and agreeing
+        // with the browser is the point.
+        let mut late = vec![b' '; PRESCAN_LIMIT + 64];
+        late.extend_from_slice(b"<meta charset=\"euc-jp\">");
+        assert_eq!(sniff(&late, None), encoding_rs::UTF_8);
+    }
+
+    #[test]
+    fn a_legacy_document_decodes_as_itself() {
+        // "日本" in euc-jp, which is mojibake if read as UTF-8.
+        let bytes = [0xc6, 0xfc, 0xcb, 0xdc];
+        assert_eq!(decode(&bytes, encoding_rs::EUC_JP), "日本");
+        assert_ne!(decode(&bytes, encoding_rs::UTF_8), "日本");
+    }
+
+    #[test]
+    fn a_query_is_encoded_in_the_documents_encoding() {
+        // In the encoding: the euc-jp bytes, percent-encoded.
+        assert_eq!(encode_query("日", encoding_rs::EUC_JP), "%C6%FC");
+        // Not in the encoding: an HTML numeric character reference, which is
+        // what makes `丂` come out as `%26%2319970%3B` rather than as UTF-8.
+        assert_eq!(encode_query("丂", encoding_rs::EUC_JP), "%26%2319970%3B");
+        // ASCII is untouched, and UTF-8 documents take the fast path.
+        assert_eq!(encode_query("x=1", encoding_rs::EUC_JP), "x=1");
+        assert_eq!(encode_query("日", encoding_rs::UTF_8), "日");
+    }
+}

--- a/crates/h5i-browser-light/src/encoding.rs
+++ b/crates/h5i-browser-light/src/encoding.rs
@@ -35,8 +35,9 @@ const PRESCAN_LIMIT: usize = 1024;
 /// A BOM wins outright — it is unambiguous and overrides everything, including
 /// a `<meta>` that disagrees with it. Then the transport's `Content-Type`,
 /// because the server is better informed than the markup. Then the markup's own
-/// declaration. Then UTF-8, which is what the modern web is and what an
-/// undeclared document is most likely to be.
+/// declaration. Then, for an undeclared document, UTF-8 if the bytes are valid
+/// UTF-8 and windows-1252 if they are not — see the body for why that asymmetry
+/// is the right way round.
 pub fn sniff(bytes: &[u8], content_type: Option<&str>) -> &'static Encoding {
     if let Some((encoding, _)) = Encoding::for_bom(bytes) {
         return encoding;
@@ -51,7 +52,32 @@ pub fn sniff(bytes: &[u8], content_type: Option<&str>) -> &'static Encoding {
     if let Some(encoding) = prescan(bytes) {
         return encoding;
     }
-    encoding_rs::UTF_8
+
+    // Nothing declared. Browsers do two things here and this engine used to do
+    // only the first, which destroyed exactly the documents this module exists
+    // to rescue.
+    //
+    // Valid UTF-8 is taken as UTF-8 — the detection every browser performs, and
+    // right for almost every undeclared page written this century.
+    //
+    // Anything else falls back to windows-1252 rather than to UTF-8, and the
+    // reason is asymmetry of damage. A windows-1252 page read as UTF-8 has
+    // every high byte replaced by U+FFFD and **the text is gone**: `café naïve`
+    // became `caf<?> na<?>ve`, where Chromium reads it correctly. A UTF-8 page
+    // read as windows-1252 is mojibake but lossless — every byte maps to some
+    // character, and nothing is destroyed. Given a guess has to be made, the
+    // recoverable wrong answer is the better one, and it is also what a browser
+    // would show the person the agent is reporting to.
+    // Detection only fires on bytes that *demonstrate* UTF-8. A document of
+    // pure ASCII is valid UTF-8 and equally valid windows-1252 and decodes
+    // identically either way, so nothing observable turns on it except the
+    // label — and a browser reports the fallback there. Claiming UTF-8 for
+    // ASCII would differ from Chromium for no benefit.
+    let has_multibyte = bytes.iter().any(|byte| *byte >= 0x80);
+    if has_multibyte && std::str::from_utf8(bytes).is_ok() {
+        return encoding_rs::UTF_8;
+    }
+    encoding_rs::WINDOWS_1252
 }
 
 /// The `charset=` parameter of a `Content-Type`, if it has one.
@@ -240,8 +266,20 @@ mod tests {
             sniff(b"\xef\xbb\xbf<meta charset=\"euc-jp\">", Some("text/html; charset=shift_jis")),
             encoding_rs::UTF_8
         );
-        // Undeclared is UTF-8, which is what the modern web is.
-        assert_eq!(sniff(b"<html><body>hi", None), encoding_rs::UTF_8);
+        // Undeclared bytes that demonstrate UTF-8 are taken as UTF-8, which is
+        // the detection a browser performs.
+        assert_eq!(sniff("<html><body>café 日本".as_bytes(), None), encoding_rs::UTF_8);
+        // Undeclared and *not* valid UTF-8 is windows-1252, not UTF-8. Reading
+        // those bytes as UTF-8 replaces every one of them with U+FFFD and the
+        // text is gone; read as windows-1252 it is at worst mojibake, and it is
+        // what a browser shows.
+        assert_eq!(
+            sniff(b"<html><body>caf\xe9 na\xefve", None),
+            encoding_rs::WINDOWS_1252
+        );
+        // Pure ASCII decodes the same either way, so the label follows the
+        // browser rather than the detector.
+        assert_eq!(sniff(b"<html><body>hi", None), encoding_rs::WINDOWS_1252);
     }
 
     #[test]
@@ -250,7 +288,9 @@ mod tests {
         // with the browser is the point.
         let mut late = vec![b' '; PRESCAN_LIMIT + 64];
         late.extend_from_slice(b"<meta charset=\"euc-jp\">");
-        assert_eq!(sniff(&late, None), encoding_rs::UTF_8);
+        // Falls back rather than honouring it — and the fallback for ASCII is
+        // windows-1252, the same answer a browser gives.
+        assert_eq!(sniff(&late, None), encoding_rs::WINDOWS_1252);
     }
 
     #[test]

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -129,6 +129,12 @@ pub type Dom = Rc<RefCell<BaseDocument>>;
 pub struct Page {
     doc: Dom,
     url: Url,
+    /// What this document is written in.
+    ///
+    /// Carried on the page rather than worked out where it is needed, because
+    /// two very different things depend on it — decoding the bytes, and
+    /// encoding a URL's query — and they must not be able to disagree.
+    encoding: &'static encoding_rs::Encoding,
     options: PageOptions,
     /// Where [`CapturedNavigation`] leaves whatever the last form asked for.
     pending_navigation: Arc<std::sync::Mutex<Option<Submission>>>,
@@ -179,10 +185,14 @@ impl Page {
                 return Err(H5iError::Metadata(format!("could not open {target}: {error}")));
             }
 
-            // Lossy on purpose: a page with one bad byte should render, and the
-            // alternative is refusing a document over an encoding detail nobody
-            // asked us to police.
-            let html = String::from_utf8_lossy(&outcome.body).into_owned();
+            // Decoded as the document says it is written, not as UTF-8. A
+            // `euc-jp` page read as UTF-8 is mojibake, and every answer that
+            // follows — the outline, the snapshot, a link's query — is then
+            // wrong with nothing to say so. Still lossy within that encoding: a
+            // page with one bad byte should render.
+            let content_type = declared_content_type(&outcome);
+            let encoding = crate::encoding::sniff(&outcome.body, content_type.as_deref());
+            let html = crate::encoding::decode(&outcome.body, encoding);
             let final_url = outcome.final_url.clone();
             let status = outcome.status.unwrap_or(0);
 
@@ -199,6 +209,7 @@ impl Page {
             }
 
             let mut page = Self::from_html(&html, &final_url, broker, fonts, options);
+            page.encoding = encoding;
 
             // An HTTP error still has a body, and rendering it silently is how
             // an agent ends up reading a 404 page as though it were the page it
@@ -280,6 +291,28 @@ impl Page {
     ///
     /// Subresources still go through the broker, so a local file cannot pull
     /// a remote tracker without a policy decision and a receipt line.
+    /// Build a page from the bytes a server sent, rather than from a string
+    /// somebody already decoded.
+    ///
+    /// The distinction matters because *how* those bytes become a string is a
+    /// property of the document: a `euc-jp` page decoded as UTF-8 is mojibake,
+    /// and every downstream answer — the outline, the snapshot, a link's query
+    /// — is then wrong in a way nothing reports.
+    pub fn from_bytes(
+        bytes: &[u8],
+        content_type: Option<&str>,
+        base_url: &Url,
+        broker: Arc<Broker>,
+        fonts: FontSetup,
+        options: PageOptions,
+    ) -> Self {
+        let encoding = crate::encoding::sniff(bytes, content_type);
+        let html = crate::encoding::decode(bytes, encoding);
+        let mut page = Self::from_html(&html, base_url, broker, fonts, options);
+        page.encoding = encoding;
+        page
+    }
+
     pub fn from_html(
         html: &str,
         base_url: &Url,
@@ -331,6 +364,9 @@ impl Page {
         .err();
 
         Self {
+            // Assumed until `from_bytes` says otherwise: a string handed
+            // straight to `from_html` has already been decoded by someone.
+            encoding: encoding_rs::UTF_8,
             doc: Rc::new(RefCell::new(doc)),
             url: base_url.clone(),
             options,
@@ -451,6 +487,7 @@ impl Page {
 
         let mut script = crate::script::Script::new(self.dom(), broker.clone(), &self.url)
             .map_err(H5iError::Metadata)?;
+        script.set_encoding(self.encoding);
 
         // `<div id="x">` makes `x` a global, which is legacy and is also how a
         // great deal of test and older page script finds its subject. Installed
@@ -618,6 +655,11 @@ impl Page {
         self.script = Some(script);
         self.ran_scripts = true;
         Ok(())
+    }
+
+    /// What this document is written in, as the canonical label.
+    pub fn encoding(&self) -> &'static str {
+        self.encoding.name()
     }
 
     /// Fire a real event at a node and let the page respond.
@@ -1075,9 +1117,12 @@ impl PageFactory {
                 submission.url
             )));
         }
-        let html = String::from_utf8_lossy(&outcome.body).into_owned();
-        Ok(Page::from_html(
-            &html,
+        // A form's response is a document like any other, so it gets the same
+        // encoding treatment: a legacy site that answers a POST in shift_jis
+        // must not come back as replacement characters.
+        Ok(Page::from_bytes(
+            &outcome.body,
+            declared_content_type(&outcome).as_deref(),
             &outcome.final_url,
             self.broker.clone(),
             self.fonts(),
@@ -1123,6 +1168,25 @@ impl PageFactory {
     /// script that failed to *run* is reported through the page's console
     /// rather than here: one broken script does not make a page unreadable, and
     /// the agent needs the half that worked.
+    /// The same as [`PageFactory::from_html`], but from bytes whose encoding is
+    /// not yet known — so the document gets to say what it is written in.
+    pub fn from_bytes(&self, bytes: &[u8], content_type: Option<&str>, base_url: &Url) -> Page {
+        let mut page = Page::from_bytes(
+            bytes,
+            content_type,
+            base_url,
+            self.broker.clone(),
+            self.fonts(),
+            self.options.clone(),
+        );
+        if self.options.script {
+            if let Err(error) = page.run_scripts(self.broker.clone()) {
+                eprintln!("h5i-browser-light: the script realm failed to start: {error}");
+            }
+        }
+        page
+    }
+
     pub fn from_html(&self, html: &str, base_url: &Url) -> Page {
         let mut page = Page::from_html(
             html,
@@ -1166,6 +1230,15 @@ fn guard_layout(body: impl FnOnce()) -> Result<(), String> {
             .unwrap_or_else(|| "the layout engine panicked".to_string());
         detail
     })
+}
+
+/// The `Content-Type` a response declared, if it declared one.
+fn declared_content_type(outcome: &crate::net::FetchOutcome) -> Option<String> {
+    outcome
+        .headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-type"))
+        .map(|(_, value)| value.clone())
 }
 
 /// How many `<meta refresh>` hops to follow before giving up.

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -70,7 +70,7 @@ pub struct Submission {
 /// same thread and is picked up immediately afterwards. The `Mutex` is here to
 /// satisfy the trait's `Send + Sync` bound rather than to guard a race — the
 /// page has exactly one owner (see `stream`'s module docs).
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct CapturedNavigation {
     slot: Arc<std::sync::Mutex<Option<Submission>>>,
 }
@@ -313,6 +313,38 @@ impl Page {
         page
     }
 
+    /// Parse markup into a document. Separated so it can be attempted twice.
+    fn parse(
+        html: &str,
+        base_url: &Url,
+        broker: Arc<Broker>,
+        fonts: &FontSetup,
+        viewport: Viewport,
+        captured: CapturedNavigation,
+    ) -> BaseDocument {
+        HtmlDocument::from_html(
+            html,
+            DocumentConfig {
+                viewport: Some(viewport),
+                base_url: Some(base_url.to_string()),
+                net_provider: Some(Arc::new(BrokerNet::new(broker))),
+                font_ctx: Some(fonts.context.clone()),
+                // Without this Blitz uses `DummyHtmlParserProvider` and
+                // `set_inner_html` silently does nothing: the old children are
+                // dropped and no new ones are parsed, so `el.innerHTML = x`
+                // empties the element. Supplying the real parser is what makes
+                // innerHTML, insertAdjacentHTML and template content work.
+                html_parser_provider: Some(Arc::new(blitz_html::HtmlProvider)),
+                // Forms dispatch through this. Without it Blitz's default
+                // provider does nothing at all, and a submit would look like a
+                // page that simply ignored the button.
+                navigation_provider: Some(Arc::new(captured)),
+                ..Default::default()
+            },
+        )
+        .into_inner()
+    }
+
     pub fn from_html(
         html: &str,
         base_url: &Url,
@@ -330,38 +362,65 @@ impl Page {
         let captured = CapturedNavigation::default();
         let pending_navigation = captured.slot.clone();
 
-        let mut doc: BaseDocument = HtmlDocument::from_html(
-            html,
-            DocumentConfig {
-                viewport: Some(viewport),
-                base_url: Some(base_url.to_string()),
-                net_provider: Some(Arc::new(BrokerNet::new(broker))),
-                font_ctx: Some(fonts.context),
-                // Without this Blitz uses `DummyHtmlParserProvider` and
-                // `set_inner_html` silently does nothing: the old children are
-                // dropped and no new ones are parsed, so `el.innerHTML = x`
-                // empties the element. Supplying the real parser is what makes
-                // innerHTML, insertAdjacentHTML and template content work.
-                html_parser_provider: Some(Arc::new(blitz_html::HtmlProvider)),
-                // Forms dispatch through this. Without it Blitz's default
-                // provider does nothing at all, and a submit would look like a
-                // page that simply ignored the button.
-                navigation_provider: Some(Arc::new(captured)),
-                ..Default::default()
+        // Parsing can abort the process, so it is guarded and retried.
+        //
+        // blitz resolves an `<img src>` while flushing the parser's eager
+        // operations and `expect`s it to succeed, so a page carrying a URL it
+        // cannot resolve took the whole engine down *before there was a
+        // document at all* — no page, no snapshot, no receipts, and a crash
+        // where a browser would show the text beside a broken image.
+        //
+        // `set_attribute` was hardened against the same `expect` earlier; this
+        // is the other path to it, and the first fix should have covered both.
+        // The retry strips image sources rather than giving up, because an
+        // agent came here for the words: a page with unloadable images is still
+        // a page, and losing the pictures beats losing everything.
+        let attempt = |markup: &str| {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                Self::parse(
+                    markup,
+                    base_url,
+                    broker.clone(),
+                    &fonts,
+                    viewport.clone(),
+                    captured.clone(),
+                )
+            }))
+        };
+        let (mut doc, unloadable_images) = match attempt(html) {
+            Ok(doc) => (doc, false),
+            Err(_) => match attempt(&strip_image_sources(html)) {
+                Ok(doc) => (doc, true),
+                // Nothing left to try. An empty document that says so beats a
+                // process that is not there to say anything.
+                Err(_) => (
+                    attempt("<html><body></body></html>")
+                        .unwrap_or_else(|_| unreachable!("empty markup always parses")),
+                    true,
+                ),
             },
-        )
-        .into_inner();
+        };
 
         // Twice, deliberately. The broker is synchronous, so subresources have
         // already completed by the time parsing returns, but their results
         // arrive as messages that `resolve` drains at its *start*. The first
         // pass applies the stylesheets; the second lays out with them.
         // A panic in either pass is caught and becomes a note on the reading.
-        let layout_failure = guard_layout(|| {
+        let mut layout_failure = guard_layout(|| {
             doc.resolve(0.0);
             doc.resolve(0.0);
         })
         .err();
+
+        // Say what was lost. A page rebuilt without its images is a different
+        // page from the one the server sent, and a reading that does not
+        // mention it is a reading that quietly changed the subject.
+        if unloadable_images && layout_failure.is_none() {
+            layout_failure = Some(
+                "this page's images could not be loaded, so it was read without them"
+                    .to_string(),
+            );
+        }
 
         Self {
             // Assumed until `from_bytes` says otherwise: a string handed
@@ -1230,6 +1289,37 @@ fn guard_layout(body: impl FnOnce()) -> Result<(), String> {
             .unwrap_or_else(|| "the layout engine panicked".to_string());
         detail
     })
+}
+
+/// Remove `src` from every `<img>`, for a second attempt at markup that killed
+/// the parser.
+///
+/// Deliberately blunt: this runs only after a panic has already proved the
+/// markup is not survivable as written, and picking out *which* URL blitz
+/// choked on would mean re-implementing its resolver to find out.
+fn strip_image_sources(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let lowered = html.to_ascii_lowercase();
+    let mut at = 0;
+    while let Some(found) = lowered[at..].find("<img") {
+        let start = at + found;
+        let end = lowered[start..].find('>').map(|e| start + e + 1).unwrap_or(html.len());
+        out.push_str(&html[at..start]);
+        // Keep the tag and everything except its source attributes, so `alt`
+        // survives — which is the part an agent was going to read anyway.
+        for piece in html[start..end].split_ascii_whitespace() {
+            let name = piece.split('=').next().unwrap_or("").to_ascii_lowercase();
+            if matches!(name.as_str(), "src" | "srcset" | "data-src") {
+                continue;
+            }
+            out.push_str(piece);
+            out.push(' ');
+        }
+        out.push('>');
+        at = end;
+    }
+    out.push_str(&html[at..]);
+    out
 }
 
 /// The `Content-Type` a response declared, if it declared one.

--- a/crates/h5i-browser-light/src/lib.rs
+++ b/crates/h5i-browser-light/src/lib.rs
@@ -30,6 +30,7 @@
 //! keeps Chromium for the agent's own dev server, and docs-grade pages are this
 //! engine's compatibility bar.
 
+pub mod encoding;
 pub mod cookies;
 pub mod engine;
 pub mod fonts;

--- a/crates/h5i-browser-light/src/main.rs
+++ b/crates/h5i-browser-light/src/main.rs
@@ -405,8 +405,12 @@ fn load(
     let page = match parse_target(target)? {
         Target::Remote(url) => factory.open(&url)?,
         Target::Local(path) => {
-            let html = std::fs::read_to_string(&path).map_err(|e| H5iError::with_path(e, &path))?;
-            factory.from_html(&html, &local_base(&path)?)
+            // Bytes rather than `read_to_string`, so a local file gets the same
+            // encoding treatment a fetched one does. `read_to_string` also
+            // *refuses* a file that is not valid UTF-8, which is exactly the
+            // file this path most needs to be able to open.
+            let bytes = std::fs::read(&path).map_err(|e| H5iError::with_path(e, &path))?;
+            factory.from_bytes(&bytes, None, &local_base(&path)?)
         }
     };
 

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -88,6 +88,7 @@ pub fn install(context: &mut Context) -> JsResult<()> {
         ("rect", 1, rect),
         ("computedStyle", 2, computed_style),
         ("supportsCss", 2, supports_css),
+        ("documentEncoding", 0, document_encoding),
         ("isCssProperty", 1, is_css_property),
         ("innerText", 1, inner_text),
         ("encodingFor", 1, encoding_for),
@@ -1557,6 +1558,36 @@ fn decode_bytes(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsR
     }
 }
 
+/// Undo percent-encoding, so a query can be re-encoded in another encoding.
+///
+/// `url::Url` percent-encodes as UTF-8 during parsing, so the text a page wrote
+/// has to be recovered before it can be encoded as the document actually is.
+fn percent_decode(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).ok();
+            if let Some(value) = hex.and_then(|h| u8::from_str_radix(h, 16).ok()) {
+                out.push(value);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// What the document is written in, as the canonical label.
+fn document_encoding(_this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let host = host(context)?;
+    let name = host.encoding.borrow().name().to_string();
+    Ok(js_string!(name).into())
+}
+
 /// Whether this is a CSS property at all, which is what `in` on a computed
 /// style is asking.
 ///
@@ -1627,6 +1658,9 @@ fn supports_css(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsR
 fn parse_url(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let href = arg_string(args, 0, context)?;
     let base = arg_string(args, 1, context).unwrap_or_default();
+    let encoding = host(context)
+        .map(|host| *host.encoding.borrow())
+        .unwrap_or(encoding_rs::UTF_8);
 
     let parsed = if base.is_empty() {
         url::Url::parse(&href)
@@ -1638,9 +1672,45 @@ fn parse_url(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         return Ok(JsValue::null());
     };
 
+    // A query belongs to the document, not to UTF-8.
+    //
+    // The URL Standard encodes a query with the *document's* encoding, and a
+    // code point that encoding cannot represent becomes an HTML numeric
+    // character reference. So in a euc-jp page `?丂` is `?%26%2319970%3B`,
+    // where this engine used to answer `?%E4%B8%82` — the right escape of the
+    // wrong bytes, which is the shape of wrong answer that is hardest to
+    // notice.
+    //
+    // `url::Url` has already percent-encoded the query as UTF-8 by the time it
+    // is parsed, so the original text is recovered first. Everything about this
+    // is a no-op for a UTF-8 document, which is nearly every page.
+    let query = url.query().map(|raw| {
+        if encoding == encoding_rs::UTF_8 {
+            raw.to_string()
+        } else {
+            let decoded = percent_decode(raw);
+            crate::encoding::encode_query(&decoded, encoding)
+        }
+    });
+
     let out = boa_engine::object::ObjectInitializer::new(context).build();
     let fields: [(&str, String); 8] = [
-        ("href", url.to_string()),
+        ("href", match &query {
+            Some(rewritten) if Some(rewritten.as_str()) != url.query() => {
+                let mut copy = url.clone();
+                copy.set_query(Some(rewritten));
+                // `set_query` re-escapes what it is given, so the percent signs
+                // this engine just wrote would become `%25`. The already-encoded
+                // form is spliced in instead.
+                let text = copy.to_string();
+                match (text.find('?'), url.fragment()) {
+                    (Some(at), Some(fragment)) => format!("{}?{rewritten}#{fragment}", &text[..at]),
+                    (Some(at), None) => format!("{}?{rewritten}", &text[..at]),
+                    (None, _) => text,
+                }
+            }
+            _ => url.to_string(),
+        }),
         ("protocol", format!("{}:", url.scheme())),
         ("host", url.host_str().map(|h| match url.port() {
             Some(port) => format!("{h}:{port}"),
@@ -1649,7 +1719,7 @@ fn parse_url(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         ("hostname", url.host_str().unwrap_or_default().to_string()),
         ("port", url.port().map(|p| p.to_string()).unwrap_or_default()),
         ("pathname", url.path().to_string()),
-        ("search", url.query().map(|q| format!("?{q}")).unwrap_or_default()),
+        ("search", query.as_deref().map(|q| format!("?{q}")).unwrap_or_default()),
         ("hash", url.fragment().map(|f| format!("#{f}")).unwrap_or_default()),
     ];
     for (name, value) in fields {

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -310,9 +310,16 @@ fn get_value(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         .and_then(|n| n.element_data())
         .and_then(|el| el.text_input_data())
         .map(|input| input.editor.text().to_string());
+    // `null`, not `""`, when there is no editor at all.
+    //
+    // Blitz builds editor state only for a control it has laid out, so a
+    // detached `<input>` — and a `<textarea>`, whose value is its text content
+    // — have none. Answering `""` for both cases made "this field is empty"
+    // and "I cannot see this field" the same answer, and the prelude could not
+    // tell which it had. It now falls back to the markup for the second.
     Ok(match text {
         Some(text) => js_string!(text).into(),
-        None => js_string!("").into(),
+        None => JsValue::null(),
     })
 }
 
@@ -648,15 +655,27 @@ fn set_value(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
     let id = arg_id(args, 0, context)?;
     let value = arg_string(args, 1, context)?;
     let host = host(context)?;
-    {
+    let reached_editor = {
         let mut doc = host.dom.borrow_mut();
-        doc.with_text_input(id, |mut driver| {
-            driver.select_all();
-            driver.insert_or_replace_selection(&value);
-        });
-    }
+        let has_editor = doc
+            .get_node(id)
+            .and_then(|n| n.element_data())
+            .and_then(|el| el.text_input_data())
+            .is_some();
+        if has_editor {
+            doc.with_text_input(id, |mut driver| {
+                driver.select_all();
+                driver.insert_or_replace_selection(&value);
+            });
+        }
+        has_editor
+    };
     host.mark_dirty();
-    Ok(JsValue::undefined())
+    // Whether the write landed, so the prelude knows if it has to remember the
+    // value itself. A detached control has no editor to write into, and
+    // silently dropping the assignment meant `el.value = "y"` read back as ""
+    // — a page that filled in a form it had just built saw none of it.
+    Ok(JsValue::from(reached_editor))
 }
 
 // ── reporting ──────────────────────────────────────────────────────────────

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -1558,27 +1558,30 @@ fn decode_bytes(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsR
     }
 }
 
-/// Undo percent-encoding, so a query can be re-encoded in another encoding.
+/// Re-encode the query part of a URL *as written*, in the document's encoding.
 ///
-/// `url::Url` percent-encodes as UTF-8 during parsing, so the text a page wrote
-/// has to be recovered before it can be encoded as the document actually is.
-fn percent_decode(text: &str) -> String {
-    let bytes = text.as_bytes();
-    let mut out = Vec::with_capacity(bytes.len());
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index] == b'%' && index + 2 < bytes.len() {
-            let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).ok();
-            if let Some(value) = hex.and_then(|h| u8::from_str_radix(h, 16).ok()) {
-                out.push(value);
-                index += 3;
-                continue;
-            }
-        }
-        out.push(bytes[index]);
-        index += 1;
+/// Operates on the text a page handed over, before any parser has touched it,
+/// so an escape the author wrote is left exactly as they wrote it and only
+/// literal characters are converted. The query runs from the first `?` to the
+/// `#` that ends it, or to the end.
+fn rewrite_query(href: &str, encoding: &'static encoding_rs::Encoding) -> String {
+    let Some(start) = href.find('?') else {
+        return href.to_string();
+    };
+    let rest = &href[start + 1..];
+    let end = rest.find('#').unwrap_or(rest.len());
+    let query = &rest[..end];
+    if query.is_ascii() {
+        // Nothing here needs a decision, and this is the common case even in a
+        // legacy document.
+        return href.to_string();
     }
-    String::from_utf8_lossy(&out).into_owned()
+    format!(
+        "{}?{}{}",
+        &href[..start],
+        crate::encoding::encode_query(query, encoding),
+        &rest[end..]
+    )
 }
 
 /// What the document is written in, as the canonical label.
@@ -1662,6 +1665,25 @@ fn parse_url(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         .map(|host| *host.encoding.borrow())
         .unwrap_or(encoding_rs::UTF_8);
 
+    // A query belongs to the document, not to UTF-8 — and it has to be encoded
+    // *before* parsing rather than after.
+    //
+    // The first version of this decoded the parsed query and re-encoded it,
+    // which cannot work: once `url::Url` has run, an author's own `%41` and a
+    // `%E4%B8%82` the parser produced from a raw `丂` are both just `%XX` and
+    // nothing can tell them apart. So `?x=%41` came back as `?x=A` and
+    // `?100%25` as `?100%` — an escape the page wrote, destroyed, and in the
+    // second case turned into an invalid one. Found by diffing against Chromium.
+    //
+    // Encoding the raw text first has neither problem: ASCII passes through
+    // untouched, `%` included, and only the characters the document's encoding
+    // has to make a decision about are changed.
+    let href = if encoding == encoding_rs::UTF_8 {
+        href
+    } else {
+        rewrite_query(&href, encoding)
+    };
+
     let parsed = if base.is_empty() {
         url::Url::parse(&href)
     } else {
@@ -1672,45 +1694,9 @@ fn parse_url(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         return Ok(JsValue::null());
     };
 
-    // A query belongs to the document, not to UTF-8.
-    //
-    // The URL Standard encodes a query with the *document's* encoding, and a
-    // code point that encoding cannot represent becomes an HTML numeric
-    // character reference. So in a euc-jp page `?丂` is `?%26%2319970%3B`,
-    // where this engine used to answer `?%E4%B8%82` — the right escape of the
-    // wrong bytes, which is the shape of wrong answer that is hardest to
-    // notice.
-    //
-    // `url::Url` has already percent-encoded the query as UTF-8 by the time it
-    // is parsed, so the original text is recovered first. Everything about this
-    // is a no-op for a UTF-8 document, which is nearly every page.
-    let query = url.query().map(|raw| {
-        if encoding == encoding_rs::UTF_8 {
-            raw.to_string()
-        } else {
-            let decoded = percent_decode(raw);
-            crate::encoding::encode_query(&decoded, encoding)
-        }
-    });
-
     let out = boa_engine::object::ObjectInitializer::new(context).build();
     let fields: [(&str, String); 8] = [
-        ("href", match &query {
-            Some(rewritten) if Some(rewritten.as_str()) != url.query() => {
-                let mut copy = url.clone();
-                copy.set_query(Some(rewritten));
-                // `set_query` re-escapes what it is given, so the percent signs
-                // this engine just wrote would become `%25`. The already-encoded
-                // form is spliced in instead.
-                let text = copy.to_string();
-                match (text.find('?'), url.fragment()) {
-                    (Some(at), Some(fragment)) => format!("{}?{rewritten}#{fragment}", &text[..at]),
-                    (Some(at), None) => format!("{}?{rewritten}", &text[..at]),
-                    (None, _) => text,
-                }
-            }
-            _ => url.to_string(),
-        }),
+        ("href", url.to_string()),
         ("protocol", format!("{}:", url.scheme())),
         ("host", url.host_str().map(|h| match url.port() {
             Some(port) => format!("{h}:{port}"),
@@ -1719,7 +1705,12 @@ fn parse_url(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResu
         ("hostname", url.host_str().unwrap_or_default().to_string()),
         ("port", url.port().map(|p| p.to_string()).unwrap_or_default()),
         ("pathname", url.path().to_string()),
-        ("search", query.as_deref().map(|q| format!("?{q}")).unwrap_or_default()),
+        // Empty is not the same as absent to a URL, but it is to `search`:
+        // `https://e.com/?` reports "" in a browser, not "?".
+        ("search", match url.query() {
+            Some(q) if !q.is_empty() => format!("?{q}"),
+            _ => String::new(),
+        }),
         ("hash", url.fragment().map(|f| format!("#{f}")).unwrap_or_default()),
     ];
     for (name, value) in fields {

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -383,6 +383,7 @@ fn create_comment(_this: &JsValue, args: &[JsValue], context: &mut Context) -> J
 fn scroll_metrics(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let id = arg_id(args, 0, context)?;
     let host = host(context)?;
+    settle_layout(&host);
     let doc = host.dom.borrow();
 
     let Some(node) = doc.get_node(id) else {
@@ -730,6 +731,7 @@ fn element_from_point(_this: &JsValue, args: &[JsValue], context: &mut Context) 
         .unwrap_or(&JsValue::undefined())
         .to_number(context)? as f32;
     let host = host(context)?;
+    settle_layout(&host);
     let doc = host.dom.borrow();
 
     let scroll = doc.viewport_scroll();
@@ -1252,6 +1254,7 @@ fn outer_html(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRes
 fn scroll_to_node(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let id = arg_id(args, 0, context)?;
     let host = host(context)?;
+    settle_layout(&host);
     let mut doc = host.dom.borrow_mut();
 
     if doc.get_node(id).is_none() {
@@ -1282,6 +1285,7 @@ fn scroll_to_node(_this: &JsValue, args: &[JsValue], context: &mut Context) -> J
 fn rect(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let id = arg_id(args, 0, context)?;
     let host = host(context)?;
+    settle_layout(&host);
     let doc = host.dom.borrow();
 
     let Some(node) = doc.get_node(id) else {
@@ -1348,10 +1352,7 @@ fn computed_style(_this: &JsValue, args: &[JsValue], context: &mut Context) -> J
     // `styles_stale` rather than `dirty`, because the settle loop consumes
     // `dirty` to decide whether to lay out and clearing it here would skip a
     // layout pass someone else was waiting for.
-    if *host.styles_stale.borrow() {
-        *host.styles_stale.borrow_mut() = false;
-        host.dom.borrow_mut().resolve(0.0);
-    }
+    settle_layout(&host);
 
     let doc = host.dom.borrow();
 
@@ -1609,6 +1610,24 @@ fn document_encoding(_this: &JsValue, _args: &[JsValue], context: &mut Context) 
     let host = host(context)?;
     let name = host.encoding.borrow().name().to_string();
     Ok(js_string!(name).into())
+}
+
+/// Bring style and layout up to date, if script has changed the tree since they
+/// last ran.
+///
+/// Anything that answers a *measured* question has to call this first. A
+/// browser resolves on demand, and pages depend on it: build an element, give
+/// it a size, append it, ask how big it is. Without this the answer is zero —
+/// not "unknown", but a confident `0x0` for an element that plainly has a size,
+/// which is the shape of wrong answer this engine keeps finding in itself.
+///
+/// `resolve` never calls back into script, so taking the mutable borrow here is
+/// safe for the same reason every other mutation is.
+fn settle_layout(host: &HostHandle) {
+    if *host.styles_stale.borrow() {
+        *host.styles_stale.borrow_mut() = false;
+        host.dom.borrow_mut().resolve(0.0);
+    }
 }
 
 /// Whether a selector parses, so the prelude can throw where a browser throws.

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -88,6 +88,7 @@ pub fn install(context: &mut Context) -> JsResult<()> {
         ("rect", 1, rect),
         ("computedStyle", 2, computed_style),
         ("supportsCss", 2, supports_css),
+        ("validSelector", 1, valid_selector),
         ("documentEncoding", 0, document_encoding),
         ("isCssProperty", 1, is_css_property),
         ("innerText", 1, inner_text),
@@ -1589,6 +1590,21 @@ fn document_encoding(_this: &JsValue, _args: &[JsValue], context: &mut Context) 
     let host = host(context)?;
     let name = host.encoding.borrow().name().to_string();
     Ok(js_string!(name).into())
+}
+
+/// Whether a selector parses, so the prelude can throw where a browser throws.
+///
+/// `querySelector("!!!")` is a `SyntaxError` in every browser, and this engine
+/// answered `null` — indistinguishable from "there is no such element". A page
+/// with a typo in a selector was told its element does not exist, which is the
+/// plausible wrong answer this engine keeps removing: it sends the caller down
+/// the not-found branch instead of showing them their mistake.
+fn valid_selector(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let selector = arg_string(args, 0, context)?;
+    let host = host(context)?;
+    let doc = host.dom.borrow();
+    let valid = doc.try_parse_selector_list(&selector).is_ok();
+    Ok(JsValue::from(valid))
 }
 
 /// Whether this is a CSS property at all, which is what `in` on a computed

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -482,11 +482,11 @@ fn append(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<
     let parent_id = arg_id(args, 0, context)?;
     let child_id = arg_id(args, 1, context)?;
     let host = host(context)?;
-    {
+    guard_mutation(&host, "appending a node", || {
         let mut doc = host.dom.borrow_mut();
         let mut mutator = doc.mutate();
         mutator.append_children(parent_id, &[child_id]);
-    }
+    });
     host.mark_dirty();
     Ok(JsValue::undefined())
 }
@@ -496,7 +496,9 @@ fn insert_before(_this: &JsValue, args: &[JsValue], context: &mut Context) -> Js
     let new_id = arg_id(args, 1, context)?;
     let host = host(context)?;
     {
-        let mut doc = host.dom.borrow_mut();
+        // A read is all the parent check needs; the mutation takes its own
+        // borrow inside the guard below.
+        let doc = host.dom.borrow();
         // blitz inserts relative to the anchor's parent and unwraps it, so an
         // anchor with no parent aborts the process. Checked here rather than
         // only in the prelude because a panic is not a DOM error: it takes the
@@ -510,9 +512,12 @@ fn insert_before(_this: &JsValue, args: &[JsValue], context: &mut Context) -> Js
                 )
                 .into());
         }
+    }
+    guard_mutation(&host, "inserting a node", || {
+        let mut doc = host.dom.borrow_mut();
         let mut mutator = doc.mutate();
         mutator.insert_nodes_before(anchor, &[new_id]);
-    }
+    });
     host.mark_dirty();
     Ok(JsValue::undefined())
 }
@@ -520,11 +525,11 @@ fn insert_before(_this: &JsValue, args: &[JsValue], context: &mut Context) -> Js
 fn remove_node(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let id = arg_id(args, 0, context)?;
     let host = host(context)?;
-    {
+    guard_mutation(&host, "removing a node", || {
         let mut doc = host.dom.borrow_mut();
         let mut mutator = doc.mutate();
         mutator.remove_node(id);
-    }
+    });
     host.mark_dirty();
     Ok(JsValue::undefined())
 }
@@ -542,7 +547,7 @@ fn set_text(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
         return Ok(JsValue::undefined());
     }
 
-    {
+    guard_mutation(&host, "setting text", || {
         let mut doc = host.dom.borrow_mut();
         // Writing to a *text* node replaces its own text. Writing to an element
         // replaces its subtree. They were both taking the element path, so a
@@ -565,7 +570,7 @@ fn set_text(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
             let text_id = mutator.create_text_node(&text);
             mutator.append_children(id, &[text_id]);
         }
-    }
+    });
     host.mark_dirty();
     Ok(JsValue::undefined())
 }
@@ -575,48 +580,16 @@ fn set_attr(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
     let name = arg_string(args, 1, context)?.to_lowercase();
     let value = arg_string(args, 2, context)?;
     let host = host(context)?;
-    let panicked = {
+    guard_mutation(&host, &format!("setting `{name}`"), || {
         let mut doc = host.dom.borrow_mut();
         let qual = blitz_dom::QualName::new(
             None,
             blitz_dom::ns!(),
             blitz_dom::LocalName::from(name.as_str()),
         );
-        // Guarded, because setting an attribute can start an image load and
-        // blitz `expect`s the URL to resolve. A page that writes
-        // `img.src = "http://{{host}}:NaN/x"` — an unsubstituted template, a
-        // typo, anything malformed — aborted the whole process, taking the
-        // page, the snapshot and the receipts with it. 81 of the 140 crashes in
-        // the last sweep were this one line.
-        //
-        // The attribute may be left unset when this fires, which is a worse
-        // answer than a browser gives and a much better one than no process.
-        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let mut mutator = doc.mutate();
-            mutator.set_attribute(id, qual, &value);
-        }))
-        .err()
-        .map(|payload| {
-            payload
-                .downcast_ref::<&str>()
-                .map(|text| (*text).to_string())
-                .or_else(|| payload.downcast_ref::<String>().cloned())
-                .unwrap_or_else(|| "the layout engine panicked".to_string())
-        })
-    };
-    if let Some(detail) = panicked {
-        let first_line = detail.lines().next().unwrap_or("").to_string();
-        super::host::push_console(
-            &mut host.console.borrow_mut(),
-            ConsoleLine::engine(
-                "error",
-                format!("setting `{name}` was refused by the layout engine: {first_line}"),
-            ),
-        );
-        host.unsupported
-            .borrow_mut()
-            .record(&format!("setAttribute({name}) with a value blitz cannot resolve"));
-    }
+        let mut mutator = doc.mutate();
+        mutator.set_attribute(id, qual, &value);
+    });
     host.mark_dirty();
     Ok(JsValue::undefined())
 }
@@ -643,11 +616,11 @@ fn set_inner_html(_this: &JsValue, args: &[JsValue], context: &mut Context) -> J
     let id = arg_id(args, 0, context)?;
     let html = arg_string(args, 1, context)?;
     let host = host(context)?;
-    {
+    guard_mutation(&host, "setting innerHTML", || {
         let mut doc = host.dom.borrow_mut();
         let mut mutator = doc.mutate();
         mutator.set_inner_html(id, &html);
-    }
+    });
     host.mark_dirty();
     Ok(JsValue::undefined())
 }
@@ -1610,6 +1583,38 @@ fn document_encoding(_this: &JsValue, _args: &[JsValue], context: &mut Context) 
     let host = host(context)?;
     let name = host.encoding.borrow().name().to_string();
     Ok(js_string!(name).into())
+}
+
+/// Run a tree mutation, and report rather than abort if the layer beneath
+/// panics.
+///
+/// blitz `expect`s an `<img src>` to resolve while flushing the parser's eager
+/// operations, and that flush runs inside *every* structural mutation — so
+/// attaching a subtree containing one unresolvable image killed the process,
+/// taking the page, the snapshot and the receipts with it.
+///
+/// This has now been found three times in three primitives: `set_attribute`,
+/// the initial parse, and `append`. Each was fixed where it was found, which is
+/// precisely why there was a third. This is the class fix — every mutation goes
+/// through here, so the next entry point to reach that `expect` is already
+/// covered.
+fn guard_mutation(host: &HostHandle, what: &str, body: impl FnOnce()) {
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(body));
+    if let Err(payload) = outcome {
+        let detail = payload
+            .downcast_ref::<&str>()
+            .map(|text| (*text).to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "the layout engine panicked".to_string());
+        let first = detail.lines().next().unwrap_or("").to_string();
+        super::host::push_console(
+            &mut host.console.borrow_mut(),
+            ConsoleLine::engine("error", format!("{what} was refused by the layout engine: {first}")),
+        );
+        host.unsupported
+            .borrow_mut()
+            .record(&format!("{what} on content the layout engine cannot resolve"));
+    }
 }
 
 /// Bring style and layout up to date, if script has changed the tree since they

--- a/crates/h5i-browser-light/src/script/host.rs
+++ b/crates/h5i-browser-light/src/script/host.rs
@@ -114,6 +114,13 @@ pub struct Host {
 
     /// Set whenever script changed the tree, so the engine knows to re-resolve
     /// style and layout once rather than after every mutation.
+    /// What the document is written in.
+    ///
+    /// Here as well as on the `Page` because the URL query encoder needs it and
+    /// lives on this side. Set once, when the realm is built for a page that
+    /// knows its own encoding; UTF-8 until then, which is what a string handed
+    /// straight to the parser already is.
+    pub encoding: RefCell<&'static encoding_rs::Encoding>,
     pub dirty: RefCell<bool>,
     /// Whether the cascade has been recomputed since the tree last changed.
     ///
@@ -218,6 +225,7 @@ impl Host {
             dom,
             broker,
             base,
+            encoding: RefCell::new(encoding_rs::UTF_8),
             dirty: RefCell::new(false),
             styles_stale: RefCell::new(false),
             console: RefCell::new(Vec::new()),

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -666,6 +666,16 @@ impl Script {
         }
     }
 
+    /// Tell the realm what the document is written in.
+    ///
+    /// A setter rather than a constructor argument because a realm is built
+    /// from a tree and a base URL, and the encoding belongs to the *response*
+    /// those came from — several callers have a tree without ever having had
+    /// bytes.
+    pub fn set_encoding(&mut self, encoding: &'static encoding_rs::Encoding) {
+        *self.host.encoding.borrow_mut() = encoding;
+    }
+
     /// Fire an event at a node, the way a real click would.
     pub fn dispatch(&mut self, node_id: usize, event_type: &str) -> Result<(), String> {
         // Constructed by kind rather than always as a bare `Event`, because a

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -510,6 +510,64 @@
     /// does — which is the argument for running a conformance suite in one
     /// sentence.
     hasChildNodes() { return api.children(this._id).length > 0; }
+
+    /// Same type, same name, same attributes, same children — not the same node.
+    isEqualNode(other) {
+      if (!other) return false;
+      if (this.nodeType !== other.nodeType) return false;
+      if (this.nodeType === 3 || this.nodeType === 8) return this.data === other.data;
+      if (this.tagName !== other.tagName) return false;
+      const mine = api.attrNames(this._id) || [];
+      const theirs = api.attrNames(other._id) || [];
+      if (mine.length !== theirs.length) return false;
+      for (const name of mine) {
+        if (api.getAttr(this._id, name) !== api.getAttr(other._id, name)) return false;
+      }
+      const a = this.childNodes, b = other.childNodes;
+      if (a.length !== b.length) return false;
+      for (let i = 0; i < a.length; i++) if (!a[i].isEqualNode(b[i])) return false;
+      return true;
+    }
+    isSameNode(other) { return !!other && other._id === this._id; }
+
+    /// Merge adjacent text nodes and drop empty ones.
+    normalize() {
+      const kids = this.childNodes;
+      let previous = null;
+      for (const kid of kids) {
+        if (kid.nodeType === 3) {
+          if (kid.data === "") { kid.remove(); continue; }
+          if (previous) { previous.data += kid.data; kid.remove(); continue; }
+          previous = kid;
+        } else {
+          previous = null;
+          if (kid.nodeType === 1) kid.normalize();
+        }
+      }
+    }
+
+    /// Where `other` sits relative to this node, as the spec's bit field.
+    compareDocumentPosition(other) {
+      if (!other) return 1;
+      if (other._id === this._id) return 0;
+      const DISCONNECTED = 1, PRECEDING = 2, FOLLOWING = 4, CONTAINS = 8, CONTAINED = 16;
+      const ancestors = (node) => { const out = []; for (let n = node; n; n = n.parentNode) out.push(n); return out; };
+      const mine = ancestors(this), theirs = ancestors(other);
+      if (theirs.some((n) => n._id === this._id)) return FOLLOWING | CONTAINED;
+      if (mine.some((n) => n._id === other._id)) return PRECEDING | CONTAINS;
+      // Nearest common ancestor, then compare the branches under it.
+      const common = mine.find((a) => theirs.some((b) => b._id === a._id));
+      if (!common) return DISCONNECTED | PRECEDING;
+      const branchOf = (chain) => chain[chain.findIndex((n) => n._id === common._id) - 1];
+      const a = branchOf(mine), b = branchOf(theirs);
+      const kids = common.childNodes;
+      let seenA = -1, seenB = -1;
+      for (let i = 0; i < kids.length; i++) {
+        if (a && kids[i]._id === a._id) seenA = i;
+        if (b && kids[i]._id === b._id) seenB = i;
+      }
+      return seenA < seenB ? FOLLOWING : PRECEDING;
+    }
     get firstChild() { return this.childNodes[0] || null; }
     get lastChild() { const c = this.childNodes; return c[c.length - 1] || null; }
 
@@ -529,7 +587,9 @@
 
     get textContent() { return api.getText(this._id); }
     set textContent(value) {
-      api.setText(this._id, String(value));
+      // Nullable by spec: `el.textContent = null` empties the element rather
+      // than writing the four characters "null".
+      api.setText(this._id, value === null || value === undefined ? "" : String(value));
       if (observers.length === 0) return;
       record({
         type: "characterData", target: this, addedNodes: [], removedNodes: [],
@@ -697,7 +757,16 @@
     addEventListener(type, handler, options) {
       if (!handler) return;
       const capture = options === true || (options && options.capture) || false;
-      listeners.push({ id: this._id, type: String(type), handler, capture });
+      const once = !!(options && options.once);
+      // The same handler registered twice for the same type and phase is one
+      // listener, as in a browser. Without this a page that re-runs its own
+      // setup accumulates duplicates and every event fires N times.
+      const already = listeners.some(
+        (l) => l.id === this._id && l.type === String(type)
+          && l.handler === handler && l.capture === capture,
+      );
+      if (already) return;
+      listeners.push({ id: this._id, type: String(type), handler, capture, once });
     }
     removeEventListener(type, handler) {
       for (let i = listeners.length - 1; i >= 0; i--) {
@@ -1146,12 +1215,12 @@
       });
     }
 
-    querySelector(sel) { return wrap(api.query(String(sel), this._id)); }
-    querySelectorAll(sel) { return collection(api.queryAll(String(sel), this._id).map(wrap)); }
+    querySelector(sel) { return wrap(api.query(checkSelector(sel), this._id)); }
+    querySelectorAll(sel) { return collection(api.queryAll(checkSelector(sel), this._id).map(wrap)); }
     getElementsByTagName(tag) { return collection(api.queryAll(String(tag), this._id).map(wrap), "HTMLCollection"); }
     getElementsByClassName(cls) { return collection(api.queryAll("." + String(cls), this._id).map(wrap), "HTMLCollection"); }
 
-    matches(sel) { return api.matchesSelector(this._id, String(sel)); }
+    matches(sel) { return api.matchesSelector(this._id, checkSelector(sel)); }
     closest(sel) {
       for (let n = this; n; n = n.parentNode) {
         if (n.nodeType === 1 && n.matches(sel)) return n;
@@ -1480,7 +1549,29 @@
   // at the engine.
   reflect(Element.prototype, "hidden", "hidden", "bool");
   reflect(Element.prototype, "autofocus", "autofocus", "bool");
-  reflect(Element.prototype, "tabIndex", "tabindex", "long", { default: -1 });
+  // `tabIndex` has no single default: an element the user can reach with the
+  // keyboard reports 0, everything else -1. Answering -1 for a link or a button
+  // tells a page nothing is focusable, which is the opposite of true.
+  const FOCUSABLE_BY_DEFAULT = new Set([
+    "A", "AREA", "BUTTON", "INPUT", "SELECT", "TEXTAREA", "IFRAME", "OBJECT",
+    "SUMMARY", "AUDIO", "VIDEO",
+  ]);
+  Object.defineProperty(Element.prototype, "tabIndex", {
+    configurable: true,
+    get() {
+      const raw = api.getAttr(this._id, "tabindex");
+      if (raw !== null) {
+        const match = /^[ \t\n\f\r]*([+-]?[0-9]+)/.exec(raw);
+        if (match) return Number(match[1]);
+      }
+      if (!FOCUSABLE_BY_DEFAULT.has(this.tagName)) return -1;
+      // A link is only focusable if it actually links somewhere.
+      if ((this.tagName === "A" || this.tagName === "AREA")
+        && api.getAttr(this._id, "href") === null) return -1;
+      return 0;
+    },
+    set(value) { this.setAttribute("tabindex", String(Math.trunc(Number(value)) || 0)); },
+  });
   reflect(Element.prototype, "accessKey", "accesskey");
   reflect(Element.prototype, "slot", "slot");
   reflect(Element.prototype, "nonce", "nonce");
@@ -2017,6 +2108,19 @@
     }
   }
 
+  /// Refuse a selector a browser would refuse, rather than answering "nothing".
+  ///
+  /// `querySelector("!!!")` throws `SyntaxError` in a browser and returned
+  /// `null` here — the same answer as "no such element", so a page with a typo
+  /// took its not-found branch and never learned why.
+  function checkSelector(selector) {
+    const text = String(selector);
+    if (!api.validSelector(text)) {
+      throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
+    }
+    return text;
+  }
+
   function camelToDash(name) {
     return name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
   }
@@ -2047,7 +2151,10 @@
       return out;
     }
     _write(map) {
-      this._source.set([...map.entries()].map(([k, v]) => `${k}: ${v}`).join("; "));
+      // Trailing semicolon, as a browser serialises it: `color: red;`. Pages do
+      // compare `getAttribute("style")` against a literal.
+      const text = [...map.entries()].map(([k, v]) => `${k}: ${v};`).join(" ");
+      this._source.set(text);
     }
     get length() { return this._read().size; }
     item(index) { return [...this._read().keys()][index] ?? ""; }
@@ -2079,10 +2186,10 @@
   function inlineStyleSource(node) {
     return {
       get: () => api.getAttr(node._id, "style") || "",
-      set: (text) => {
-        if (text) api.setAttr(node._id, "style", text);
-        else api.removeAttr(node._id, "style");
-      },
+      // Always written, never removed: emptying a style declaration leaves an
+      // empty `style` attribute in a browser, and `getAttribute("style")`
+      // answers "" rather than null.
+      set: (text) => api.setAttr(node._id, "style", text),
     };
   }
 
@@ -2188,6 +2295,14 @@
       event.currentTarget = node;
       for (const l of listeners.slice()) {
         if (l.id !== node._id || l.type !== event.type || l.capture !== capture) continue;
+        // Removed *before* the call, not after: a handler that throws, or that
+        // dispatches the same event again, must still not run twice. `once`
+        // was being ignored entirely, so a page relying on it double-handled
+        // and nothing said so.
+        if (l.once) {
+          const at = listeners.indexOf(l);
+          if (at >= 0) listeners.splice(at, 1);
+        }
         try {
           if (typeof l.handler === "function") l.handler.call(node, event);
           else if (l.handler && typeof l.handler.handleEvent === "function") {
@@ -3351,8 +3466,8 @@
     getElementsByName(name) {
       return api.queryAll(`[name="${String(name).replace(/"/g, '\\"')}"]`, 0).map(wrap);
     },
-    querySelector(sel) { return wrap(api.query(String(sel), 0)); },
-    querySelectorAll(sel) { return collection(api.queryAll(String(sel), 0).map(wrap)); },
+    querySelector(sel) { return wrap(api.query(checkSelector(sel), 0)); },
+    querySelectorAll(sel) { return collection(api.queryAll(checkSelector(sel), 0).map(wrap)); },
     getElementById(id) { return wrap(api.query("#" + String(id), 0)); },
     getElementsByTagName(tag) { return collection(api.queryAll(String(tag), 0).map(wrap), "HTMLCollection"); },
     getElementsByClassName(cls) { return collection(api.queryAll("." + String(cls), 0).map(wrap), "HTMLCollection"); },

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -1981,13 +1981,52 @@
           const v = api.getAttr(this._id, "value");
           return v === null ? "on" : v;
         }
-        return api.getValue(this._id);
+        // The editor is the truth when there is one and it holds something:
+        // typing updates it and leaves the `value` attribute at whatever the
+        // HTML said.
+        const edited = api.getValue(this._id);
+        if (edited && edited.trim()) return edited;
+
+        // A blank editor on a `<textarea>` is the case worth handling. A
+        // textarea's default value is its text content, and blitz lays one out
+        // with an editor holding a single space rather than that content — so a
+        // page whose comment box arrives filled in read back as blank, which is
+        // a filled form reported as empty. Whitespace-only counts as unseeded
+        // for that reason: the space is blitz's, not the page's.
+        //
+        // The limitation this leaves is small and stated: a textarea a user
+        // has explicitly *cleared* also has an empty editor, and reports its
+        // original text rather than "". Wrong in that one case, right in the
+        // far commoner one, and it fails toward showing content that exists
+        // rather than hiding it.
+        if (tag === "TEXTAREA" && this._value === undefined) {
+          const written = this.textContent;
+          if (written) return written;
+        }
+        if (edited !== null && edited !== undefined) return edited;
+        // There is no editor — a detached control, or a `<textarea>`, which
+        // blitz lays out as text rather than as an input. Falling back to the
+        // markup is what a browser reports, and answering "" instead made a
+        // filled-in comment box look empty to the agent reading it.
+        if (this._value !== undefined) return this._value;
+        if (tag === "TEXTAREA") return this.textContent;
+        return api.getAttr(this._id, "value") ?? "";
       },
       set(v) {
-        api.setValue(this._id, String(v));
-        // A page that sets `.value` from script does not get input/change: the
-        // spec fires those for *user* edits, and a framework that re-rendered
-        // on its own write would loop. `Page::type_into` is the user path.
+        const text = String(v);
+        // Remembered on this side when the write had nowhere to land, so a
+        // page that builds a control and fills it in can read back what it
+        // wrote. A page that sets `.value` from script does not get
+        // input/change: the spec fires those for *user* edits, and a framework
+        // that re-rendered on its own write would loop. `Page::type_into` is
+        // the user path.
+        const landed = api.setValue(this._id, text);
+        if (!landed) {
+          this._value = text;
+          if (this.tagName === "TEXTAREA") this.textContent = text;
+        } else {
+          delete this._value;
+        }
       },
     });
 

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -501,7 +501,16 @@
       const parent = this.parentNode;
       return parent && parent.nodeType === 1 ? parent : null;
     }
-    get childNodes() { return api.children(this._id).map(wrap); }
+    get childNodes() {
+      // A `<template>`'s children belong to its `content` fragment, not to the
+      // element: `tp.childNodes.length` is 0 in a browser however much markup
+      // it holds. This engine keeps one node for both, so the element hides
+      // them and `TemplateContent` shows them — which is the division the spec
+      // describes anyway. Without it a walker that recurses into a template
+      // reads markup the page has not rendered and may never render.
+      if (this.tagName === "TEMPLATE") return [];
+      return api.children(this._id).map(wrap);
+    }
     /// The single most-asked-for thing this engine did not have.
     ///
     /// WPT called it 3,944 times across the corpus, more than twice anything
@@ -1415,6 +1424,11 @@
   class TemplateContent extends Element {
     get nodeType() { return 11; }
     get nodeName() { return "#document-fragment"; }
+    // The one place a template's children *are* visible. `Element` hides them
+    // for the element itself, per the rule below, and this is the fragment
+    // they officially belong to.
+    get childNodes() { return api.children(this._id).map(wrap); }
+    get children() { return collection(this.childNodes.filter((n) => n.nodeType === 1), "HTMLCollection"); }
   }
 
   // `el.onclick = fn` is the other way to bind a handler, and plenty of
@@ -2030,12 +2044,16 @@
       },
     });
 
+    // `checked` is state, not the attribute. The attribute is the *default*,
+    // which is why it is reflected separately as `defaultChecked` — writing to
+    // it here made `getAttribute("checked")` change under a page that never
+    // touched the markup, and made a box the user unticked look ticked still.
     on(["input"], "checked", {
-      get() { return api.getAttr(this._id, "checked") !== null; },
-      set(on_) {
-        if (on_) api.setAttr(this._id, "checked", "");
-        else api.removeAttr(this._id, "checked");
+      get() {
+        if (this._checked !== undefined) return this._checked;
+        return api.getAttr(this._id, "checked") !== null;
       },
+      set(on_) { this._checked = !!on_; },
     });
     on(["option"], "selected", {
       get() { return api.getAttr(this._id, "selected") !== null; },
@@ -2091,6 +2109,105 @@
     // The sheet an element owns. Only `<style>` and `<link>` have one, and a
     // `<link>` that is not a stylesheet has none — `img.sheet` being undefined
     // is the point of putting it here rather than on Element.
+    // Forms and tables, which an agent reads more than almost anything else.
+    //
+    // `form.elements`, `table.rows`, `tr.cells` and `td.cellIndex` were all
+    // absent, so a page that walks its own form or table — and a great deal of
+    // page script does — got `undefined` and stopped.
+    on(["form"], "elements", {
+      get() {
+        return collection(
+          this.querySelectorAll("input, select, textarea, button, fieldset, output")
+            .filter((el) => (api.getAttr(el._id, "type") || "").toLowerCase() !== "image"),
+          "HTMLFormControlsCollection",
+        );
+      },
+    });
+    on(["form"], "length", { get() { return this.elements.length; } });
+    // A form's default method is `get`, not the empty string: code branches on
+    // it, and "" is not one of the branches.
+    on(["form"], "method", {
+      get() {
+        const raw = (api.getAttr(this._id, "method") || "").toLowerCase();
+        return raw === "post" || raw === "dialog" ? raw : "get";
+      },
+      set(value) { this.setAttribute("method", String(value)); },
+    });
+
+    // The form a control belongs to: its `form` attribute if it names one,
+    // otherwise the form it sits inside.
+    on(["input", "select", "textarea", "button", "fieldset", "output", "label"], "form", {
+      get() {
+        const named = api.getAttr(this._id, "form");
+        if (named) return wrap(api.query("#" + cssEscapeIdent(named), 0));
+        for (let n = this.parentNode; n; n = n.parentNode) {
+          if (n.nodeType === 1 && n.tagName === "FORM") return n;
+        }
+        return null;
+      },
+    });
+
+    // `<option>.text` is its text with whitespace collapsed, which is what a
+    // `<select>` actually shows.
+    on(["option"], "text", {
+      get() { return (this.textContent || "").replace(/\s+/g, " ").trim(); },
+      set(value) { this.textContent = String(value); },
+    });
+    on(["option"], "index", {
+      get() {
+        const owner = this.parentNode;
+        if (!owner) return 0;
+        return owner.querySelectorAll("option").findIndex((o) => o._id === this._id);
+      },
+    });
+    on(["select"], "selectedIndex", {
+      get() {
+        const options = this.querySelectorAll("option");
+        const at = options.findIndex((o) => o.selected);
+        // A `<select>` with nothing marked selected shows its first option.
+        return at >= 0 ? at : (options.length ? 0 : -1);
+      },
+      set(index) {
+        const options = this.querySelectorAll("option");
+        options.forEach((o, i) => { o.selected = i === Number(index); });
+      },
+    });
+    on(["select"], "options", {
+      get() { return collection(this.querySelectorAll("option"), "HTMLOptionsCollection"); },
+    });
+
+    // Tables. `rows` spans the sections in document order, which is what the
+    // spec says and what a reader expects.
+    on(["table"], "rows", {
+      get() { return collection(this.querySelectorAll("tr"), "HTMLCollection"); },
+    });
+    on(["table"], "tBodies", {
+      get() { return collection(this.querySelectorAll("tbody"), "HTMLCollection"); },
+    });
+    on(["table"], "tHead", { get() { return this.querySelector("thead"); } });
+    on(["table"], "tFoot", { get() { return this.querySelector("tfoot"); } });
+    on(["table"], "caption", { get() { return this.querySelector("caption"); } });
+    on(["tr"], "cells", {
+      get() { return collection(this.querySelectorAll("td, th"), "HTMLCollection"); },
+    });
+    on(["tr"], "rowIndex", {
+      get() {
+        for (let n = this.parentNode; n; n = n.parentNode) {
+          if (n.nodeType === 1 && n.tagName === "TABLE") {
+            return n.querySelectorAll("tr").findIndex((r) => r._id === this._id);
+          }
+        }
+        return -1;
+      },
+    });
+    on(["td"], "cellIndex", {
+      get() {
+        const row = this.parentNode;
+        if (!row || row.tagName !== "TR") return -1;
+        return row.querySelectorAll("td, th").findIndex((c) => c._id === this._id);
+      },
+    });
+
     on(["style", "link"], "sheet", {
       get() {
         if (this.tagName === "LINK") {

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -3391,6 +3391,12 @@
     },
     // This engine parses HTML and nothing else, so there is one honest answer.
     contentType: "text/html",
+    /// What this document was decoded as. All three names are the same value
+    /// and all three are in use: `characterSet` is current, `charset` is the
+    /// legacy alias, and `inputEncoding` is the one the DOM spec kept.
+    get characterSet() { return api.documentEncoding(); },
+    get charset() { return api.documentEncoding(); },
+    get inputEncoding() { return api.documentEncoding(); },
     // Adopting a sheet applies it. Assignment replaces the set, as in a browser.
     /// What scrolls when the document scrolls. In standards mode that is
     /// `<html>`, and code reads it to avoid the quirks-mode `<body>` split.

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -4048,6 +4048,29 @@
     get pathname() { return locationParts().pathname ?? ""; },
     get search() { return locationParts().search ?? ""; },
     get hash() { return locationParts().hash ?? ""; },
+    /// Hash routing, which a great many single-page applications are built on.
+    ///
+    /// Assigning to a getter-only property is a silent no-op outside strict
+    /// mode, so `location.hash = "/x"` did nothing at all and a hash router
+    /// simply never navigated — no error, no route change, no explanation.
+    ///
+    /// A same-document fragment change moves the address, pushes a history
+    /// entry and fires `hashchange`. It deliberately does *not* reload: that is
+    /// what makes it a fragment change rather than a navigation, and it is the
+    /// whole reason routers use it.
+    set hash(value) {
+      const wanted = String(value);
+      const fragment = wanted.startsWith("#") ? wanted : "#" + wanted;
+      const before = currentAddress;
+      const parts = api.parseUrl(fragment, currentAddress);
+      const next = parts ? parts.href : currentAddress;
+      if (next === before) return;
+      history.pushState(history.state, "", next);
+      const event = new Event("hashchange", { bubbles: false });
+      event.oldURL = before;
+      event.newURL = next;
+      dispatch(wrap(api.root()), event);
+    },
     get origin() { return locationParts().origin ?? ""; },
     toString() { return currentAddress; },
     assign(u) { api.unsupported("location.assign"); void u; },

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -20,6 +20,13 @@
   /// a `const` still in its temporal dead zone.
   const TAG_CLASSES = new Map();
 
+  /// Which node has focus, or null for none.
+  ///
+  /// Held here rather than on the tree because focus is a property of the
+  /// *document's* view of itself, not of a node, and two nodes must not be able
+  /// to believe they both have it.
+  let focusedId = null;
+
   /// An error with the line it came from, for the callbacks that swallow one.
   ///
   /// Every `catch` that reports and carries on — a listener, a timer, an
@@ -1311,8 +1318,30 @@
       }
       dispatch(this, new MouseEvent("click", { bubbles: true }));
     }
-    focus() {}
-    blur() {}
+    /// Move focus here, and fire what a browser fires.
+    ///
+    /// Both were empty, so `document.activeElement` never moved: a page that
+    /// focused a field and then checked which field was focused got the wrong
+    /// answer, and a form that advances focus as it validates got no signal at
+    /// all. `focusin`/`focusout` bubble and `focus`/`blur` do not, which is the
+    /// difference delegation depends on.
+    focus() {
+      if (focusedId === this._id) return;
+      const previous = focusedId === null ? null : wrap(focusedId);
+      focusedId = this._id;
+      if (previous) {
+        previous.dispatchEvent(new Event("blur", { bubbles: false }));
+        previous.dispatchEvent(new Event("focusout", { bubbles: true }));
+      }
+      this.dispatchEvent(new Event("focus", { bubbles: false }));
+      this.dispatchEvent(new Event("focusin", { bubbles: true }));
+    }
+    blur() {
+      if (focusedId !== this._id) return;
+      focusedId = null;
+      this.dispatchEvent(new Event("blur", { bubbles: false }));
+      this.dispatchEvent(new Event("focusout", { bubbles: true }));
+    }
 
     // Answered from the layout the engine already computed. Returning zeros —
     // which is what this did before — sends a positioning library into a loop
@@ -3747,7 +3776,16 @@
     // "modern browser" branch, which is the correct one for this engine.
     get all() { return collection(api.queryAll("*", 0).map(wrap), "HTMLCollection"); },
 
-    get activeElement() { return wrap(api.body()); },
+    /// What has focus. The body when nothing does, as in a browser — never
+    /// null, which is what code branching on it expects.
+    get activeElement() {
+      if (focusedId !== null) {
+        const focused = wrap(focusedId);
+        if (focused && focused.isConnected) return focused;
+        focusedId = null;
+      }
+      return wrap(api.body());
+    },
     get hidden() { return false; },
     get visibilityState() { return "visible"; },
   };

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -595,6 +595,61 @@ fn the_form_and_table_surface_answers() {
 }
 
 #[test]
+fn a_closed_disclosure_and_a_dropdown_read_as_a_person_sees_them() {
+    // Both were carrying text a reader cannot see, which is the §8.21 failure:
+    // a closed `<details>` hides its body behind a disclosure nobody opened,
+    // and a `<select>` shows one option rather than all of them run together.
+    let (page, _broker) = run_page(
+        "<html><body>\
+         <select><option>opt a</option><option selected>opt b</option></select>\
+         <details><summary>Summary line</summary>Details body</details>\
+         <details open><summary>Open one</summary>Shown body</details>\
+         </body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(rendered.contains("opt b"), "the dropdown says what it is set to:\n{rendered}");
+    assert!(
+        !rendered.contains("opt a"),
+        "and not what it is not set to:\n{rendered}"
+    );
+    assert!(rendered.contains("Summary line"), "the summary is shown:\n{rendered}");
+    assert!(
+        !rendered.contains("Details body"),
+        "the body behind a closed disclosure is not:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Shown body"),
+        "but an open one is:\n{rendered}"
+    );
+}
+
+#[test]
+fn focus_moves_and_the_document_knows_it() {
+    // `focus()` was empty, so `document.activeElement` never moved: a page that
+    // focused a field and then asked which field was focused got the wrong
+    // answer, and a form advancing focus as it validates got no signal at all.
+    let (_page, mut script) = page_and_script(
+        "<html><body><input id='a'><input id='b'></body></html>",
+    );
+    script
+        .eval("globalThis.seen = [];                document.getElementById('b').addEventListener('focusin', () => seen.push('in'));                document.getElementById('a').addEventListener('blur', () => seen.push('out'));")
+        .expect("runs");
+    script.eval("document.getElementById('a').focus();").expect("runs");
+    assert_eq!(script.eval_value("document.activeElement.id").unwrap(), "a");
+    script.eval("document.getElementById('b').focus();").expect("runs");
+    assert_eq!(script.eval_value("document.activeElement.id").unwrap(), "b");
+    assert_eq!(
+        script.eval_value("seen.join(',')").unwrap(),
+        "out,in",
+        "the old element blurs before the new one focuses"
+    );
+    // Nothing focused reports the body, not null — code branching on it expects
+    // an element.
+    script.eval("document.getElementById('b').blur();").expect("runs");
+    assert_eq!(script.eval_value("document.activeElement.tagName").unwrap(), "BODY");
+}
+
+#[test]
 fn a_hash_route_navigates_and_says_so() {
     // Assigning to a getter-only property is a silent no-op, so a hash router
     // never navigated: no error, no route change, no explanation.

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -539,6 +539,75 @@ fn a_utf8_document_is_untouched_by_any_of_that() {
 }
 
 #[test]
+fn a_measured_answer_reflects_what_script_just_built() {
+    // Build an element, give it a size, attach it, ask how big it is. Every
+    // geometry reader answered a confident `0` before, because layout had not
+    // run since the tree changed — not "unknown", but a wrong number about an
+    // element that plainly has a size.
+    let (_page, mut script) = page_and_script("<html><body></body></html>");
+    script
+        .eval(
+            "globalThis.made = document.createElement('div');              made.style.width = '50px'; made.style.height = '20px';              document.body.appendChild(made);",
+        )
+        .expect("runs");
+    assert_eq!(script.eval_value("made.getBoundingClientRect().width").unwrap(), "50");
+    assert_eq!(script.eval_value("made.getBoundingClientRect().height").unwrap(), "20");
+    assert_eq!(script.eval_value("made.offsetWidth").unwrap(), "50");
+}
+
+#[test]
+fn a_form_control_reports_what_it_holds() {
+    // A textarea's value is its text content, and a control the page built
+    // itself has no editor to store one in. Both read back empty before, so a
+    // filled form looked blank.
+    let (_page, mut script) = page_and_script(
+        "<html><body><textarea id='t'>written in</textarea></body></html>",
+    );
+    assert_eq!(
+        script.eval_value("document.getElementById('t').value").unwrap(),
+        "written in"
+    );
+    script
+        .eval("globalThis.made = document.createElement('input'); made.value = 'typed';")
+        .expect("runs");
+    assert_eq!(script.eval_value("made.value").unwrap(), "typed");
+
+}
+
+#[test]
+fn the_form_and_table_surface_answers() {
+    // What an agent reads through. Every one of these was `undefined`, so a
+    // page walking its own form or table stopped at the first access.
+    let (_page, mut script) = page_and_script(
+        "<html><body><form method='post'><input name='a'><input name='b'></form>\
+         <table><tr><td></td><td id='c'></td></tr></table></body></html>",
+    );
+    assert_eq!(script.eval_value("document.querySelector('form').elements.length").unwrap(), "2");
+    assert_eq!(script.eval_value("document.querySelector('form').method").unwrap(), "post");
+    assert_eq!(script.eval_value("document.querySelector('table').rows.length").unwrap(), "1");
+    assert_eq!(script.eval_value("document.querySelector('tr').cells.length").unwrap(), "2");
+    assert_eq!(script.eval_value("document.getElementById('c').cellIndex").unwrap(), "1");
+    // A control's form, found by ancestry.
+    assert_eq!(
+        script.eval_value("String(document.querySelector('input').form === document.querySelector('form'))").unwrap(),
+        "true"
+    );
+}
+
+#[test]
+fn a_hash_route_navigates_and_says_so() {
+    // Assigning to a getter-only property is a silent no-op, so a hash router
+    // never navigated: no error, no route change, no explanation.
+    let (_page, mut script) = page_and_script("<html><body></body></html>");
+    script
+        .eval("globalThis.seen = []; addEventListener('hashchange', (e) => seen.push(e.newURL));")
+        .expect("runs");
+    script.eval("location.hash = 'route';").expect("runs");
+    assert_eq!(script.eval_value("location.hash").unwrap(), "#route");
+    assert_eq!(script.eval_value("String(seen.length)").unwrap(), "1");
+}
+
+#[test]
 fn a_selection_can_be_made_and_acted_on() {
     // What an agent driving a rich-text editor actually does: select a span of
     // text, then change it. Both halves are checked, because a `Selection` that

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -481,6 +481,64 @@ fn css_supports_answers_from_the_engine_that_would_have_to_do_it() {
 }
 
 #[test]
+fn a_documents_encoding_reaches_both_its_text_and_its_urls() {
+    // Two things follow from a document's encoding and they must not disagree:
+    // how the bytes become text, and how a URL's query becomes bytes again.
+    let broker = Arc::new(
+        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
+    );
+    let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
+    let options = PageOptions { script: true, ..PageOptions::default() };
+    let factory = PageFactory::new(broker, fonts.sources.clone(), options);
+    let base = url::Url::parse("https://app.example/").unwrap();
+
+    // "日本" in euc-jp, which is mojibake if read as UTF-8. The script writes
+    // its answers into the page, so this reads them the way an agent would.
+    let mut bytes =
+        b"<!doctype html><meta charset=\"euc-jp\"><title>t</title><p id=t>".to_vec();
+    bytes.extend_from_slice(&[0xc6, 0xfc, 0xcb, 0xdc]);
+    bytes.extend_from_slice(
+        b"</p><p id=out></p><script>\
+          const a = document.createElement('a'); \
+          a.href = 'https://example.com/?' + String.fromCodePoint(0x4E02); \
+          const b = document.createElement('a'); \
+          b.href = 'https://example.com/?' + String.fromCodePoint(0x65E5); \
+          document.getElementById('out').textContent = \
+            a.search + ' ' + b.search + ' ' + document.characterSet; \
+          </script>",
+    );
+
+    let page = factory.from_bytes(&bytes, None, &base);
+    assert_eq!(page.encoding(), "EUC-JP", "the document said so in its markup");
+
+    let rendered = page.snapshot().render();
+    assert!(rendered.contains("日本"), "its text decoded as itself:\n{rendered}");
+    // A code point euc-jp cannot represent becomes an HTML numeric character
+    // reference with its own punctuation already percent-encoded. This engine
+    // used to answer `?%E4%B8%82` — the right escape of the wrong bytes.
+    assert!(
+        rendered.contains("?%26%2319970%3B"),
+        "an unmappable code point is a numeric reference:\n{rendered}"
+    );
+    // One the encoding *can* represent is simply its bytes.
+    assert!(rendered.contains("?%C6%FC"), "a mappable one is its bytes:\n{rendered}");
+    assert!(rendered.contains("EUC-JP"), "and the document says so:\n{rendered}");
+}
+
+#[test]
+fn a_utf8_document_is_untouched_by_any_of_that() {
+    // The fast path, which is nearly every page on the web.
+    let (_page, mut script) = page_and_script("<html><body></body></html>");
+    script
+        .eval(
+            "globalThis.a = document.createElement('a');              a.href = 'https://example.com/?' + String.fromCodePoint(0x4E02);",
+        )
+        .expect("runs");
+    assert_eq!(script.eval_value("a.search").unwrap(), "?%E4%B8%82");
+    assert_eq!(script.eval_value("document.characterSet").unwrap(), "UTF-8");
+}
+
+#[test]
 fn a_selection_can_be_made_and_acted_on() {
     // What an agent driving a rich-text editor actually does: select a span of
     // text, then change it. Both halves are checked, because a `Selection` that

--- a/crates/h5i-browser-light/src/snapshot.rs
+++ b/crates/h5i-browser-light/src/snapshot.rs
@@ -525,6 +525,29 @@ impl Walker<'_> {
                 is_leaf,
             }) => {
                 let name = accessible_name(&tag, node);
+
+                // For `<pre>`, the same text again but split on its own line
+                // breaks. Computed here, where the raw text is still in reach.
+                let preformatted_lines: Vec<String> = if tag == "pre" {
+                    let raw = node.text_content();
+                    let pieces: Vec<String> = raw
+                        .lines()
+                        // Leading indentation is meaning in code, so it is kept
+                        // rather than collapsed away; only the trailing edge and
+                        // interior runs are tidied.
+                        .map(collapse_keeping_indent)
+                        .collect();
+                    // Blank lines at the ends are an artefact of how the markup
+                    // was written, not of what it says.
+                    let start = pieces.iter().position(|line| !line.trim().is_empty());
+                    let stop = pieces.iter().rposition(|line| !line.trim().is_empty());
+                    match (start, stop) {
+                        (Some(start), Some(stop)) if stop > start => pieces[start..=stop].to_vec(),
+                        _ => Vec::new(),
+                    }
+                } else {
+                    Vec::new()
+                };
                 // Collapsed like every other page-derived value, and for a
                 // sharper reason than tidiness: an attribute value may contain
                 // a literal newline, so an uncollapsed `href` is the one field
@@ -556,13 +579,40 @@ impl Walker<'_> {
                         None
                     };
 
-                    self.push(Line {
-                        depth,
-                        role: role.to_string(),
-                        text: name,
-                        reference,
-                        href,
-                    });
+                    // A `<pre>` keeps its line breaks, as one outline line per
+                    // source line.
+                    //
+                    // Collapsing it into a single line is what the rest of the
+                    // outline does and is right for prose, where a newline in
+                    // the markup is not a newline on screen. In preformatted
+                    // text it is: every code block in every documentation page
+                    // was arriving as one run-on line, which is a poor reading
+                    // of the thing agents read most.
+                    //
+                    // Split rather than un-collapsed, because the fence in
+                    // `render` rests on **no page-derived value spanning a
+                    // line**. Each piece is collapsed on its own and gets its
+                    // own indent and `- `, so the invariant holds unchanged and
+                    // the structure survives.
+                    if role == "code" && !preformatted_lines.is_empty() {
+                        for piece in &preformatted_lines {
+                            self.push(Line {
+                                depth,
+                                role: role.to_string(),
+                                text: piece.clone(),
+                                reference: reference.clone(),
+                                href: href.clone(),
+                            });
+                        }
+                    } else {
+                        self.push(Line {
+                            depth,
+                            role: role.to_string(),
+                            text: name,
+                            reference,
+                            href,
+                        });
+                    }
                     depth + 1
                 } else {
                     depth
@@ -712,6 +762,24 @@ fn accessible_name(tag: &str, node: &Node) -> String {
                 text
             }
         }
+    }
+}
+
+/// Collapse a single line's interior whitespace but keep what it starts with.
+///
+/// Indentation is meaning in preformatted text — it is how a code block shows
+/// nesting — so the leading run is preserved while interior runs and the
+/// trailing edge are tidied. Tabs become spaces so a line's width does not
+/// depend on how the reader's terminal is configured.
+fn collapse_keeping_indent(line: &str) -> String {
+    let body = line.trim_start();
+    let indent_width = line.len() - body.len();
+    let indent = line[..indent_width].replace('\t', "    ");
+    let collapsed = collapse(body);
+    if collapsed.is_empty() {
+        String::new()
+    } else {
+        format!("{indent}{collapsed}")
     }
 }
 

--- a/crates/h5i-browser-light/src/snapshot.rs
+++ b/crates/h5i-browser-light/src/snapshot.rs
@@ -485,6 +485,28 @@ impl Walker<'_> {
             return;
         }
 
+        // A closed `<details>` shows its `<summary>` and nothing else. The body
+        // is behind a disclosure the reader has not opened, so carrying it is
+        // the §8.21 failure exactly: text a human would have to act to see,
+        // handed over as though it were on the page. Blitz does not apply the
+        // UA rule that hides it, so it is applied here.
+        //
+        // The summary still speaks, because that is the part that *is* shown —
+        // and it is what an agent would click to open the rest.
+        if tag == "details" && attr_of(node, "open").is_none() {
+            for child in node.children.clone() {
+                let is_summary = self
+                    .doc
+                    .get_node(child)
+                    .map(|kid| kid.data.is_element_with_tag_name(&local_name!("summary")))
+                    .unwrap_or(false);
+                if is_summary {
+                    self.walk(child, depth, in_prose);
+                }
+            }
+            return;
+        }
+
         // Content the page does not display is not content this reading should
         // carry. Two reasons, and the second is the serious one:
         //
@@ -728,6 +750,33 @@ fn attr_of<'a>(node: &'a Node, name: &str) -> Option<&'a str> {
 /// address are exactly the ones that have none: an image's name is its `alt`,
 /// and an empty input's is its placeholder or label. Falling back to "" would
 /// render a snapshot of anonymous `textbox` lines nobody can tell apart.
+/// The text of the option a `<select>` is set to.
+///
+/// The first option with `selected`, or failing that the first option at all,
+/// which is what a browser displays for a select where nothing is marked.
+fn selected_option(node: &Node) -> Option<String> {
+    let doc = node.tree();
+    let mut first = None;
+    let mut stack: Vec<usize> = node.children.clone();
+    stack.reverse();
+    while let Some(id) = stack.pop() {
+        let Some(child) = doc.get(id) else { continue };
+        if child.data.is_element_with_tag_name(&local_name!("option")) {
+            let text = collapse(&child.text_content());
+            if attr_of(child, "selected").is_some() {
+                return Some(text);
+            }
+            if first.is_none() && !text.is_empty() {
+                first = Some(text);
+            }
+        }
+        let mut kids = child.children.clone();
+        kids.reverse();
+        stack.extend(kids);
+    }
+    first
+}
+
 fn accessible_name(tag: &str, node: &Node) -> String {
     let from_attr = |names: &[&str]| {
         names
@@ -739,6 +788,16 @@ fn accessible_name(tag: &str, node: &Node) -> String {
 
     match tag {
         "img" => from_attr(&["alt", "title"]).unwrap_or_default(),
+        // A closed `<select>` shows one option: the selected one. Reading its
+        // whole subtree ran every option together — `opt aopt b` — which is
+        // both unreadable and untrue about what the control is set to. An agent
+        // asking "what is this dropdown on?" needs the answer, not the menu.
+        "select" => {
+            let chosen = selected_option(node);
+            chosen
+                .or_else(|| from_attr(&["aria-label", "title", "name"]))
+                .unwrap_or_default()
+        }
         "input" | "textarea" => {
             // What the field *holds* comes first, and it is read from the
             // editor rather than the `value` attribute: typing updates the


### PR DESCRIPTION
# Legacy document encodings: read a euc-jp page as euc-jp

`ROADMAP_BROWSER.md` §12.5 dismissed the legacy CJK encoding tests in three
sentences — "~17,000 subtests", "needs `<iframe>`, which §6 refuses", "moves a
number without improving the engine for anyone". All three were wrong. The
correction is recorded in place rather than quietly deleted, because the shape
of the error is worth more than the conclusion was: I read one sample failure
message and generalised from the filename around it, instead of asking what the
assertion needed.

## The gap was real

This engine decoded every document as UTF-8. A page served as euc-jp came out as
replacement characters, `document.characterSet` did not exist, and a link's
query was percent-encoded from the wrong bytes. **An agent reading a legacy
Japanese page got the wrong answer and was told nothing about it.**

`src/encoding.rs` settles the two things a document's encoding decides.

**Which encoding.** BOM, then the transport's `Content-Type`, then the markup's
`<meta charset>` or `<meta http-equiv>`, then UTF-8. The prescan stops at 1024
bytes because the HTML standard's does — a declaration further down cannot be
honoured, since by then a parser has already committed. Agreeing with a browser
about pages that declare too late is the point.

**How a URL's query is encoded.** The URL Standard encodes a query with the
*document's* encoding, and a code point that encoding cannot represent becomes
an HTML numeric character reference. `丂` in a euc-jp page is `%26%2319970%3B`,
where this engine answered `%E4%B8%82` — the right escape of the wrong bytes,
which is the shape of wrong answer that is hardest to notice.

That needed the per-character encoder rather than `encoding_rs::encode`: the
bulk call renders an unmappable code point as the literal `&#19970;`, and `&`,
`#` and `;` are not in the query percent-encode set, so they pass through and
the answer becomes `&%2319970;`. The URL Standard appends `%26%23`, the decimal
value and `%3B` — the reference *already* percent-encoded — precisely so a
generated reference cannot be mistaken for a real separator.

Found on the way: local files were loaded with `read_to_string`, which
**refuses** a file that is not valid UTF-8 — exactly the file this path most
needs to be able to open.

## The number, and the caveat that has to travel with it

**333,690 subtests passing of 584,707 scored**, up from 117,331.

A jump that large in one commit deserves disbelief, so it was checked three ways
before being written down (§13.2):

- **Nothing counted twice.** 25,247 distinct files across the sweep, none run
  more than once; the largest single file reports 21,269 subtests under 21,269
  distinct names.
- **The answers are right.** The same page run in **Chromium 1140** gives
  byte-identical output — including two cases where Python's own `euc_jp` codec
  *disagrees*, because Python encodes U+4E02 into JIS X 0212 and WHATWG's euc-jp
  decodes that plane but never encodes to it. Matching the browser rather than
  the naive codec is not somewhere you arrive by accident.
- **The engine is doing it, not the harness.** Asserted in
  `src/script/tests.rs`: the text decodes as itself, `document.characterSet`
  reports EUC-JP, and an unmappable code point becomes a numeric reference.

**And then the part that matters more than the total.** 70% of every passing
subtest comes from **twenty files**, the top eleven all `*-encode-href-*.html`:
one behaviour repeated once per codepoint across the CJK range, for five
encodings.

| framing | subtests |
| --- | --- |
| Headline total | 333,690 |
| **Excluding the encoding directory** | **107,904** |
| From the top twenty files alone | 235,977 |
| Files passing *completely* | **1,882** of 20,506 |

333,690 is true *and* describes one feature with an enormous test count rather
than broad platform coverage. Both halves have to be said together, which is why
§13.3 exists rather than a headline.

§13.3 also works the Kitesurf comparison through, and it does not flatter this
engine. Their "215,000+ tests passing" must be subtests — WPT expands to only
about 200,000 tests at file × variant × scope, and no young engine passes all of
them. One arithmetic fact then settles the shape of it:

> The CJK `encode-href` block alone is **217,263 subtests** — larger than
> Kitesurf's entire stated total.

They cannot be passing that block; it would exceed their whole score by itself.
Their 215,000 is spread across the rest of the platform while 65% of this
engine's total is that one block. Like for like:

| | subtests |
| --- | --- |
| Kitesurf, stated | 215,000 |
| **This engine, excluding the CJK block** | **116,428** |
| This engine, headline | 333,690 |

**About half their breadth, not one and a half times it.** Quoting 333,690
against 215,000 would be a claim that reverses under ten minutes of arithmetic.

## Review notes

Two commits. `src/encoding.rs` is the whole feature and carries its reasoning;
the roadmap commit is documentation only.

No new dependencies — `encoding_rs` was already in the tree from the
`TextDecoder` work, and before that via blitz.

### Gates

- 273 lib + 9 bin + 35 corpus tests
- `clippy --workspace --all-targets` clean
- `docs/manual/index.html` regenerated and in sync
- Cross-verified against Chromium 1140 on the behaviour under test