### PR TITLE
Build aarch64 musl natively, and check the engine on every target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,9 @@ concurrency:
 
 jobs:
   # The `h5i ui` console is a React bundle embedded into the binary at compile
-  # time. Built once here and fanned out to every target job, because two of
-  # them run under `cross` — a Docker image with no Node in it, where the build
-  # script could not produce the bundle even if it wanted to. Every build job
-  # therefore sets H5I_SKIP_WEB_BUILD=1 and consumes this artifact.
+  # time. Built once here and fanned out to every target job rather than built
+  # four times, which also keeps Node off three of the four runners. Every build
+  # job sets H5I_SKIP_WEB_BUILD=1 and consumes this artifact.
   bundle:
     name: Build the console bundle
     runs-on: ubuntu-latest
@@ -81,25 +80,21 @@ jobs:
           # Linux x86_64 — native
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            use_cross: false
             archive_ext: tar.gz
 
-          # Linux aarch64 — cross-compiled
+          # Linux aarch64 — native, on GitHub's arm64 runner
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
-            use_cross: true
+            os: ubuntu-24.04-arm
             archive_ext: tar.gz
 
           # macOS arm64 (Apple Silicon)
           - target: aarch64-apple-darwin
             os: macos-latest
-            use_cross: false
             archive_ext: tar.gz
 
           # Windows x86_64
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            use_cross: false
             archive_ext: zip
 
     steps:
@@ -154,36 +149,29 @@ jobs:
 
       # musl linker/compiler; OpenSSL is vendored so no system libssl-dev needed
       - name: Install musl-tools (Linux)
-        if: runner.os == 'Linux' && !matrix.use_cross
+        if: runner.os == 'Linux'
         run: sudo apt-get update -q && sudo apt-get install -y musl-tools
 
-      - name: Install cross
-        if: matrix.use_cross
-        uses: taiki-e/install-action@cross
-
+      # Every target builds natively, aarch64 Linux included: it used to go
+      # through `cross`, whose container is Ubuntu 18.04 with no python in it,
+      # and stylo generates its CSS property tables by running python at build
+      # time. Installing the container's python3 does not help — it is 3.6, and
+      # stylo's vendored mako needs 3.8. GitHub's arm64 runners are free for
+      # public repositories, so the target that needed the most machinery is
+      # now the same three steps as the other three.
+      #
       # Both binaries in one job, and failing together on purpose. The engine
       # is a shipped product now rather than an internal component, so a target
       # that cannot build it is a defect in the release — the same reading the
       # asset guard below already takes. Note its dependency set is not h5i's:
       # no git2, but blitz, vello_cpu and boa instead, so a target that builds
       # one does not automatically build the other.
-      - name: Build (native)
-        if: "!matrix.use_cross"
+      - name: Build
         env:
           H5I_SKIP_WEB_BUILD: "1"
         run: |
           cargo build --release --locked --target ${{ matrix.target }}
           cargo build --release --locked --target ${{ matrix.target }} -p ${{ env.ENGINE_NAME }}
-
-      - name: Build (cross)
-        if: matrix.use_cross
-        env:
-          H5I_SKIP_WEB_BUILD: "1"
-          # Forward it into cross's Docker container, which has no Node.
-          CROSS_CONTAINER_OPTS: "-e H5I_SKIP_WEB_BUILD"
-        run: |
-          cross build --release --locked --target ${{ matrix.target }}
-          cross build --release --locked --target ${{ matrix.target }} -p ${{ env.ENGINE_NAME }}
 
       # ── Package ───────────────────────────────────────────────────────────
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -326,27 +326,27 @@ jobs:
   # caught BEFORE a tag is cut — not in `release.yaml`, which only runs on tags.
   # `cargo check` (not a full build) is enough: every such failure is a
   # front-end compile/type/cfg error. Keep this matrix in sync with
-  # `release.yaml`'s build matrix.
+  # `release.yaml`'s build matrix — and check both products it ships, because
+  # this job checked only `h5i` while the release built the engine too, and so
+  # let two separate engine-only failures through to the v0.3.5 tag.
   cross-check:
     name: cross-check ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    # 45 rather than 30: the engine pulls stylo, blitz and boa, and the first
+    # run on a cold cache checks all three from source.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            use_cross: false
           - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
-            use_cross: true
+            os: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
             os: macos-latest
-            use_cross: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            use_cross: false
     steps:
       - uses: actions/checkout@v7
 
@@ -359,29 +359,21 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
-      # musl linker/compiler for the native musl target; OpenSSL is vendored.
-      - name: Install musl-tools (Linux, native)
-        if: runner.os == 'Linux' && !matrix.use_cross
+      # musl linker/compiler for both musl targets; OpenSSL is vendored.
+      - name: Install musl-tools (Linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update -q && sudo apt-get install -y musl-tools
-
-      - name: Install cross
-        if: matrix.use_cross
-        uses: taiki-e/install-action@cross
 
       # Compile-only, so the console bundle is irrelevant: skip the npm build
       # (the build script stubs web/dist so `rust-embed` still resolves) rather
       # than put Node on four more runners.
-      - name: cargo check (native)
-        if: "!matrix.use_cross"
+      # Both products, in two invocations rather than one `-p a -p b`, because
+      # that is exactly how `release.yaml` builds them: `-p h5i-browser-light`
+      # resolves features over the engine's dependency graph alone, and a
+      # unified check would hide anything that graph is missing on its own.
+      - name: cargo check
         env:
           H5I_SKIP_WEB_BUILD: "1"
-        run: cargo check --locked --target ${{ matrix.target }}
-
-      - name: cross check (container)
-        if: matrix.use_cross
-        env:
-          H5I_SKIP_WEB_BUILD: "1"
-          # Forward both into cross's Docker container: no Node in there, and
-          # keep the `-D warnings` RUSTFLAGS from the workflow env.
-          CROSS_CONTAINER_OPTS: '-e H5I_SKIP_WEB_BUILD -e RUSTFLAGS'
-        run: cross check --locked --target ${{ matrix.target }}
+        run: |
+          cargo check --locked --target ${{ matrix.target }}
+          cargo check --locked --target ${{ matrix.target }} -p h5i-browser-light


### PR DESCRIPTION
The v0.3.5 tag failed a second time. The OpenSSL fix in #526 worked — x86_64 musl, macOS and Windows all built both binaries — and then `aarch64-unknown-linux-musl`, the one target that goes through `cross`, died in stylo's build script with `Can't find python (tried python3)`. stylo generates its CSS property tables by running python at build time. No release was published.

Installing python in the container does not fix it. Checked directly in `ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5`:

- there is no `python3` in the image at all
- the one apt offers is 3.6.9, on Ubuntu 18.04
- stylo's vendored mako 1.3.10 needs 3.8+, and fails on 3.6 with `ImportError: cannot import name 'metadata'`

So this drops `cross` instead. GitHub's arm64 runners are free for public repositories, and on `ubuntu-24.04-arm` the target that needed the most machinery becomes the same three steps as the other three: musl-tools, build, package. The cross install step, the duplicate cross build step, the `CROSS_CONTAINER_OPTS` forwarding and the `use_cross` matrix flag all go with it.

### The reason this reached a tag twice

`cross-check` runs `cargo check` on the root package. `release.yaml` builds `h5i` **and** `h5i-browser-light`. Every engine-only failure was invisible to PR CI by construction, which is exactly what both of these were.

It now checks both products on all four targets, in two invocations rather than one `-p a -p b`, because that is how the release builds them: `-p h5i-browser-light` resolves features over the engine's dependency graph alone, and a unified check would hide anything that graph is missing on its own. Timeout goes to 45 minutes for the cold-cache stylo/blitz/boa compile.

### Verification

Run on an aarch64 Linux host, the same command the new job runs:

```
cargo check --locked --target aarch64-unknown-linux-musl -p h5i-browser-light
    Finished `dev` profile [unoptimized] target(s) in 2m 16s
```

vendored OpenSSL, libssh2-sys and libgit2-sys compiled for musl along the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)