### PR TITLE
v0.3.4: actionable create errors and h5i join --bind for WSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "h5i"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ toml = { version = "0.8", features = ["parse", "display"] }
 # drives is `crates/h5i-core`.
 [package]
 name = "h5i"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 description = "h5i — disposable, confined development environments for AI coding agents (CLI)."
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -408,6 +408,7 @@ The other side runs:
 h5i join h5i1_eyJ2IjoxLCJib3hf…
 h5i join -                            # the same, with the ticket on stdin
 h5i join - --shared-jar               # on a machine with only 127.0.0.1 to offer
+h5i join - --bind 127.0.0.1           # WSL: the only loopback Windows can reach
 ```
 
 The share needs a live session of the box to dial into, not a live dev server.
@@ -457,6 +458,17 @@ join` refuses that jar unless you pass `--shared-jar`. If you would rather not,
 `sudo ifconfig lo0 alias 127.0.0.2` gives h5i an address to take instead, which
 lasts until you reboot. Keep that one for h5i: an address you also run your own
 services on is a jar shared with them, and h5i cannot tell why it is there.
+
+WSL is the case where the private address works against you. Windows forwards
+only `127.0.0.1` into the VM, so the address a join picks binds fine, the P2P
+path comes up, and the URL is still dead in every Windows browser: nothing on
+the Linux side fails. `h5i join` prints a warning when it sees this. The answer
+is `--bind 127.0.0.1`, which binds that address exactly and counts as
+shared-jar consent on its own, with the same cookie filter and the same
+caveats as `--shared-jar`. Any other loopback address given to `--bind` keeps
+a jar of its own. An address outside `127.0.0.0/8` is refused outright: the
+proxy is a door for one browser on this machine, never a way to republish the
+box to the network.
 
 Two things the joining proxy refuses outright. A service worker registration,
 because one would keep control of that address after the share ended. And a

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -1956,7 +1956,26 @@ pub fn create(
             .revparse_single(rev)
             .and_then(|o| o.peel_to_commit())
             .map_err(|e| {
-                H5iError::Metadata(format!("cannot resolve base revision '{rev}': {e}"))
+                // A fresh `git init` has a HEAD that names a branch with no
+                // commit behind it. "revspec 'HEAD' not found" is technically
+                // that, but only to a reader who already knows it — name the
+                // real precondition and the command that satisfies it. An
+                // explicit `--from` that fails keeps the literal diagnosis:
+                // there, "revision not found" is the right one.
+                let head_unborn = matches!(
+                    repo.head(),
+                    Err(ref he) if he.code() == git2::ErrorCode::UnbornBranch
+                );
+                if opts.from.is_none() && head_unborn {
+                    H5iError::Metadata(
+                        "this repository has no commits yet — the box branches from HEAD, \
+                         so make an initial commit first, e.g. \
+                         `git commit --allow-empty -m \"initial commit\"`"
+                            .into(),
+                    )
+                } else {
+                    H5iError::Metadata(format!("cannot resolve base revision '{rev}': {e}"))
+                }
             })?;
         let base_tree = base_commit.tree()?.id();
         let parent_branch = opts.parent_branch.clone().unwrap_or_else(|| {

--- a/crates/h5i-share/src/join.rs
+++ b/crates/h5i-share/src/join.rs
@@ -44,10 +44,11 @@ pub struct Joined {
     /// The ticket worked, but the share said something worth repeating: it is
     /// full, or the box has nothing listening on the shared port yet.
     pub warning: Option<String>,
-    /// This join had to fall back to `127.0.0.1`, so it shares a cookie jar
-    /// with every other local service. See [`bind_loopback`] for what that
-    /// costs. Reaching here at all means the joiner asked for it: `run` refuses
-    /// this case unless they said so on the command line.
+    /// This join is on `127.0.0.1`, so it shares a cookie jar with every
+    /// other local service. See [`bind_loopback`] for what that costs.
+    /// Reaching here at all means the joiner asked for it on the command
+    /// line: `--shared-jar` accepting the fallback, or `--bind 127.0.0.1`
+    /// naming the address outright.
     pub shared_jar: bool,
 }
 
@@ -140,6 +141,50 @@ async fn bind_loopback(port: u16) -> Result<(tokio::net::TcpListener, bool), H5i
     Ok((l, true))
 }
 
+/// Bind the address the joiner *chose*, or fall back to [`bind_loopback`].
+///
+/// An explicit address is bound exactly — no retries, no fallback: somebody
+/// who asked for `127.0.0.1` on purpose is not served better by silently
+/// getting a random private address, and the other way around. Loopback only,
+/// on this path as on every other: this proxy exists to give one browser on
+/// this machine a door, not to republish somebody else's box to the network.
+///
+/// Naming `127.0.0.1` by hand *is* the shared-jar consent. The flag exists so
+/// the person carrying the risk says so on the command line, and an explicit
+/// `--bind 127.0.0.1` says it at least as clearly as `--shared-jar` does —
+/// what it must not do is skip the machinery that consent buys: the
+/// [`crate::gate::AppCookies`] filter and the warning both key off the
+/// returned flag, so they engage here exactly as they do on the fallback.
+///
+/// WSL is where the explicit choice is real rather than a preference: Windows
+/// forwards only `127.0.0.1` into the VM, so the private address this proxy
+/// prefers binds fine — the fallback never fires, and `--shared-jar` alone
+/// changes nothing — and is then unreachable from every Windows browser.
+async fn bind_for(
+    bind: Option<std::net::Ipv4Addr>,
+    port: u16,
+    allow_shared_jar: bool,
+) -> Result<(tokio::net::TcpListener, bool), H5iError> {
+    let Some(addr) = bind else {
+        let (l, shared) = bind_loopback(port).await?;
+        if shared && !allow_shared_jar {
+            return Err(H5iError::Metadata(shared_jar_refusal()));
+        }
+        return Ok((l, shared));
+    };
+    if !addr.is_loopback() {
+        return Err(H5iError::Metadata(format!(
+            "{BIND_FLAG} {addr} is not a loopback address. This proxy gives one browser on \
+             this machine a door; binding beyond loopback would republish somebody else's \
+             box to the network. Pick an address in 127.0.0.0/8."
+        )));
+    }
+    let l = tokio::net::TcpListener::bind((addr, port))
+        .await
+        .map_err(|e| H5iError::Metadata(format!("could not bind {addr}:{port}: {e}")))?;
+    Ok((l, addr == std::net::Ipv4Addr::LOCALHOST))
+}
+
 /// Connect, bind, and serve until interrupted.
 ///
 /// `port` of 0 asks the operating system for a free one, which is the default:
@@ -148,6 +193,7 @@ async fn bind_loopback(port: u16) -> Result<(tokio::net::TcpListener, bool), H5i
 pub async fn run(
     ticket: Ticket,
     port: u16,
+    bind: Option<std::net::Ipv4Addr>,
     allow_shared_jar: bool,
     announce: impl FnOnce(&Joined),
 ) -> Result<String, H5iError> {
@@ -166,10 +212,7 @@ pub async fn run(
     // made in their name. Reaching the sharer first would spend one of their
     // share's slots and put a visitor on their receipt for a join that never
     // happened.
-    let (listener, shared_jar) = bind_loopback(port).await?;
-    if shared_jar && !allow_shared_jar {
-        return Err(H5iError::Metadata(shared_jar_refusal()));
-    }
+    let (listener, shared_jar) = bind_for(bind, port, allow_shared_jar).await?;
     let local = listener.local_addr()?;
 
     let endpoint = crate::p2p::bind_joiner().await?;
@@ -413,6 +456,10 @@ fn shared_jar_refusal() -> String {
 /// The flag that answers [`shared_jar_refusal`], named in one place so the
 /// message and the command line cannot drift apart.
 pub const SHARED_JAR_FLAG: &str = "--shared-jar";
+
+/// The flag that picks the proxy's address outright, same rule as
+/// [`SHARED_JAR_FLAG`]: named once so messages and the command line agree.
+pub const BIND_FLAG: &str = "--bind";
 
 /// What to say about a ticket that looks expired *on this machine*.
 ///
@@ -724,7 +771,7 @@ mod tests {
         // Checked here as well as by the sharer. The joiner should be told
         // plainly rather than watching a connection fail for reasons that look
         // like a network problem.
-        let err = run(ticket(1), 0, true, |_| {
+        let err = run(ticket(1), 0, None, true, |_| {
             panic!("must not get as far as announcing")
         })
         .await
@@ -756,7 +803,7 @@ mod tests {
         // about the ticket, and one that had expired would pass for the wrong
         // reason — the expiry check runs first.
         let good = ticket(chrono::Utc::now().timestamp() + 3600);
-        let err = run(good, 0, false, |_| {
+        let err = run(good, 0, None, false, |_| {
             panic!("a shared jar was announced instead of refused")
         })
         .await
@@ -764,6 +811,50 @@ mod tests {
         let said = format!("{err}");
         assert!(said.contains(SHARED_JAR_FLAG), "{said}");
         assert!(said.contains("127.0.0.1"), "{said}");
+    }
+
+    /// An explicit `--bind` is bound exactly, and choosing `127.0.0.1` by
+    /// name is itself the shared-jar consent — with the machinery consent
+    /// buys, not around it: the returned flag is what turns on the cookie
+    /// filter and the warning, so it must say `true` for `127.0.0.1` and
+    /// `false` for an address of the join's own.
+    #[tokio::test]
+    async fn an_explicit_bind_is_exact_and_names_its_own_consent() {
+        let localhost = std::net::Ipv4Addr::LOCALHOST;
+        let (l, shared) = bind_for(Some(localhost), 0, false)
+            .await
+            .expect("127.0.0.1 must bind everywhere");
+        assert_eq!(l.local_addr().unwrap().ip().to_string(), "127.0.0.1");
+        assert!(shared, "an explicit 127.0.0.1 must still engage the shared-jar machinery");
+
+        // A named address of the join's own keeps a private jar. Only where
+        // the host routes it — macOS without an lo0 alias cannot bind this,
+        // and that failure must be an error, not a silent fallback.
+        let own = std::net::Ipv4Addr::new(127, 0, 0, 7);
+        match bind_for(Some(own), 0, false).await {
+            Ok((l, shared)) => {
+                assert_eq!(l.local_addr().unwrap().ip().to_string(), "127.0.0.7");
+                assert!(!shared, "an address of the join's own is not a shared jar");
+            }
+            Err(e) => assert!(
+                format!("{e}").contains("127.0.0.7"),
+                "a failed explicit bind must name the address it could not bind: {e}"
+            ),
+        }
+    }
+
+    /// Beyond loopback is refused before anything is bound or dialled: this
+    /// proxy is a door for one browser on this machine, and no flag turns it
+    /// into a republisher.
+    #[tokio::test]
+    async fn a_bind_beyond_loopback_is_refused() {
+        let err = bind_for(Some(std::net::Ipv4Addr::new(192, 168, 1, 10)), 0, true)
+            .await
+            .expect_err("a non-loopback bind must refuse");
+        let said = format!("{err}");
+        assert!(said.contains(BIND_FLAG), "{said}");
+        assert!(said.contains("loopback"), "{said}");
+        assert!(said.contains("127.0.0.0/8"), "{said}");
     }
 
     /// What the refusal has to say, in the words of the person reading it.

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -609,6 +609,7 @@ h5i box share stop &lt;name&gt; --force            # delete the record, whatever
 <pre><code class="language-bash">h5i join h5i1_eyJ2IjoxLCJib3hf…
 h5i join -                            # the same, with the ticket on stdin
 h5i join - --shared-jar               # on a machine with only 127.0.0.1 to offer
+h5i join - --bind 127.0.0.1           # WSL: the only loopback Windows can reach
 </code></pre>
 <p>The share needs a live session of the box to dial into, not a live dev server.
 Starting one before the server is up warns and carries on. Visitors get a <code>502</code>
@@ -650,6 +651,16 @@ join</code> refuses that jar unless you pass <code>--shared-jar</code>. If you w
 <code>sudo ifconfig lo0 alias 127.0.0.2</code> gives h5i an address to take instead, which
 lasts until you reboot. Keep that one for h5i: an address you also run your own
 services on is a jar shared with them, and h5i cannot tell why it is there.</p>
+<p>WSL is the case where the private address works against you. Windows forwards
+only <code>127.0.0.1</code> into the VM, so the address a join picks binds fine, the P2P
+path comes up, and the URL is still dead in every Windows browser: nothing on
+the Linux side fails. <code>h5i join</code> prints a warning when it sees this. The answer
+is <code>--bind 127.0.0.1</code>, which binds that address exactly and counts as
+shared-jar consent on its own, with the same cookie filter and the same
+caveats as <code>--shared-jar</code>. Any other loopback address given to <code>--bind</code> keeps
+a jar of its own. An address outside <code>127.0.0.0/8</code> is refused outright: the
+proxy is a door for one browser on this machine, never a way to republish the
+box to the network.</p>
 <p>Two things the joining proxy refuses outright. A service worker registration,
 because one would keep control of that address after the share ended. And a
 request that fetch metadata says came from another page, including one from

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -930,7 +930,7 @@ Open a box someone else is sharing, from a ticket they sent you
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBjoin\fR [\fB\-\-port\fR] [\fB\-\-shared\-jar\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fITICKET\fR> 
+\fBjoin\fR [\fB\-\-port\fR] [\fB\-\-shared\-jar\fR] [\fB\-\-bind\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fITICKET\fR> 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
@@ -944,6 +944,11 @@ Join even when the only address left is `127.0.0.1`.
 Each join normally gets a loopback address of its own, because a browser\*(Aqs cookie jar is scoped by host and ignores the port. On `127.0.0.1` the jar is shared with every local service you run, so the token this proxy sets is sent to any of them you visit while joined \(em and that token reaches the box. macOS configures only `127.0.0.1` on `lo0`, so this is the macOS answer unless you add an address yourself (`sudo ifconfig lo0 alias 127.0.0.2`).
 
 Your own cookies are not the other half of this: they are filtered on a shared jar whether or not you pass this, and only cookies the box set itself are ever sent back to it.
+.TP
+\fB\-\-bind\fR \fI<ADDR>\fR
+Serve on this loopback address instead of a random `127.x.y.z`.
+
+The address is bound exactly \(em no fallback \(em and only loopback (`127.0.0.0/8`) is accepted. This is the WSL answer: Windows forwards only `127.0.0.1` into the VM, so the private address a join normally picks binds fine and is then unreachable from a Windows browser. `\-\-bind 127.0.0.1` counts as shared\-jar consent by itself and carries the same cookie caveats as \-\-shared\-jar; any other loopback address keeps a cookie jar of its own.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH h5i 1  "h5i 0.3.3" 
+.TH h5i 1  "h5i 0.3.4" 
 .SH NAME
 h5i \- Disposable, confined development environments for coding agents
 .SH SYNOPSIS
@@ -40,7 +40,7 @@ Generate the roff man page from the CLI definition (so it never drifts from the 
 h5i\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.3.3
+v0.3.4
 .SH "H5I BOX"
 Disposable, confined development boxes. `h5i box` with no verb creates one from the current repository; `h5i box --help` has the verb table
 .ie \n(.g .ds Aq \(aq

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -511,7 +511,7 @@ pub fn name_from_url(url: &str) -> anyhow::Result<String> {
 /// slugified, with a numeric suffix when that name is taken. Deterministic
 /// enough to predict, unique enough to keep two boxes off one name.
 pub fn default_box_name() -> anyhow::Result<String> {
-    let repo = git2::Repository::discover(".")?;
+    let repo = super::discover_repo("h5i box")?;
     let branch = repo
         .head()
         .ok()
@@ -536,7 +536,7 @@ fn slugify(s: &str) -> String {
 
 /// `base`, or `base-2`, `base-3`, … — the first name no box has taken.
 pub fn free_box_name(base: &str) -> anyhow::Result<String> {
-    let repo = git2::Repository::discover(".")?;
+    let repo = super::discover_repo("h5i box")?;
     let h5i_root = h5i_core::storage::h5i_root_for_repo(&repo)?;
     let base = if base.is_empty() { "box" } else { base };
     let taken: std::collections::HashSet<String> = h5i_core::env::list(&h5i_root)
@@ -682,7 +682,7 @@ fn run_cache(
 
 pub fn run(action: BoxCommands) -> anyhow::Result<()> {
     {
-            let git_repo = git2::Repository::discover(".")?;
+            let git_repo = super::discover_repo("h5i box")?;
             let h5i_root = h5i_core::storage::h5i_root_for_repo(&git_repo)?;
             h5i_core::storage::ensure_layout(&h5i_root)?;
             let git = &git_repo;

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -40,7 +40,7 @@ pub enum BrowserCommands {
 }
 
 pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
-    let repo = git2::Repository::discover(".")?;
+    let repo = super::discover_repo("h5i browser")?;
     let h5i_root = h5i_core::storage::h5i_root_for_repo(&repo)?;
 
     let dir_of = |name: &str| -> anyhow::Result<std::path::PathBuf> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,3 +21,20 @@ pub mod skill;
 // `--no-default-features` binary has no `ui` verb rather than a broken one.
 #[cfg(feature = "web")]
 pub mod ui;
+
+/// `Repository::discover(".")` with an actionable failure. Every verb here
+/// stores its state relative to the enclosing repository, so outside one there
+/// is nothing to act on — and libgit2's raw `class=…; code=…` error names
+/// neither that precondition nor what to do about it.
+pub fn discover_repo(verb: &str) -> anyhow::Result<git2::Repository> {
+    git2::Repository::discover(".").map_err(|e| {
+        if e.code() == git2::ErrorCode::NotFound {
+            anyhow::anyhow!(
+                "`{verb}` needs to run inside a git repository — cd into your project, \
+                 or create one with `git init`"
+            )
+        } else {
+            e.into()
+        }
+    })
+}

--- a/src/cli/share.rs
+++ b/src/cli/share.rs
@@ -138,7 +138,7 @@ fn parse_expire(s: &str) -> anyhow::Result<Duration> {
 }
 
 fn root() -> anyhow::Result<(git2::Repository, std::path::PathBuf)> {
-    let repo = git2::Repository::discover(".")?;
+    let repo = super::discover_repo("h5i box share")?;
     let root = h5i_core::storage::h5i_root_for_repo(&repo)?;
     Ok((repo, root))
 }

--- a/src/cli/share.rs
+++ b/src/cli/share.rs
@@ -632,12 +632,29 @@ fn ticket_text(arg: &str) -> anyhow::Result<String> {
 /// --tunnel` and no `join`, which is the correct shape — the person on the
 /// other end of a tunnel opens a link in a browser and needs no h5i at all.
 #[cfg(feature = "share")]
-pub fn join(ticket: &str, port: u16, shared_jar: bool) -> anyhow::Result<()> {
+/// Whether this process runs inside WSL, where Windows forwards only
+/// `127.0.0.1` into the VM: any other loopback address binds fine here and is
+/// then unreachable from a Windows browser — with nothing failing on this
+/// side to say so.
+fn under_wsl() -> bool {
+    std::env::var_os("WSL_DISTRO_NAME").is_some()
+        || std::env::var_os("WSL_INTEROP").is_some()
+        || std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|s| s.to_ascii_lowercase().contains("microsoft"))
+            .unwrap_or(false)
+}
+
+pub fn join(
+    ticket: &str,
+    port: u16,
+    bind: Option<std::net::Ipv4Addr>,
+    shared_jar: bool,
+) -> anyhow::Result<()> {
     let ticket = h5i_share::ticket::Ticket::decode(&ticket_text(ticket)?)?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-    let ending = runtime.block_on(h5i_share::join::run(ticket, port, shared_jar, |joined| {
+    let ending = runtime.block_on(h5i_share::join::run(ticket, port, bind, shared_jar, |joined| {
         // Sanitised, because this string came out of a ticket somebody pasted.
         // `ticket::decode` validates the version, the base64, the JSON shape
         // and the secret's width, and nothing about `box_id` — so a `\r` or an
@@ -666,6 +683,20 @@ pub fn join(ticket: &str, port: u16, shared_jar: bool) -> anyhow::Result<()> {
             ),
             Some(h5i_share::bridge::Path::Tunnel) => println!("   path      through a tunnel"),
             None => println!("   path      settling — end-to-end encrypted either way"),
+        }
+        // Said here, at the moment it bites, because nothing on this side
+        // fails: the bind succeeds, the P2P path comes up, and the URL is
+        // simply dead in a Windows browser. `path: direct` above makes it look
+        // healthy, which is exactly why the person staring at a blank tab
+        // needs the one fact this machine has and their browser does not.
+        if !joined.shared_jar && under_wsl() {
+            println!(
+                "   {} this is WSL: Windows forwards only 127.0.0.1 into it, so a Windows \
+                 browser cannot reach this address. If the page will not load there, stop \
+                 this join (Ctrl-C) and rerun with `{} 127.0.0.1`.",
+                WARN,
+                h5i_share::join::BIND_FLAG
+            );
         }
         // Said plainly, because the person joining is the one taking this risk
         // and they are not the one who chose to.

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -9,7 +9,7 @@ use console::style;
 pub fn run(port: u16, open: bool) -> anyhow::Result<()> {
     // Discover from the cwd so the console shows the fleet of the repository
     // the human is standing in, exactly like every other verb.
-    let repo = git2::Repository::discover(".")?;
+    let repo = super::discover_repo("h5i ui")?;
     let repo_path = repo
         .workdir()
         .ok_or_else(|| anyhow::anyhow!("h5i ui requires a non-bare repository"))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,17 @@ enum Commands {
         /// box set itself are ever sent back to it.
         #[arg(long)]
         shared_jar: bool,
+        /// Serve on this loopback address instead of a random `127.x.y.z`.
+        ///
+        /// The address is bound exactly — no fallback — and only loopback
+        /// (`127.0.0.0/8`) is accepted. This is the WSL answer: Windows
+        /// forwards only `127.0.0.1` into the VM, so the private address a
+        /// join normally picks binds fine and is then unreachable from a
+        /// Windows browser. `--bind 127.0.0.1` counts as shared-jar consent
+        /// by itself and carries the same cookie caveats as --shared-jar;
+        /// any other loopback address keeps a cookie jar of its own.
+        #[arg(long, value_name = "ADDR")]
+        bind: Option<std::net::Ipv4Addr>,
     },
 
     /// Write or print the agent skill this binary carries.
@@ -270,7 +281,8 @@ fn main() -> anyhow::Result<()> {
             ticket,
             port,
             shared_jar,
-        } => cli::share::join(&ticket, port, shared_jar)?,
+            bind,
+        } => cli::share::join(&ticket, port, bind, shared_jar)?,
         Commands::Skill { action } => cli::skill::run(action)?,
         Commands::Completion { shell } => cli::completion::run(shell)?,
         Commands::Man => cli::man::run()?,

--- a/tests/env_integration.rs
+++ b/tests/env_integration.rs
@@ -453,6 +453,67 @@ fn create_refuses_duplicates_and_bad_names() {
     }
 }
 
+/// The two states a brand-new user meets before git is ready — no repository
+/// at all, and a `git init` with no commit behind HEAD — must answer with the
+/// command that fixes them. Both used to leak libgit2's diagnosis
+/// (`could not find repository at '.'; class=Repository (6)` and
+/// `revspec 'HEAD' not found`), which names neither the precondition nor
+/// what to do about it.
+#[test]
+fn create_names_the_fix_when_there_is_no_repo_or_no_commit() {
+    let h5i_in = |dir: &Path, args: &[&str]| -> Output {
+        Command::new(H5I)
+            .args(args)
+            .env("H5I_AGENT", "tester")
+            .env("H5I_DEFAULT_ISOLATION", "workspace")
+            .current_dir(dir)
+            .output()
+            .expect("failed to run h5i")
+    };
+
+    // Outside any repository: name the requirement and the way in.
+    let no_repo = TempDir::new().expect("tempdir");
+    let out = h5i_in(no_repo.path(), &["env", "create", "test"]);
+    assert!(!out.status.success(), "create outside a repo must refuse");
+    let said = out_str(&out);
+    assert!(
+        said.contains("needs to run inside a git repository") && said.contains("git init"),
+        "no-repo refusal must name the fix, said: {said}"
+    );
+    assert!(
+        !said.contains("class="),
+        "libgit2 internals must not leak: {said}"
+    );
+
+    // A fresh `git init` with an unborn HEAD: say what is missing — a commit —
+    // and how to make one, rather than "revspec 'HEAD' not found".
+    let unborn = TempDir::new().expect("tempdir");
+    run_ok(Command::new("git").args(["init", "-b", "main"]).arg(unborn.path()));
+    let out = h5i_in(unborn.path(), &["env", "create", "test"]);
+    assert!(!out.status.success(), "create on an unborn HEAD must refuse");
+    let said = out_str(&out);
+    assert!(
+        said.contains("no commits yet") && said.contains("--allow-empty"),
+        "unborn-HEAD refusal must name the fix, said: {said}"
+    );
+
+    // An explicit `--from` that does not resolve keeps the literal diagnosis:
+    // there, "revision not found" is the correct one, and rewording it as
+    // "make a commit" would point at the wrong problem.
+    let r = Repo::new();
+    let out = r.h5i(&["env", "create", "test", "--from", "deadbeef"]);
+    assert!(!out.status.success(), "an unknown --from must refuse");
+    let said = out_str(&out);
+    assert!(
+        said.contains("cannot resolve base revision 'deadbeef'"),
+        "an explicit --from keeps the literal diagnosis, said: {said}"
+    );
+    assert!(
+        !said.contains("no commits yet"),
+        "a repo with commits must not be told it has none: {said}"
+    );
+}
+
 /// A directory under `.git/worktrees/` that is not a worktree registration
 /// must not be able to stop `create` — for this env or any other.
 ///


### PR DESCRIPTION
Bumps the version to 0.3.4, makes the two errors a brand-new user hits first actually say what to do, and adds `h5i join --bind` so WSL users can reach their join from a Windows browser.

## Error messages

`h5i box create` outside a repository leaked libgit2's raw diagnosis (`could not find repository at '.'; class=Repository (6); code=NotFound (-3)`), and in a fresh `git init` repo it said `revspec 'HEAD' not found`. Neither names the precondition, let alone the fix.

- A shared `discover_repo(verb)` helper in the CLI turns the not-found discover failure into: needs to run inside a git repository, cd into your project or create one with `git init`. Every repo-discovering verb uses it (`box`, `browser`, `ui`, `box share`), each naming itself in the message. Other discover failures still surface the underlying error.
- `env::create` now detects the unborn-HEAD case (no commits yet, and no explicit `--from`) and says so, naming `git commit --allow-empty -m "initial commit"` as the way forward. An explicit `--from` that fails keeps the literal "cannot resolve base revision" diagnosis, because there "revision not found" is the correct one.

## `h5i join --bind`

Windows forwards only `127.0.0.1` into WSL, so the private `127.x.y.z` a join picks binds fine, the P2P path comes up, and the URL is dead in every Windows browser with nothing failing on the Linux side. `--shared-jar` never helps there: it only permits the `127.0.0.1` fallback, and on Linux the private bind always succeeds.

- `--bind <addr>` binds the named address exactly, no fallback. Loopback only: anything outside `127.0.0.0/8` is refused, since that would republish the box to the network.
- `--bind 127.0.0.1` counts as shared-jar consent by itself and still engages what consent buys (the app-cookie filter and the warning key off the same flag as the fallback). `--shared-jar` keeps its existing meaning untouched.
- Because nothing fails locally, `h5i join` now prints a hint under WSL when the URL is not on `127.0.0.1`, naming the rerun that will work.

## Tests

- Integration test driving the compiled binary through the three create paths: no repository (also asserting no `class=` internals leak), unborn HEAD, and a bad `--from` that must keep the literal diagnosis.
- Unit tests for `--bind`: exact bind, `127.0.0.1` reporting the shared jar, private addresses keeping their own, and non-loopback refused with the flag named.

## Release

- `0.3.3` to `0.3.4` in `Cargo.toml`/`Cargo.lock`; generated manuals regenerated (man page from the CLI, `/manual/` HTML from MANUAL.md, which gains a WSL section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)