### PR TITLE
Add FastAPI starter to showcase

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,3 +1,4 @@
 # Showcase
 
 - [senv](https://github.com/h5i-dev/senv): Sandboxed Python environments, with the workflow of uv.
+- [h5i-fastapi-starter](https://github.com/SumedhAnupSupe/h5i-fastapi-starter): A small FastAPI application with a simple HTML UI, designed to run inside an h5i box.


### PR DESCRIPTION
## Summary

Adds `h5i-fastapi-starter` to the h5i showcase.

The starter provides:
- A small FastAPI application
- A simple HTML frontend
- h5i environment configuration
- Documented process and supervised isolation workflows

This implements the showcase step requested in #499.

Closes #499