### PR TITLE
Vendor OpenSSL where git2 is declared, so the browser builds on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ name = "h5i-error"
 version = "0.2.8"
 dependencies = [
  "git2",
+ "openssl",
  "serde_json",
  "thiserror 2.0.18",
  "toml 0.8.23",

--- a/crates/h5i-error/Cargo.toml
+++ b/crates/h5i-error/Cargo.toml
@@ -9,3 +9,15 @@ thiserror = { workspace = true }
 git2 = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+
+# git2 lives here, so this is where its OpenSSL problem belongs. Under musl,
+# libgit2-sys → libssh2-sys → openssl-sys wants a musl-linked system libssl that
+# no runner has; vendoring builds it from source instead. h5i-core and
+# h5i-sandbox each carry the same line, and in a whole-workspace build feature
+# unification means any one of them covers the others — but `cargo build -p
+# h5i-browser-light` resolves features over that crate's graph alone, which
+# holds git2 (via this crate) and neither of those two. That is exactly how the
+# v0.3.5 release built h5i and then failed to build the browser. Declared at the
+# root of the git2 dependency, it holds for every consumer and every invocation.
+[target.'cfg(target_env = "musl")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }


### PR DESCRIPTION
The v0.3.5 tag build got as far as `Create GitHub Release` and stopped: both musl targets built `h5i` and then failed on `cargo build -p h5i-browser-light`, with `openssl-sys` unable to find a musl-linked system libssl. No release was published.

The vendoring that solves this was declared in `h5i-core` and `h5i-sandbox`. Neither is in the browser's dependency graph, and `cargo build -p h5i-browser-light` resolves features over that graph alone. The whole-workspace build one line above it in the same job unified the feature and hid the gap, which is why nothing caught this before the tag.

This moves the declaration to `h5i-error`, the crate that actually depends on `git2` and therefore the one every path to `openssl-sys` runs through. It holds for every consumer and every invocation, including a standalone `cargo install --git ... h5i-browser-light`, which the release notes tell people the engine supports.

Verified with `cargo tree -p h5i-browser-light -i openssl-sys -e features --target x86_64-unknown-linux-musl`: `openssl-sys feature "vendored"` is now enabled in that graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)