### PR TITLE
fix: warn when H5I_AGENT is invalid

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -914,7 +914,7 @@ All optional; h5i ships with working defaults.
 
 | Variable | Purpose |
 |---|---|
-| `H5I_AGENT` | Agent identity used for the branch namespace and automatic runtime profile selection. Leading and trailing whitespace is trimmed; valid values contain 1–64 ASCII letters, digits, hyphens, or underscores. An unset value silently uses `human`; a present invalid value warns on stderr and falls back to `human`. |
+| `H5I_AGENT` | Which runtime a box is scoped to (`claude`, `codex`). Decides the env's branch namespace and the `agent` profile's credentials and egress. The namespace takes 1–64 ASCII letters, digits, hyphens, or underscores after trimming; unset is `human` silently, anything else warns on stderr and namespaces the box under `human`. |
 | `H5I_DEFAULT_ISOLATION` | Pin this clone's default tier when `--isolation` is not given. `--isolation auto` re-probes past it. |
 | `H5I_SECRET_<NAME>` | Default source for a secret grant `<NAME>`. Injected for one run, redacted from evidence, audited by fingerprint. |
 | `H5I_SKILL_DIR` | Where `h5i skill install` writes. |

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -914,7 +914,7 @@ All optional; h5i ships with working defaults.
 
 | Variable | Purpose |
 |---|---|
-| `H5I_AGENT` | Which runtime a box is scoped to (`claude`, `codex`). Decides the `agent` profile's credentials and egress. |
+| `H5I_AGENT` | Agent identity used for the branch namespace and automatic runtime profile selection. Leading and trailing whitespace is trimmed; valid values contain 1–64 ASCII letters, digits, hyphens, or underscores. An unset value silently uses `human`; a present invalid value warns on stderr and falls back to `human`. |
 | `H5I_DEFAULT_ISOLATION` | Pin this clone's default tier when `--isolation` is not given. `--isolation auto` re-probes past it. |
 | `H5I_SECRET_<NAME>` | Default source for a secret grant `<NAME>`. Injected for one run, redacted from evidence, audited by fingerprint. |
 | `H5I_SKILL_DIR` | Where `h5i skill install` writes. |

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1145,7 +1145,7 @@ container and microVM tiers do not share a terminal at all.</p>
 <tbody>
 <tr>
 <td><code>H5I_AGENT</code></td>
-<td>Which runtime a box is scoped to (<code>claude</code>, <code>codex</code>). Decides the <code>agent</code> profile's credentials and egress.</td>
+<td>Agent identity used for the branch namespace and automatic runtime profile selection. Leading and trailing whitespace is trimmed; valid values contain 1–64 ASCII letters, digits, hyphens, or underscores. An unset value silently uses <code>human</code>; a present invalid value warns on stderr and falls back to <code>human</code>.</td>
 </tr>
 <tr>
 <td><code>H5I_DEFAULT_ISOLATION</code></td>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1145,7 +1145,7 @@ container and microVM tiers do not share a terminal at all.</p>
 <tbody>
 <tr>
 <td><code>H5I_AGENT</code></td>
-<td>Agent identity used for the branch namespace and automatic runtime profile selection. Leading and trailing whitespace is trimmed; valid values contain 1–64 ASCII letters, digits, hyphens, or underscores. An unset value silently uses <code>human</code>; a present invalid value warns on stderr and falls back to <code>human</code>.</td>
+<td>Which runtime a box is scoped to (<code>claude</code>, <code>codex</code>). Decides the env's branch namespace and the <code>agent</code> profile's credentials and egress. The namespace takes 1–64 ASCII letters, digits, hyphens, or underscores after trimming; unset is <code>human</code> silently, anything else warns on stderr and namespaces the box under <code>human</code>.</td>
 </tr>
 <tr>
 <td><code>H5I_DEFAULT_ISOLATION</code></td>

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -374,6 +374,11 @@ pub enum EnvServiceCommands {
 /// Who is creating this env. `$H5I_AGENT` is injected per host (Claude Code
 /// sets `claude`, Codex sets `codex`); a human on a bare shell gets `human`.
 /// The identity scopes the env's branch namespace and the agent-in-box profile.
+///
+/// Unset is `human` and says nothing — that is the normal bare-shell case. A
+/// value that is present but unusable warns instead of falling through in
+/// silence, so a typo'd identity does not quietly scatter a run's envs into the
+/// `human` namespace, where the agent then fails to find them by their own name.
 fn agent_identity() -> String {
     match std::env::var("H5I_AGENT") {
         Err(std::env::VarError::NotPresent) => "human".to_string(),
@@ -394,6 +399,10 @@ fn agent_identity() -> String {
     }
 }
 
+/// The stderr line for a rejected `$H5I_AGENT`, returning the `human` fallback
+/// it announces. The offending value is deliberately not echoed: it is ambient
+/// input of unknown provenance, and a raw `\e[` in it would repaint the
+/// terminal. The rule is stated instead, which is what the reader needs anyway.
 fn warn_invalid_agent_identity() -> String {
     eprintln!(
         "{} invalid H5I_AGENT; expected 1-64 ASCII letters, digits, hyphens, or underscores; using 'human'",

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -375,15 +375,31 @@ pub enum EnvServiceCommands {
 /// sets `claude`, Codex sets `codex`); a human on a bare shell gets `human`.
 /// The identity scopes the env's branch namespace and the agent-in-box profile.
 fn agent_identity() -> String {
-    std::env::var("H5I_AGENT")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| {
-            !s.is_empty()
-                && s.len() <= 64
-                && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        })
-        .unwrap_or_else(|| "human".to_string())
+    match std::env::var("H5I_AGENT") {
+        Err(std::env::VarError::NotPresent) => "human".to_string(),
+        Ok(value) => {
+            let identity = value.trim();
+            if !identity.is_empty()
+                && identity.len() <= 64
+                && identity
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+            {
+                identity.to_string()
+            } else {
+                warn_invalid_agent_identity()
+            }
+        }
+        Err(std::env::VarError::NotUnicode(_)) => warn_invalid_agent_identity(),
+    }
+}
+
+fn warn_invalid_agent_identity() -> String {
+    eprintln!(
+        "{} invalid H5I_AGENT; expected 1-64 ASCII letters, digits, hyphens, or underscores; using 'human'",
+        style("warning:").yellow()
+    );
+    "human".to_string()
 }
 
 /// Is `source` a pull request spec (a number, `#number`, or a GitHub PR URL)?

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -355,6 +355,76 @@ fn create_builds_worktree_branch_policy_and_event() {
 }
 
 #[test]
+fn create_warns_for_invalid_agent_identity_without_contaminating_json() {
+    let r = Repo::new();
+    let create = |name: &str, agent: Option<&str>| {
+        let mut command = Command::new(H5I);
+        command
+            .args([
+                "box",
+                "create",
+                name,
+                "--isolation",
+                "workspace",
+                "--profile",
+                "default",
+                "--json",
+            ])
+            .current_dir(&r.dir);
+        match agent {
+            Some(value) => {
+                command.env("H5I_AGENT", value);
+            }
+            None => {
+                command.env_remove("H5I_AGENT");
+            }
+        }
+        command.output().expect("failed to run h5i")
+    };
+
+    let overlong = "a".repeat(65);
+    let cases = [
+        ("d", Some("codex.code"), "human", true),
+        ("s", Some("claude code"), "human", true),
+        ("e", Some(""), "human", true),
+        ("l", Some(overlong.as_str()), "human", true),
+        ("u", Some("雪"), "human", true),
+        ("v", Some("codex"), "codex", false),
+        ("t", Some(" codex "), "codex", false),
+        ("n", None, "human", false),
+    ];
+    for (name, value, expected_agent, should_warn) in cases {
+        let out = create(name, value);
+        assert_eq!(out.status.code(), Some(0), "{}", out_str(&out));
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&out.stdout).expect("create stdout must remain valid JSON");
+        assert_eq!(manifest["agent"], expected_agent);
+        assert_eq!(manifest["id"], format!("env/{expected_agent}/{name}"));
+        assert_eq!(
+            manifest["branch"],
+            format!("refs/heads/h5i/env/{expected_agent}/{name}")
+        );
+
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if should_warn {
+            assert_eq!(stderr.lines().count(), 1, "{stderr}");
+            assert!(stderr.contains("warning: invalid H5I_AGENT"), "{stderr}");
+            assert!(stderr.contains("using 'human'"), "{stderr}");
+            if let Some(value) = value {
+                if !value.is_empty() {
+                    assert!(
+                        !stderr.contains(value),
+                        "the invalid value must not be echoed: {stderr}"
+                    );
+                }
+            }
+        } else {
+            assert!(stderr.is_empty(), "unexpected warning: {stderr}");
+        }
+    }
+}
+
+#[test]
 fn create_audit_all_pins_capture_policy() {
     let r = Repo::new();
     r.h5i_ok(&["env", "create", "audit-all", "--audit", "all"]);

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -410,13 +410,14 @@ fn create_warns_for_invalid_agent_identity_without_contaminating_json() {
             assert_eq!(stderr.lines().count(), 1, "{stderr}");
             assert!(stderr.contains("warning: invalid H5I_AGENT"), "{stderr}");
             assert!(stderr.contains("using 'human'"), "{stderr}");
-            if let Some(value) = value {
-                if !value.is_empty() {
-                    assert!(
-                        !stderr.contains(value),
-                        "the invalid value must not be echoed: {stderr}"
-                    );
-                }
+            // Skip the empty-string case: it has nothing to look for, and
+            // `contains("")` is true for every haystack. Filtered rather than
+            // nested so the check reads as one condition on both editions.
+            if let Some(value) = value.filter(|v| !v.is_empty()) {
+                assert!(
+                    !stderr.contains(value),
+                    "the invalid value must not be echoed: {stderr}"
+                );
             }
         } else {
             assert!(stderr.is_empty(), "unexpected warning: {stderr}");


### PR DESCRIPTION
An invalid but present `H5I_AGENT` currently falls back to `human` without telling the user. Emit one warning on stderr when the value fails the existing identity grammar, while preserving the `human` fallback and successful create behavior.

Unset identities remain silent, valid values keep their current behavior, JSON stdout stays parseable, and the warning does not echo the invalid value. The integration test covers punctuation, whitespace, empty, overlong, non-ASCII, valid, trimmed, and unset identities. The manual now documents the validation and fallback behavior.

Closes #458

### Testing

- `cargo test --locked --no-default-features --test env_integration create_warns_for_invalid_agent_identity_without_contaminating_json -- --exact`
- `cargo test --locked --no-default-features --bin h5i`
- `cargo clippy --locked --no-default-features --bin h5i --test env_integration -- -D warnings`
- `cargo build --locked --no-default-features --bin h5i --test env_integration`
- `python scripts/gen_manual.py`
