### PR TITLE
fix: one stale worktree registration broke `box create` repo-wide

### DIFF
--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -1624,6 +1624,56 @@ fn manifest_worktree_name(agent: &str, slug: &str) -> String {
     format!("h5i-env-{agent}-{slug}")
 }
 
+/// The files a directory under `.git/worktrees/` must hold to be a worktree
+/// registration rather than a leftover. libgit2 requires all three before it
+/// will even list the entry (`is_worktree_dir`); git's own `worktree prune`
+/// drops an entry the moment `gitdir` is gone.
+const WORKTREE_REG_FILES: [&str; 3] = ["gitdir", "commondir", "HEAD"];
+
+/// Drop directories under `.git/worktrees/` that are not worktree
+/// registrations, and report how many went.
+///
+/// This is not tidiness, it is a prerequisite for creating *any* worktree.
+/// libgit2's `git_worktree_lookup` fails on such a directory, and
+/// `git_repository_foreach_worktree` propagates that failure as a **truthy**
+/// return (`error = lookup(...) < 0` — the comparison lands in `error`, so a
+/// failure arrives as `1`, never as `GIT_ENOTFOUND`). Its one caller is
+/// `git_branch_is_checked_out`, which reads `== 1` as "yes, checked out". So a
+/// single stale directory makes libgit2 answer *checked out* for **every**
+/// branch in the repository, and `git_worktree_add` then refuses every
+/// worktree with
+///
+/// ```text
+/// reference refs/heads/<branch> is already checked out
+/// ```
+///
+/// — a repo-wide, permanent break of `box create` caused by an empty directory
+/// nothing is using, reported against a branch that was created seconds ago
+/// and is checked out nowhere (libgit2 1.9.2 / git2 0.20). Sweeping first both
+/// heals a repo already in that state and keeps `create` from tripping over a
+/// leftover of its own.
+///
+/// Only invalid entries go. A *valid* registration whose working tree has
+/// vanished is left alone: it is still a worktree as far as git is concerned,
+/// and whether the env behind it is still wanted is `gc`/`rm`'s question, not
+/// this function's.
+fn sweep_invalid_worktree_registrations(repo: &Repository) -> usize {
+    let Ok(entries) = std::fs::read_dir(repo.commondir().join("worktrees")) else {
+        return 0;
+    };
+    let mut swept = 0;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || WORKTREE_REG_FILES.iter().all(|f| path.join(f).is_file()) {
+            continue;
+        }
+        if std::fs::remove_dir_all(&path).is_ok() {
+            swept += 1;
+        }
+    }
+    swept
+}
+
 /// Undo a half-built env if `create` fails before the manifest exists.
 ///
 /// Only that window needs it: once `manifest.json` is on disk the env is
@@ -1655,6 +1705,11 @@ impl Drop for CreateRollback<'_> {
             .args(["worktree", "prune", "--expire=now"])
             .current_dir(self.repo.commondir())
             .output();
+        // …and again without git: a half-written registration left by a
+        // `worktree_add` that failed part-way is the exact thing that poisons
+        // every later `create` (see `sweep_invalid_worktree_registrations`), so
+        // clearing it must not depend on a `git` binary being on PATH.
+        sweep_invalid_worktree_registrations(self.repo);
         if let Some(b) = &self.branch
             && let Ok(mut r) = self.repo.find_branch(b, git2::BranchType::Local)
         {
@@ -1690,14 +1745,37 @@ pub fn create(
     let branch_short = format!("{BRANCH_PREFIX}{agent}/{slug}");
     let branch_full = format!("refs/heads/{branch_short}");
     if dir.exists() {
-        return Err(H5iError::Metadata(format!(
-            "environment {id} already exists"
-        )));
+        // A directory with no `manifest.json` is not an environment — it is
+        // what a `create` that died before the manifest landed leaves behind.
+        // Reporting it as "already exists" sends the reader to `box rm`, which
+        // resolves envs *through* the manifest and so cannot see this one, and
+        // `list` cannot either: the name is simply burnt. An empty leftover has
+        // nothing in it to lose, so reclaim it and carry on; one that still
+        // holds a workspace is left for a human to look at, with the paths
+        // named rather than implied.
+        let orphan = !dir.join(MANIFEST_FILE).exists();
+        let has_work = dir.join(WORK_DIR).exists();
+        if orphan && !has_work {
+            std::fs::remove_dir_all(&dir).map_err(|e| H5iError::with_path(e, &dir))?;
+        } else if orphan {
+            return Err(H5iError::Metadata(format!(
+                "{} holds a workspace but no manifest — a leftover from a `create` that failed \
+                 part-way, which `h5i box rm` cannot resolve. Remove it by hand (and its branch, \
+                 `git branch -D {branch_short}`), or pick another name",
+                dir.display()
+            )));
+        } else {
+            return Err(H5iError::Metadata(format!(
+                "environment {id} already exists"
+            )));
+        }
     }
     if repo.find_reference(&branch_full).is_ok() {
         return Err(H5iError::Metadata(format!(
-            "branch {branch_full} already exists — `h5i box gc` keeps applied/aborted env \
-             branches for provenance; pick a new name"
+            "branch {branch_full} already exists with no environment {id} behind it — either \
+             `h5i box gc` kept it for provenance after the env was applied/aborted, or a `create` \
+             failed and left it. Reuse the name with `git branch -D {branch_short}` first, or \
+             pick a new one"
         )));
     }
 
@@ -1787,15 +1865,32 @@ pub fn create(
         let missing = sandbox::engine_tooling_missing(engine);
         if !missing.is_empty() {
             let (_, install) = engine.required_tooling();
+            // "pick another engine" has to name one that is actually *another*
+            // engine and actually runnable here — a hint that offers the engine
+            // the reader just failed on reads as a bug in the tool, and one that
+            // offers an equally-missing engine only costs them a second attempt.
+            let fallback = sandbox::BROWSER_ENGINES
+                .iter()
+                .copied()
+                .find(|e| *e != engine && sandbox::engine_tooling_missing(*e).is_empty());
+            let alternative = match fallback {
+                Some(e) => format!(
+                    "Then create the box again, or run it on the engine this host already has: \
+                     `--engine {}`.",
+                    e.as_str()
+                ),
+                None => "Then create the box again — no other browser engine is installed here \
+                         either, so there is nothing to fall back to (fail-closed)."
+                    .to_string(),
+            };
             return Err(H5iError::Metadata(format!(
                 "the `{}` profile is pinned to the `{}` engine, which needs {} on this host, \
-                 and it is not there.\n  Install with:  {}\n  \
-                 Then create the box again, or pick another engine with \
-                 `--engine chromium` (fail-closed).",
+                 and it is not there.\n  Install with:  {}\n  {}",
                 profile.name,
                 engine.as_str(),
                 missing.join(" and "),
-                install
+                install,
+                alternative
             )));
         }
     }
@@ -1812,6 +1907,26 @@ pub fn create(
 
     let work_path = dir.join(WORK_DIR);
     std::fs::create_dir_all(&dir).map_err(|e| H5iError::with_path(e, &dir))?;
+
+    // Armed *before* the branch and the worktree exist, not after they both do.
+    //
+    // The window it used to open on was the one that actually bites: making the
+    // worktree is the step most likely to fail (a poisoned registration
+    // directory, a full disk, a name git refuses), and failing there left the
+    // branch and `<env>/` behind with no manifest — so `list` showed nothing,
+    // `rm` could not resolve the name, and the same `create` retried reported
+    // "already exists" for an env that never existed. `branch` is filled in
+    // below only once `repo.branch` has actually created one (a detached box's
+    // repository lives inside `work` and goes with the directory).
+    let mut rollback = CreateRollback {
+        repo,
+        h5i_root,
+        dir: dir.clone(),
+        work: work_path.clone(),
+        worktree: manifest_worktree_name(agent, slug),
+        branch: None,
+        armed: true,
+    };
 
     // Where the code comes from decides the shape of the workspace.
     //
@@ -1842,8 +1957,14 @@ pub fn create(
         });
 
         repo.branch(&branch_short, &base_commit, false)?;
+        rollback.branch = Some(branch_short.clone());
         let wt_name = format!("h5i-env-{agent}-{slug}");
         {
+            // One directory under `.git/worktrees/` that is not a worktree makes
+            // libgit2 report *every* branch as already checked out, so the add
+            // below would fail for this env and every future one. Clear those
+            // before asking (see `sweep_invalid_worktree_registrations`).
+            sweep_invalid_worktree_registrations(repo);
             let branch_ref = repo.find_reference(&branch_full)?;
             let mut wt_opts = git2::WorktreeAddOptions::new();
             wt_opts.reference(Some(&branch_ref));
@@ -1867,19 +1988,9 @@ pub fn create(
     // `[service.*]` table, a persona source missing at the base revision), and
     // without a rollback their failure left a registered+locked worktree and a
     // branch that `create` refuses to reuse and `rm` cannot see, recoverable
-    // only by hand with `git worktree prune` and `git branch -D`.
-    //
-    // `CreateRollback` undoes exactly what has been built so far unless it is
+    // only by hand with `git worktree prune` and `git branch -D`. `rollback`,
+    // armed above, undoes exactly what has been built so far unless it is
     // disarmed once the manifest lands.
-    let mut rollback = CreateRollback {
-        repo,
-        h5i_root,
-        dir: dir.clone(),
-        work: work_path.clone(),
-        worktree: manifest_worktree_name(agent, slug),
-        branch: (!opts.source.is_detached()).then(|| branch_short.clone()),
-        armed: true,
-    };
 
     // Pin service declarations from the base worktree into an env-local,
     // box-immutable manifest, recording its digest (review #1). Always Some for
@@ -9333,6 +9444,17 @@ fn prune_workspace(repo: &Repository, h5i_root: &Path, m: &EnvManifest) -> Resul
         let mut opts = git2::WorktreePruneOptions::new();
         opts.valid(true).locked(true).working_tree(true);
         wt.prune(Some(&mut opts))?;
+    } else {
+        // `find_worktree` failing means the registration is there but no longer
+        // readable as a worktree — and leaving it is not the harmless no-op the
+        // early `if let Ok` reads as: libgit2 turns one such directory into
+        // "every branch is already checked out", which breaks `box create` for
+        // the whole repository (see `sweep_invalid_worktree_registrations`).
+        // Reclaiming the workspace has to reclaim that too.
+        let reg = repo.commondir().join("worktrees").join(m.worktree_name());
+        if reg.is_dir() && !WORKTREE_REG_FILES.iter().all(|f| reg.join(f).is_file()) {
+            std::fs::remove_dir_all(&reg).map_err(|e| H5iError::with_path(e, &reg))?;
+        }
     }
     let work = m.work_dir(h5i_root);
     if work.exists() {

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -47,7 +47,7 @@ use crate::error::H5iError;
 pub use crate::sandbox_policy::{
     agent_browser_binary, browser_light_binary, browser_read_grants, browser_tooling_present,
     chrome_binary, chrome_exec_patterns, engine_tooling_missing, AgentRuntime, AuditCapture,
-    BrowserEngine,
+    BrowserEngine, BROWSER_ENGINES,
     AuditPolicy, BackgroundHandle,
     BoxGitPath, ExecOutcome, HomeBind, InteractiveOutcome, IsolationClaim, NetMode, PrivateBind,
     PrivatePath, Profile, ResolvedPolicy, RoBind, SecretGrant, DEFAULT_WALL,

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -720,6 +720,19 @@ pub fn validate_browser_deny(entry: &str) -> Result<(), String> {
     ))
 }
 
+/// Every engine a profile may pin, in preference order (fidelity first).
+///
+/// A list rather than a derived iterator so that adding a variant to
+/// [`BrowserEngine`] and forgetting it here is a one-line diff to spot in
+/// review: the callers that walk it are the ones that pick a *fallback* engine
+/// for a host, and an engine missing from the walk is an engine the tool
+/// silently claims the host cannot run.
+pub const BROWSER_ENGINES: [BrowserEngine; 3] = [
+    BrowserEngine::Chromium,
+    BrowserEngine::Lightpanda,
+    BrowserEngine::H5iLight,
+];
+
 impl BrowserEngine {
     /// The spelling used in `.h5i/env.toml` and on `--engine`.
     pub fn as_str(&self) -> &'static str {

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -452,6 +452,100 @@ fn create_refuses_duplicates_and_bad_names() {
     }
 }
 
+/// A directory under `.git/worktrees/` that is not a worktree registration
+/// must not be able to stop `create` — for this env or any other.
+///
+/// libgit2's `git_worktree_lookup` fails on such a directory, and
+/// `git_repository_foreach_worktree` hands that failure up as `1` rather than
+/// as an error, which is exactly what `git_branch_is_checked_out` reads as
+/// "yes". So one leftover directory made libgit2 answer *checked out* for every
+/// branch in the repo, and `create` died on a branch it had made two lines
+/// earlier: `reference refs/heads/h5i/env/tester/... is already checked out`.
+/// Nothing about that message points at the leftover, and no amount of picking
+/// a different name gets past it — the repo is simply done creating boxes.
+///
+/// Several leftovers, not one: libgit2 filters the invalid entries out of
+/// `git_worktree_list` by removing them from a vector *while iterating it*, so
+/// adjacent entries survive the filter and reach the lookup that poisons the
+/// answer. A single leftover can slip through the same gap unnoticed.
+#[test]
+fn stale_worktree_registrations_do_not_break_create() {
+    let r = Repo::new();
+    let regs = r.dir.join(".git/worktrees");
+    for name in ["h5i-env-tester-gone", "stale-a", "stale-b", "stale-c"] {
+        std::fs::create_dir_all(regs.join(name)).unwrap();
+    }
+
+    r.h5i_ok(&["env", "create", "after-stale"]);
+    assert!(r.work("after-stale").join("README.md").exists());
+
+    // …and the leftovers are gone, so the next `create` is not walking back
+    // into the same hole.
+    for name in ["h5i-env-tester-gone", "stale-a", "stale-b", "stale-c"] {
+        assert!(
+            !regs.join(name).exists(),
+            "stale registration {name} should have been swept"
+        );
+    }
+    assert!(regs.join("h5i-env-tester-after-stale").is_dir());
+}
+
+/// A `create` that fails while making the worktree must leave nothing behind.
+///
+/// The branch is created immediately before the worktree, and the rollback used
+/// to be armed immediately *after* it — so a failure in between left a branch
+/// and an `<env>/` directory with no manifest. `list` resolves envs through the
+/// manifest and showed nothing; `rm` could not resolve the name either; and
+/// retrying the same name answered "already exists" for an env that had never
+/// existed. Three commands disagreeing about one box, none of them able to
+/// clear it.
+///
+/// The failure is forced by making `.git/worktrees` a regular file: git cannot
+/// register a worktree under it, and it fails at exactly that step.
+#[test]
+fn a_create_that_fails_at_the_worktree_leaves_no_branch_or_directory() {
+    let r = Repo::new();
+    std::fs::write(r.dir.join(".git/worktrees"), "not a directory\n").unwrap();
+
+    let out = r.h5i(&["env", "create", "halfmade"]);
+    assert!(!out.status.success(), "create must fail:\n{}", out_str(&out));
+
+    assert!(!r.env_dir("halfmade").exists(), "env dir must be rolled back");
+    let branches = out_str(&git(&r.dir, &["branch", "--list", "h5i/env/tester/*"]));
+    assert!(
+        branches.trim().is_empty(),
+        "branch must be rolled back, saw: {branches}"
+    );
+
+    // And the name is genuinely free again: not "already exists", not "branch
+    // already exists" — it just works.
+    std::fs::remove_file(r.dir.join(".git/worktrees")).unwrap();
+    r.h5i_ok(&["env", "create", "halfmade"]);
+}
+
+/// An `<env>/` directory with no manifest is not an environment, and `create`
+/// treats it as the leftover it is rather than reporting "already exists" for a
+/// box that `list` cannot show and `rm` cannot remove.
+#[test]
+fn create_reclaims_an_env_directory_left_without_a_manifest() {
+    let r = Repo::new();
+    std::fs::create_dir_all(r.env_dir("leftover")).unwrap();
+
+    r.h5i_ok(&["env", "create", "leftover"]);
+    assert!(r.env_dir("leftover").join("manifest.json").exists());
+
+    // A leftover that still holds a workspace is *not* silently reclaimed —
+    // there is something in it to lose, so it is reported with the paths named.
+    std::fs::create_dir_all(r.env_dir("held").join("work")).unwrap();
+    let out = r.h5i(&["env", "create", "held"]);
+    assert!(!out.status.success());
+    let text = out_str(&out);
+    assert!(
+        text.contains("holds a workspace but no manifest") && text.contains("git branch -D"),
+        "message should name the leftover and how to clear it: {text}"
+    );
+}
+
 #[test]
 fn create_pins_an_explicit_base_revision() {
     let r = Repo::new();


### PR DESCRIPTION
An empty directory under `.git/worktrees/` — the debris of a worktree that went away without its registration — made every `h5i box create` fail with

    reference refs/heads/h5i/env/<agent>/<slug> is already checked out

against a branch created two lines earlier and checked out nowhere. No name avoids it and nothing in the message points at the cause: the repository is simply done creating boxes.

libgit2's `git_worktree_lookup` fails on such a directory, and `git_repository_foreach_worktree` hands that failure up as `1` rather than as an error (`error = git_worktree_lookup(...) < 0` puts the comparison in `error`, so the `!= GIT_ENOTFOUND` guard can never match). Its one caller is `git_branch_is_checked_out`, which reads `== 1` as "yes". One leftover directory therefore makes libgit2 answer *checked out* for every branch in the repo. It takes more than one to bite: libgit2 filters invalid entries out of `git_worktree_list` by removing them from a vector while iterating it, so adjacent entries survive the filter and reach the poisoned lookup.

- Sweep directories under `.git/worktrees/` that are not registrations, before every worktree add and in the create rollback. Only invalid entries go; a valid registration whose working tree has vanished is gc/rm's business, not this function's.
- `prune_workspace` no longer treats an unreadable registration as a no-op — that early `if let Ok(wt)` is what left the poison behind.
- Arm `CreateRollback` before the branch and the worktree exist rather than after both do. Failing in between left a branch and an `<env>/` with no manifest: `list` showed nothing, `rm` could not resolve the name, and retrying it answered "already exists" for an env that never existed.
- Reclaim an `<env>/` left without a manifest instead of reporting it as an existing environment, and say what a leftover branch actually is.
- Stop offering `--engine chromium` to someone whose chromium engine is the one that is missing; name an engine that is both different and installed here, or say plainly that none is.