### PR TITLE
Forum web markdown: diffs, tables, admonitions, #n chips, and tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,14 @@ jobs:
           npm ci --no-audit --no-fund
           npm run build
 
+      # The console's unit tests, over the untrusted-text renderer that keeps an
+      # agent's forum words as data. Run after the build so its deps are already
+      # installed by the `npm ci` above, and before cargo so a renderer
+      # regression reads as a frontend failure rather than a downstream one.
+      - name: Test the console
+        working-directory: web
+        run: npm test
+
       # `--locked` throughout: Cargo.lock is committed and the release build
       # uses it, so a manifest change that never updated the lockfile has to
       # fail on a PR rather than surface at tag time.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,7 +19,8 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "typescript": "^5.5.3",
-        "vite": "^5.4.0"
+        "vite": "^5.4.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1301,6 +1302,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.12",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
@@ -1348,6 +1472,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camel-case": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
@@ -1390,6 +1524,23 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/change-case": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
@@ -1408,6 +1559,16 @@
         "sentence-case": "^3.0.4",
         "snake-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/classnames": {
@@ -1458,6 +1619,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -1484,6 +1655,13 @@
       "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1532,6 +1710,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fsevents": {
@@ -1613,6 +1811,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -1630,6 +1835,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1721,6 +1936,23 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1945,6 +2177,13 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -1963,6 +2202,64 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2103,6 +2400,95 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -2110,6 +2496,23 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@blueprintjs/core": "^5.10.5",
@@ -22,6 +23,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "typescript": "^5.5.3",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/web/src/ForumView.tsx
+++ b/web/src/ForumView.tsx
@@ -346,6 +346,13 @@ h5i forum attach codex-box  --as codex-reviewer --role reviewer`}
           const shown = thread.posts.filter(
             (p) => p.kind !== "UPVOTE" && p.kind !== "DOWNVOTE",
           );
+          // Number the posts the way `h5i forum read` does — vote posts
+          // excluded, in thread order, one-based — so a `#12` an agent wrote
+          // with `reply 12` in mind points at the post it meant. Appends never
+          // renumber what came before, so a reference stays valid as the thread
+          // grows under a reader who is watching it.
+          const num = new Map(shown.map((p, i) => [p.id, i + 1]));
+          const posts = shown.length;
           // The opening post is the thread's body, not its first comment, so it
           // sits above the rule and the replies sit below it — the shape every
           // discussion surface has, and the one a reader already knows.
@@ -359,6 +366,8 @@ h5i forum attach codex-box  --as codex-reviewer --role reviewer`}
                     p={opening}
                     me={thread.origin}
                     score={thread.scores[opening.id] ?? 0}
+                    num={num.get(opening.id)}
+                    posts={posts}
                   />
                 </div>
               )}
@@ -373,6 +382,8 @@ h5i forum attach codex-box  --as codex-reviewer --role reviewer`}
                   p={p}
                   me={thread.origin}
                   score={thread.scores[p.id] ?? 0}
+                  num={num.get(p.id)}
+                  posts={posts}
                 />
               ))}
             </>
@@ -395,20 +406,32 @@ function PostRow({
   p,
   me,
   score,
+  num,
+  posts,
 }: {
   p: ForumPost;
   me: string;
   score: number;
+  /** This post's number in the thread, matching `h5i forum read`. */
+  num?: number;
+  /** How many numbered posts the thread has, so bodies can chip `#n`. */
+  posts: number;
 }) {
   const observed = !!p.origin && p.origin === me;
   return (
-    <div className={`brd-post${observed ? "" : " is-peer"}`}>
+    <div
+      className={`brd-post${observed ? "" : " is-peer"}`}
+      id={num ? `brd-post-${num}` : undefined}
+    >
       {/* Outside the fence: what *some* host stamped. For a post this host
           wrote, none of it came from the box's payload — the wire format has no
           field for any of it, so it is knowledge rather than claim. For a post
           fetched from a peer, this host observed none of it, and the lane below
           says so rather than letting the line keep looking like a fact. */}
       <div className="brd-post-meta">
+        {/* The post's number, which is what a `#n` chip elsewhere points at —
+            shown so the target of a reference is something a reader can find. */}
+        {num && <span className="brd-postnum">#{num}</span>}
         <Avatar name={p.sender} />
         <b>{p.sender}</b>
         <span className="brd-dim">{p.role}</span>
@@ -446,7 +469,7 @@ function PostRow({
           `markdown.tsx`. Formatting the text must not be the thing that lets it
           stop being text. */}
       <div className="brd-fence">
-        <Markdown text={p.body} />
+        <Markdown text={p.body} posts={posts} />
       </div>
 
       {(p.attachments ?? []).map((a) => (
@@ -606,6 +629,10 @@ function kindClass(kind: string): string {
     case "DONE":
     case "ACK":
       return "good";
+    // Cyan, the same tone a `[!FINDING]` callout wears in the body, so the kind
+    // badge and an inline finding never disagree about what the colour means.
+    case "FINDING":
+      return "finding";
     case "TASK":
       return "task";
     default:

--- a/web/src/forum.css
+++ b/web/src/forum.css
@@ -35,6 +35,13 @@
   --brd-red-text: #ff6258; /* red as text/rule: brand and selection */
   --brd-amber: #d6a94e;
   --brd-green: #62c98c;
+  /* Two tones the palette did not have, added so the body's semantic callouts
+     and the post kinds can share one vocabulary: cyan is a finding, violet a
+     decision. Muted to sit on the near-black ground beside amber and green
+     without any of the four reading as louder than a refusal — which stays the
+     only filled red on the page. */
+  --brd-cyan: #5db8c7;
+  --brd-violet: #a68bd7;
   --brd-mono: "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
 
   /* The type scale, sized against Reddit's — the surface people already read
@@ -294,7 +301,35 @@
 }
 .brd-kind.is-warn { color: var(--brd-amber); border-color: var(--brd-amber); }
 .brd-kind.is-good { color: var(--brd-green); border-color: var(--brd-green); }
+.brd-kind.is-finding { color: var(--brd-cyan); border-color: var(--brd-cyan); }
 .brd-kind.is-task { color: var(--brd-dim); }
+
+/* A post's number, matching `h5i forum read`. It is the thing a `#n` chip
+   points at, so it is styled as the resting state of that same chip: mono,
+   ruled, cyan, sitting first on the meta line. */
+.brd-postnum {
+  font-family: var(--brd-mono);
+  font-size: var(--brd-fs-label);
+  letter-spacing: 0.04em;
+  padding: 0 0.35rem;
+  border: 1px solid var(--brd-line2);
+  color: var(--brd-faint);
+}
+
+/* A brief mark on the post a `#n` chip jumped to, so the eye lands on it rather
+   than on wherever the smooth scroll happened to stop. Cyan hairline, gone in
+   just over a second — the same tone the reference itself wears. */
+.brd-post-flash {
+  animation: brd-post-flash 1.2s ease-out;
+}
+@keyframes brd-post-flash {
+  from {
+    box-shadow: inset 0 0 0 9999px rgba(93, 184, 199, 0.14);
+  }
+  to {
+    box-shadow: inset 0 0 0 9999px rgba(93, 184, 199, 0);
+  }
+}
 
 /* Inside the fence. Everything here is an agent's claim, and the label says so.
  * `white-space: pre-wrap` keeps a patch or a stack trace readable; React
@@ -621,6 +656,208 @@
   font-size: var(--brd-fs-meta);
   color: var(--brd-faint);
   overflow-wrap: anywhere;
+}
+
+/* ── code blocks: a bar, a copy, a collapse, and a diff mode ───────────────── */
+
+.brd-fence .md-codewrap {
+  border: 1px solid var(--brd-line2);
+  margin: 0.4rem 0;
+  background: #08080b;
+}
+/* The bar carries the language, the line count, and the two actions. Mono and
+   faint so it labels the block without competing with the code in it. */
+.brd-fence .md-code-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.2rem 0.5rem;
+  border-bottom: 1px solid var(--brd-line);
+  font-family: var(--brd-mono);
+  font-size: var(--brd-fs-label);
+  color: var(--brd-faint);
+  white-space: normal;
+}
+.brd-fence .md-code-lang {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--brd-dim);
+}
+.brd-fence .md-code-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.3rem;
+}
+.brd-fence .md-code-btn {
+  font-family: var(--brd-mono);
+  font-size: var(--brd-fs-label);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0 0.4rem;
+  border: 1px solid var(--brd-line2);
+  border-radius: 0;
+  background: transparent;
+  color: var(--brd-faint);
+  cursor: pointer;
+}
+.brd-fence .md-code-btn:hover { color: var(--brd-text); }
+.brd-fence .md-code-btn:focus-visible {
+  outline: 1px solid var(--brd-red-text);
+  outline-offset: 1px;
+}
+/* The code itself keeps its own `.md-code` rule below; inside a wrapper it drops
+   the border the wrapper now carries. */
+.brd-fence .md-codewrap .md-code {
+  border: none;
+  margin: 0;
+}
+.brd-fence .md-code-more {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.25rem 0.6rem;
+  border: none;
+  border-top: 1px dashed var(--brd-line2);
+  background: transparent;
+  font-family: var(--brd-mono);
+  font-size: var(--brd-fs-label);
+  color: var(--brd-faint);
+  cursor: pointer;
+}
+.brd-fence .md-code-more:hover { color: var(--brd-text); }
+
+/* A diff colours each line by its first character. No red: on this surface red
+   is the host's voice, so a removed line is amber and the leading `-` carries
+   the meaning alongside the colour — never the colour alone. */
+.brd-fence .md-code.is-diff .md-diff {
+  display: block;
+  margin: 0 -0.6rem;
+  padding: 0 0.6rem;
+}
+.brd-fence .md-code.is-diff .md-diff.is-add {
+  color: var(--brd-green);
+  background: rgba(98, 201, 140, 0.09);
+}
+.brd-fence .md-code.is-diff .md-diff.is-del {
+  color: var(--brd-amber);
+  background: rgba(214, 169, 78, 0.09);
+}
+.brd-fence .md-code.is-diff .md-diff.is-hunk { color: var(--brd-cyan); }
+.brd-fence .md-code.is-diff .md-diff.is-file { color: var(--brd-faint); }
+
+/* ── tables ────────────────────────────────────────────────────────────────── */
+
+.brd-fence .md-tablewrap {
+  overflow-x: auto;
+  margin: 0.4rem 0;
+}
+.brd-fence .md-table {
+  border-collapse: collapse;
+  font-size: var(--brd-fs-code);
+  white-space: normal;
+}
+.brd-fence .md-table th,
+.brd-fence .md-table td {
+  border: 1px solid var(--brd-line2);
+  padding: 0.2rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+.brd-fence .md-table th {
+  font-weight: 700;
+  color: var(--brd-ink);
+  background: var(--brd-panel);
+}
+.brd-fence .md-table .is-center { text-align: center; }
+.brd-fence .md-table .is-right { text-align: right; }
+
+/* ── task lists ────────────────────────────────────────────────────────────── */
+
+.brd-fence .md-tasklist { list-style: none; padding-left: 0.2rem; }
+.brd-fence .md-taskitem { display: flex; gap: 0.4rem; align-items: baseline; }
+/* Inert: the tick is the author's claim about their own list, not a switch. */
+.brd-fence .md-check {
+  font-family: var(--brd-mono);
+  color: var(--brd-dim);
+  flex: none;
+}
+
+/* ── blockquotes ───────────────────────────────────────────────────────────── */
+
+.brd-fence .md-quote {
+  margin: 0.4rem 0;
+  padding: 0 0 0 0.7rem;
+  border-left: 2px solid var(--brd-line2);
+  color: var(--brd-dim);
+}
+.brd-fence .md-quote > :last-child { margin-bottom: 0; }
+
+/* ── admonitions: `> [!KIND]`, coloured by the shared vocabulary ───────────── */
+
+/* A callout carries its label and icon always, so colour never stands alone —
+   a monochrome terminal, a colour-blind reader, and a colour reader all see the
+   same word. The tone is a left edge and a faint wash, not a filled band: a
+   filled band on this page is a refusal and nothing else. */
+.brd-fence .md-adm {
+  margin: 0.5rem 0;
+  padding: 0.4rem 0.65rem;
+  border-left: 2px solid var(--brd-line2);
+  background: rgba(255, 255, 255, 0.02);
+}
+.brd-fence .md-adm-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--brd-mono);
+  font-size: var(--brd-fs-label);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 0.25rem;
+}
+.brd-fence .md-adm-icon { font-size: 12px; line-height: 1; }
+.brd-fence .md-adm-body > :last-child { margin-bottom: 0; }
+
+.brd-fence .md-adm.is-finding {
+  border-left-color: var(--brd-cyan);
+  background: rgba(93, 184, 199, 0.06);
+}
+.brd-fence .md-adm.is-finding .md-adm-head { color: var(--brd-cyan); }
+.brd-fence .md-adm.is-risk {
+  border-left-color: var(--brd-amber);
+  background: rgba(214, 169, 78, 0.06);
+}
+.brd-fence .md-adm.is-risk .md-adm-head { color: var(--brd-amber); }
+.brd-fence .md-adm.is-decision {
+  border-left-color: var(--brd-violet);
+  background: rgba(166, 139, 215, 0.06);
+}
+.brd-fence .md-adm.is-decision .md-adm-head { color: var(--brd-violet); }
+.brd-fence .md-adm.is-done {
+  border-left-color: var(--brd-green);
+  background: rgba(98, 201, 140, 0.06);
+}
+.brd-fence .md-adm.is-done .md-adm-head { color: var(--brd-green); }
+.brd-fence .md-adm.is-note .md-adm-head { color: var(--brd-dim); }
+
+/* ── post-reference chips (`#12`) ──────────────────────────────────────────── */
+
+/* Chipped only when the number names a post that exists (see markdown.tsx), so
+   this style never lands on a dead reference. Cyan, matching the resting `#n`
+   the chip jumps to. */
+.brd-fence .md-ref {
+  font-family: var(--brd-mono);
+  font-size: 0.92em;
+  padding: 0 0.3rem;
+  border: 1px solid var(--brd-line2);
+  border-radius: 0;
+  background: transparent;
+  color: var(--brd-cyan);
+  cursor: pointer;
+}
+.brd-fence .md-ref:hover { border-color: var(--brd-cyan); }
+.brd-fence .md-ref:focus-visible {
+  outline: 1px solid var(--brd-cyan);
+  outline-offset: 1px;
 }
 
 /* ── scores ───────────────────────────────────────────────────────────────── */

--- a/web/src/markdown.test.tsx
+++ b/web/src/markdown.test.tsx
@@ -1,0 +1,227 @@
+// Tests for the forum's untrusted-text renderer.
+//
+// Two things are being pinned here. First, the security invariants the file's
+// own header promises: the renderer emits React nodes and never HTML, links are
+// never clickable, images never render — a regression in any of those is a hole
+// in the one surface that exists to keep an agent's words as data. Second, the
+// parsing added for the console's markdown: diff colouring, tables, task lists,
+// admonitions, and the `#n` chips whose numbering has to agree with
+// `h5i forum read` or a chip points at the wrong post.
+//
+// The pure `parse()` is asserted directly; everything that only exists once
+// rendered is checked through `renderToStaticMarkup`, which turns the React
+// tree into the exact string a browser would receive — so "contains no
+// `<script>`" is a real claim about the output, not about the source.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import { Markdown, parse, plainText } from "./markdown";
+
+const html = (text: string, posts = 0) =>
+  renderToStaticMarkup(<Markdown text={text} posts={posts} />);
+
+describe("security invariants", () => {
+  it("escapes raw HTML rather than emitting it", () => {
+    const out = html("<script>alert(1)</script>");
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+  });
+
+  it("renders a link as visible, unclickable text with no href", () => {
+    const out = html("[docs](http://evil.example)");
+    expect(out).not.toContain("<a ");
+    expect(out).not.toContain("href");
+    expect(out).toContain("http://evil.example"); // the destination is shown
+  });
+
+  it("does not make a javascript: link clickable", () => {
+    const out = html("[x](javascript:alert(1))");
+    expect(out).not.toContain("<a ");
+    expect(out).not.toContain("href");
+  });
+
+  it("never renders an image element", () => {
+    const out = html("![logo](http://x.example/y.png)");
+    expect(out).not.toContain("<img");
+  });
+});
+
+describe("post-reference chips (#n)", () => {
+  it("chips a number that names an existing post", () => {
+    const out = html("see #3 for details", 5);
+    expect(out).toContain('class="md-ref"');
+    expect(out).toContain("#3");
+  });
+
+  it("leaves a number with no matching post as plain text", () => {
+    const out = html("see #3", 2);
+    expect(out).not.toContain("md-ref");
+    expect(out).toContain("#3");
+  });
+
+  it("never chips when the thread count is zero", () => {
+    expect(html("#1", 0)).not.toContain("md-ref");
+  });
+
+  it("does not chip #0", () => {
+    expect(html("#0", 5)).not.toContain("md-ref");
+  });
+
+  it("does not chip a number glued to a word, e.g. a hex colour", () => {
+    const out = html("colour #12ab34 here", 99);
+    expect(out).not.toContain("md-ref");
+    expect(out).toContain("#12ab34");
+  });
+});
+
+describe("admonitions", () => {
+  const adm = (text: string) => {
+    const b = parse(text)[0];
+    if (b.kind !== "admonition") throw new Error(`expected admonition, got ${b.kind}`);
+    return b;
+  };
+
+  it("reads a [!FINDING] marker as a finding-toned callout", () => {
+    const b = adm("> [!FINDING]\n> the race is here");
+    expect(b.tone).toBe("finding");
+    expect(b.label).toBe("FINDING");
+    expect(b.lines).toEqual(["the race is here"]);
+  });
+
+  it("maps DECISION to its own tone", () => {
+    expect(adm("> [!DECISION]\n> serialize refreshes").tone).toBe("decision");
+  });
+
+  it("maps GitHub CAUTION/WARNING to amber risk, never red", () => {
+    expect(adm("> [!CAUTION]\n> x").tone).toBe("risk");
+    expect(adm("> [!WARNING]\n> x").tone).toBe("risk");
+  });
+
+  it("assigns no admonition kind a red tone", () => {
+    const kinds = [
+      "FINDING", "NOTE", "RISK", "BLOCKED", "WARNING", "CAUTION",
+      "DECISION", "IMPORTANT", "DONE", "ACK", "TIP", "MYSTERY",
+    ];
+    const allowed = new Set(["finding", "risk", "decision", "done", "note"]);
+    for (const k of kinds) {
+      const tone = adm(`> [!${k}]\n> body`).tone;
+      expect(allowed.has(tone)).toBe(true);
+      expect(tone).not.toBe("red");
+    }
+  });
+
+  it("renders the label so colour never stands alone", () => {
+    const out = html("> [!RISK]\n> two valid refresh tokens");
+    expect(out).toContain("md-adm is-risk");
+    expect(out).toContain("RISK");
+    expect(out).toContain("two valid refresh tokens");
+  });
+
+  it("treats a plain blockquote as a quote, not a callout", () => {
+    expect(parse("> just a quote")[0].kind).toBe("quote");
+  });
+});
+
+describe("diff code blocks", () => {
+  it("classes added, removed and hunk lines", () => {
+    const out = html("```diff\n+added\n-removed\n@@ -1 +1 @@\n context\n```");
+    expect(out).toContain("is-add");
+    expect(out).toContain("is-del");
+    expect(out).toContain("is-hunk");
+  });
+
+  it("classes the file header, not as an added/removed line", () => {
+    const out = html("```diff\n--- a/x\n+++ b/x\n```");
+    expect(out).toContain("is-file");
+  });
+
+  it("does not diff-class a plain code block", () => {
+    const out = html("```\n+not a diff\n```");
+    expect(out).not.toContain("md-diff");
+  });
+});
+
+describe("code block controls", () => {
+  it("offers a copy button on every code block", () => {
+    expect(html("```\nx\n```")).toContain("copy");
+  });
+
+  it("collapses a long log and offers to expand it", () => {
+    const long = "```\n" + Array.from({ length: 30 }, (_, i) => `line ${i}`).join("\n") + "\n```";
+    const out = html(long);
+    expect(out).toContain("more lines");
+    expect(out).toContain("expand");
+  });
+
+  it("does not collapse a short block", () => {
+    const out = html("```\na\nb\n```");
+    expect(out).not.toContain("more lines");
+    expect(out).not.toContain("expand");
+  });
+});
+
+describe("tables", () => {
+  it("parses header, alignment and rows", () => {
+    const b = parse("| a | b |\n| :-- | --: |\n| 1 | 2 |")[0];
+    if (b.kind !== "table") throw new Error(`expected table, got ${b.kind}`);
+    expect(b.header).toEqual(["a", "b"]);
+    expect(b.align).toEqual(["left", "right"]);
+    expect(b.rows).toEqual([["1", "2"]]);
+  });
+
+  it("renders as a real table with alignment classes", () => {
+    const out = html("| a | b |\n| - | -: |\n| 1 | 2 |");
+    expect(out).toContain("md-table");
+    expect(out).toContain("<th");
+    expect(out).toContain("is-right");
+  });
+
+  it("does not mistake a bare --- rule for a table", () => {
+    expect(parse("text\n---\nmore").every((b) => b.kind !== "table")).toBe(true);
+  });
+});
+
+describe("task lists", () => {
+  it("keeps the checkbox markers as item text when parsing", () => {
+    const b = parse("- [ ] todo\n- [x] done")[0];
+    if (b.kind !== "list") throw new Error(`expected list, got ${b.kind}`);
+    expect(b.items).toEqual(["[ ] todo", "[x] done"]);
+  });
+
+  it("renders inert ticked and unticked glyphs", () => {
+    const out = html("- [ ] todo\n- [x] done");
+    expect(out).toContain("md-tasklist");
+    expect(out).toContain("☐");
+    expect(out).toContain("☑");
+  });
+});
+
+describe("inline and fences", () => {
+  it("lets code win over emphasis", () => {
+    const out = html("`**x**`");
+    expect(out).toContain("<code");
+    expect(out).toContain("**x**");
+    expect(out).not.toContain("<strong");
+  });
+
+  it("runs an unterminated fence to the end of the post", () => {
+    const b = parse("```\nkeep\ngoing")[0];
+    if (b.kind !== "code") throw new Error(`expected code, got ${b.kind}`);
+    expect(b.lines).toEqual(["keep", "going"]);
+  });
+});
+
+describe("plainText preview", () => {
+  it("strips markdown down to prose", () => {
+    const out = plainText(
+      "# Title\n\n> [!RISK]\n> danger\n\n- [ ] task\n\n| a | b |\n| - | - |\n| 1 | 2 |",
+    );
+    expect(out).not.toContain("|");
+    expect(out).not.toContain("[!");
+    expect(out).not.toContain("[ ]");
+    expect(out).not.toMatch(/(^|\s)#/);
+    expect(out).toContain("Title");
+    expect(out).toContain("danger");
+    expect(out).toContain("task");
+  });
+});

--- a/web/src/markdown.tsx
+++ b/web/src/markdown.tsx
@@ -102,7 +102,10 @@ function cellAlign(cell: string): Align {
   return "none";
 }
 
-function parse(text: string): Block[] {
+// Exported for tests: the pure string→blocks half of the renderer, where the
+// parsing decisions live (fences, tables, admonitions, lists). Rendering to
+// React nodes is tested through `Markdown` itself.
+export function parse(text: string): Block[] {
   const src = text.split("\n");
   const out: Block[] = [];
   let i = 0;

--- a/web/src/markdown.tsx
+++ b/web/src/markdown.tsx
@@ -12,7 +12,7 @@
 // sanitising: React escapes every text node it renders, and the element types
 // come from this file rather than from the input.
 //
-// Two deliberate departures from ordinary markdown, both because the author is
+// Deliberate departures from ordinary markdown, all because the author is
 // untrusted:
 //
 //   - **A link is never clickable, and its target is always visible.**
@@ -23,24 +23,86 @@
 //   - **Images are not rendered.** An `![…](url)` would make the page fetch
 //     something an agent chose, from a surface that is meant to observe and not
 //     to act.
+//   - **The only interactive elements point inward.** A copy button copies the
+//     text you can already see; a `#12` post-reference scrolls this page to a
+//     post that exists in this same thread; a collapse toggle hides lines. None
+//     of them can be made to reach off the page or to act on a box.
+//   - **A task checkbox is inert.** `- [x]` renders a ticked glyph, not a form
+//     control — the tick is the author's claim about their own list, not a
+//     switch the reader can throw.
+//   - **A diff is never red.** On this surface filled red is a host refusal and
+//     red text is brand or selection (see `forum.css`); a removed line is amber
+//     instead, and the leading `-` carries the meaning so colour never carries
+//     it alone.
 //
-// Everything else is the small subset an agent actually writes: fenced code,
-// inline code, bold, italic, headings, and bullet or numbered lists.
+// Everything else is the subset an agent actually writes: fenced code (with a
+// diff mode), inline code, bold, italic, headings, bullet / numbered / task
+// lists, tables, blockquotes and GitHub-style `[!KIND]` admonitions.
 
 import React from "react";
 
-/** Render one post body as React nodes. Never returns HTML. */
-export function Markdown({ text }: { text: string }) {
-  return <>{blocks(text)}</>;
+/**
+ * Render one post body as React nodes. Never returns HTML.
+ *
+ * `posts` is the number of numbered posts in the thread this body belongs to,
+ * which is what turns a `#12` in the text into a chip: the parser only makes a
+ * chip when the number names a post that exists, so a stray `#500` stays plain
+ * text rather than becoming a link to nothing. The count must be the same one
+ * `h5i forum read` prints against — vote posts excluded, in thread order — or a
+ * chip would scroll to a post the author did not mean. Zero (the default) means
+ * "no thread to point into", so nothing is ever chipped.
+ */
+export function Markdown({ text, posts = 0 }: { text: string; posts?: number }) {
+  return <>{parse(text).map((b, n) => renderBlock(b, n, posts))}</>;
 }
+
+type Align = "none" | "left" | "center" | "right";
 
 type Block =
   | { kind: "code"; lang: string; lines: string[] }
   | { kind: "heading"; level: number; text: string }
   | { kind: "list"; ordered: boolean; items: string[] }
+  | { kind: "table"; header: string[]; align: Align[]; rows: string[][] }
+  | { kind: "quote"; lines: string[] }
+  | { kind: "admonition"; tone: string; label: string; icon: string; lines: string[] }
   | { kind: "para"; lines: string[] };
 
-function blocks(text: string): React.ReactNode[] {
+const BULLET = /^\s*([-*+]|\d+[.)])\s+/;
+
+/** A `| --- | :--: |` separator: pipes, dashes, colons and space, and a dash. */
+function isDelim(line: string): boolean {
+  return /^[\s|:-]+$/.test(line) && line.includes("-") && line.includes("|");
+}
+
+/** A row that a delimiter on the next line turns into a table header. */
+function isTableStart(src: string[], i: number): boolean {
+  return (
+    src[i].includes("|") &&
+    src[i].trim() !== "" &&
+    i + 1 < src.length &&
+    isDelim(src[i + 1])
+  );
+}
+
+function splitRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((c) => c.trim());
+}
+
+function cellAlign(cell: string): Align {
+  const l = cell.startsWith(":");
+  const r = cell.endsWith(":");
+  if (l && r) return "center";
+  if (r) return "right";
+  if (l) return "left";
+  return "none";
+}
+
+function parse(text: string): Block[] {
   const src = text.split("\n");
   const out: Block[] = [];
   let i = 0;
@@ -66,23 +128,54 @@ function blocks(text: string): React.ReactNode[] {
 
     const heading = /^(#{1,4})\s+(.*)$/.exec(line);
     if (heading) {
-      out.push({
-        kind: "heading",
-        level: heading[1].length,
-        text: heading[2],
-      });
+      out.push({ kind: "heading", level: heading[1].length, text: heading[2] });
       i++;
       continue;
     }
 
-    if (/^\s*([-*+]|\d+[.)])\s+/.test(line)) {
+    // Blockquote, and its special case the admonition. Consecutive `>` lines
+    // are one quote; if its first line is a `[!KIND]` marker the quote is a
+    // callout instead, coloured by the same vocabulary the post kinds use.
+    if (/^\s*>/.test(line)) {
+      const q: string[] = [];
+      while (i < src.length && /^\s*>/.test(src[i])) {
+        q.push(src[i].replace(/^\s*>\s?/, ""));
+        i++;
+      }
+      const marker = /^\[!([A-Za-z_]+)\]\s*(.*)$/.exec(q[0] ?? "");
+      if (marker) {
+        const tone = admonition(marker[1]);
+        const body = marker[2] ? [marker[2], ...q.slice(1)] : q.slice(1);
+        out.push({ kind: "admonition", ...tone, lines: body });
+      } else {
+        out.push({ kind: "quote", lines: q });
+      }
+      continue;
+    }
+
+    if (BULLET.test(line)) {
       const ordered = /^\s*\d+[.)]\s+/.test(line);
       const items: string[] = [];
-      while (i < src.length && /^\s*([-*+]|\d+[.)])\s+/.test(src[i])) {
-        items.push(src[i].replace(/^\s*([-*+]|\d+[.)])\s+/, ""));
+      while (i < src.length && BULLET.test(src[i])) {
+        items.push(src[i].replace(BULLET, ""));
         i++;
       }
       out.push({ kind: "list", ordered, items });
+      continue;
+    }
+
+    if (isTableStart(src, i)) {
+      const header = splitRow(src[i]);
+      const align = splitRow(src[i + 1]).map(cellAlign);
+      i += 2;
+      const rows: string[][] = [];
+      while (i < src.length && src[i].includes("|") && src[i].trim() !== "") {
+        const cells = splitRow(src[i]);
+        while (cells.length < header.length) cells.push("");
+        rows.push(cells.slice(0, header.length));
+        i++;
+      }
+      out.push({ kind: "table", header, align, rows });
       continue;
     }
 
@@ -97,7 +190,9 @@ function blocks(text: string): React.ReactNode[] {
       src[i].trim() !== "" &&
       !/^\s*```/.test(src[i]) &&
       !/^#{1,4}\s/.test(src[i]) &&
-      !/^\s*([-*+]|\d+[.)])\s+/.test(src[i])
+      !/^\s*>/.test(src[i]) &&
+      !BULLET.test(src[i]) &&
+      !isTableStart(src, i)
     ) {
       lines.push(src[i]);
       i++;
@@ -105,38 +200,132 @@ function blocks(text: string): React.ReactNode[] {
     out.push({ kind: "para", lines });
   }
 
-  return out.map((b, n) => renderBlock(b, n));
+  return out;
 }
 
-function renderBlock(b: Block, key: number): React.ReactNode {
+/**
+ * A kind marker's tone, label and icon.
+ *
+ * The tones are the forum's own vocabulary — the same amber a RISK badge wears,
+ * the same green a DONE wears — extended with cyan for findings and violet for
+ * decisions so an inline callout and a post kind never disagree about what a
+ * colour means. GitHub's five standard markers map onto the same tones so a
+ * post reads the same here and there. Nothing maps to red: red on this surface
+ * is the host's, not an agent's.
+ */
+function admonition(kind: string): { tone: string; label: string; icon: string } {
+  const k = kind.toUpperCase();
+  switch (k) {
+    case "FINDING":
+      return { tone: "finding", label: k, icon: "◆" };
+    case "NOTE":
+      return { tone: "finding", label: k, icon: "•" };
+    case "RISK":
+    case "WARNING":
+    case "CAUTION":
+      return { tone: "risk", label: k, icon: "▲" };
+    case "BLOCKED":
+      return { tone: "risk", label: k, icon: "■" };
+    case "DECISION":
+    case "IMPORTANT":
+      return { tone: "decision", label: k, icon: "◈" };
+    case "DONE":
+    case "ACK":
+    case "TIP":
+      return { tone: "done", label: k, icon: "✓" };
+    default:
+      return { tone: "note", label: k, icon: "•" };
+  }
+}
+
+/** A `- [ ]` / `- [x]` task item, split into its state and its text. */
+function taskOf(item: string): { checked: boolean; text: string } | null {
+  const m = /^\[([ xX])\]\s+(.*)$/.exec(item);
+  return m ? { checked: m[1] !== " ", text: m[2] } : null;
+}
+
+function renderBlock(b: Block, key: number, posts: number): React.ReactNode {
   switch (b.kind) {
     case "code":
-      // `pre` keeps the author's whitespace; the text is a child node, so it is
-      // escaped like any other string React renders.
-      return (
-        <pre className="md-code" key={key}>
-          {b.lines.join("\n")}
-        </pre>
-      );
+      return <CodeBlock lang={b.lang} lines={b.lines} key={key} />;
     case "heading":
       return (
         <div className={`md-h md-h${b.level}`} key={key}>
-          {inline(b.text)}
+          {inline(b.text, posts)}
         </div>
       );
-    case "list":
+    case "list": {
+      const hasTask = b.items.some((it) => taskOf(it));
+      const cls = `md-list${hasTask ? " md-tasklist" : ""}`;
+      const items = b.items.map((it, j) => {
+        const task = taskOf(it);
+        return (
+          <li className={task ? "md-taskitem" : undefined} key={j}>
+            {task && (
+              <span className="md-check" aria-hidden="true">
+                {task.checked ? "☑" : "☐"}
+              </span>
+            )}
+            {inline(task ? task.text : it, posts)}
+          </li>
+        );
+      });
       return b.ordered ? (
-        <ol className="md-list" key={key}>
-          {b.items.map((it, j) => (
-            <li key={j}>{inline(it)}</li>
-          ))}
+        <ol className={cls} key={key}>
+          {items}
         </ol>
       ) : (
-        <ul className="md-list" key={key}>
-          {b.items.map((it, j) => (
-            <li key={j}>{inline(it)}</li>
-          ))}
+        <ul className={cls} key={key}>
+          {items}
         </ul>
+      );
+    }
+    case "table":
+      return (
+        <div className="md-tablewrap" key={key}>
+          <table className="md-table">
+            <thead>
+              <tr>
+                {b.header.map((c, j) => (
+                  <th className={`is-${b.align[j] ?? "none"}`} key={j}>
+                    {inline(c, posts)}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {b.rows.map((row, r) => (
+                <tr key={r}>
+                  {row.map((c, j) => (
+                    <td className={`is-${b.align[j] ?? "none"}`} key={j}>
+                      {inline(c, posts)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    case "quote":
+      return (
+        <blockquote className="md-quote" key={key}>
+          {parse(b.lines.join("\n")).map((c, j) => renderBlock(c, j, posts))}
+        </blockquote>
+      );
+    case "admonition":
+      return (
+        <div className={`md-adm is-${b.tone}`} key={key}>
+          <div className="md-adm-head">
+            <span className="md-adm-icon" aria-hidden="true">
+              {b.icon}
+            </span>
+            <span className="md-adm-label">{b.label}</span>
+          </div>
+          <div className="md-adm-body">
+            {parse(b.lines.join("\n")).map((c, j) => renderBlock(c, j, posts))}
+          </div>
+        </div>
       );
     case "para":
       return (
@@ -144,7 +333,7 @@ function renderBlock(b: Block, key: number): React.ReactNode {
           {b.lines.map((l, j) => (
             <React.Fragment key={j}>
               {j > 0 && <br />}
-              {inline(l)}
+              {inline(l, posts)}
             </React.Fragment>
           ))}
         </p>
@@ -153,16 +342,101 @@ function renderBlock(b: Block, key: number): React.ReactNode {
 }
 
 /**
+ * A fenced code block: the language it declared, a copy of exactly its text,
+ * and — for a long one — a collapse so a hundred-line log does not bury the
+ * conversation. In `diff` mode each line is coloured by its first character;
+ * everywhere else the text is one child node, escaped like any other string.
+ */
+const LONG = 24; // a log longer than this collapses by default
+const PEEK = 10; // lines left showing while it is collapsed
+
+function CodeBlock({ lang, lines }: { lang: string; lines: string[] }) {
+  const [open, setOpen] = React.useState(false);
+  const [copied, setCopied] = React.useState(false);
+  const long = lines.length > LONG;
+  const shown = long && !open ? lines.slice(0, PEEK) : lines;
+  const isDiff = lang === "diff" || lang === "patch";
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(lines.join("\n"));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  return (
+    <div className="md-codewrap">
+      <div className="md-code-bar">
+        {lang && <span className="md-code-lang">{lang}</span>}
+        <span className="md-code-lines">
+          {lines.length} {lines.length === 1 ? "line" : "lines"}
+        </span>
+        <span className="md-code-actions">
+          {long && (
+            <button
+              type="button"
+              className="md-code-btn"
+              onClick={() => setOpen((o) => !o)}
+            >
+              {open ? "collapse" : "expand"}
+            </button>
+          )}
+          <button type="button" className="md-code-btn" title="copy" onClick={copy}>
+            {copied ? "copied" : "copy"}
+          </button>
+        </span>
+      </div>
+      <pre className={`md-code${isDiff ? " is-diff" : ""}`}>
+        {isDiff
+          ? shown.map((l, j) => (
+              <span className={`md-diff ${diffClass(l)}`} key={j}>
+                {l === "" ? " " : l}
+              </span>
+            ))
+          : shown.join("\n")}
+      </pre>
+      {long && !open && (
+        <button
+          type="button"
+          className="md-code-more"
+          onClick={() => setOpen(true)}
+        >
+          … {lines.length - PEEK} more lines
+        </button>
+      )}
+    </div>
+  );
+}
+
+function diffClass(line: string): string {
+  if (line.startsWith("@@")) return "is-hunk";
+  if (line.startsWith("+++") || line.startsWith("---")) return "is-file";
+  if (line.startsWith("+")) return "is-add";
+  if (line.startsWith("-")) return "is-del";
+  return "";
+}
+
+/** Scroll this page to a numbered post and flash it. Points inward only. */
+function scrollToPost(n: number): void {
+  const el = document.getElementById(`brd-post-${n}`);
+  if (!el) return;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.classList.add("brd-post-flash");
+  setTimeout(() => el.classList.remove("brd-post-flash"), 1200);
+}
+
+/**
  * Inline spans, tokenised in one pass.
  *
  * Order matters: code wins over emphasis, so `**not bold**` inside backticks
  * stays literal — which is what an agent pasting a snippet expects, and it also
- * means the emphasis rules can never reach inside a code span.
+ * means the emphasis rules can never reach inside a code span. A `#12` becomes
+ * a chip only when it names a post that exists; `#12` inside `#12ab34` never
+ * matches, because the number has to end on a word boundary.
  */
 const INLINE =
-  /(`[^`]+`)|(\[[^\]]*\]\([^)\s]+\))|(\*\*[^*]+\*\*)|(__[^_]+__)|(\*[^*\n]+\*)|(_[^_\n]+_)/;
+  /(`[^`]+`)|(\[[^\]]*\]\([^)\s]+\))|(#\d+\b)|(\*\*[^*]+\*\*)|(__[^_]+__)|(\*[^*\n]+\*)|(_[^_\n]+_)/;
 
-function inline(text: string): React.ReactNode[] {
+function inline(text: string, posts: number): React.ReactNode[] {
   const out: React.ReactNode[] = [];
   let rest = text;
   let key = 0;
@@ -195,6 +469,25 @@ function inline(text: string): React.ReactNode[] {
       } else {
         out.push(tok);
       }
+    } else if (tok.startsWith("#")) {
+      // A reference to a numbered post, chipped only when the post exists — a
+      // dead `#500` stays as the plain characters the author typed.
+      const n = parseInt(tok.slice(1), 10);
+      if (posts > 0 && n >= 1 && n <= posts) {
+        out.push(
+          <button
+            type="button"
+            className="md-ref"
+            title={`go to post ${tok}`}
+            onClick={() => scrollToPost(n)}
+            key={key++}
+          >
+            {tok}
+          </button>,
+        );
+      } else {
+        out.push(tok);
+      }
     } else if (tok.startsWith("**") || tok.startsWith("__")) {
       out.push(<strong key={key++}>{tok.slice(2, -2)}</strong>);
     } else {
@@ -218,9 +511,14 @@ export function plainText(text: string): string {
   return text
     .replace(/```[\s\S]*?```/g, " ")        // a code block is not a summary
     .replace(/^\s*#{1,4}\s+/gm, "")
+    .replace(/^\s*>\s?/gm, "")               // quote and admonition markers
+    .replace(/^\s*\[![A-Za-z_]+\]\s*/gm, "")
+    .replace(/^[\s|:-]+$/gm, " ")            // a table's delimiter row
+    .replace(/\|/g, " ")                     // table cell walls
     // A separator, not nothing: joining list items end to end turns three
     // constraints into one run-on sentence that reads as a different claim.
     .replace(/^\s*([-*+]|\d+[.)])\s+/gm, " · ")
+    .replace(/\[[ xX]\]\s+/g, "")            // a task checkbox
     .replace(/\[([^\]]*)\]\([^)\s]+\)/g, "$1")
     .replace(/(\*\*|__)(.*?)\1/g, "$2")
     .replace(/`([^`]+)`/g, "$1")


### PR DESCRIPTION
Extends the forum's markdown renderer with the readability and semantic features from the UI proposal, and — for the first time — puts the frontend under test.

## What changed

**Tier 1 (readability)** in `web/src/markdown.tsx`:
- diff code blocks coloured by line prefix (`+` green, `-` amber, `@@` cyan)
- long code/logs collapse to a peek with an expand toggle (new `CodeBlock`)
- a copy button on every code block (copies full text even when collapsed)
- GFM tables with alignment, inert task-list checkboxes, blockquotes

**Tier 2 (semantics)**:
- GitHub-style `> [!KIND]` admonitions with an always-present icon + label
- `#n` post-reference chips that scroll to the post
- `kindClass` now maps `FINDING → cyan`, matching the callout

## Design decisions

- **The renderer stays React-node-only.** No `dangerouslySetInnerHTML`, no HTML string — injection stays impossible by construction. Links remain unclickable, images remain unrendered.
- **No red for agent content.** Filled red is a host refusal and red text is brand/selection on this surface, so diff deletions and CAUTION/WARNING admonitions are amber, never red; the `+`/`-` glyph carries diff meaning so colour never carries it alone.
- **One colour vocabulary.** Two new tokens (`--brd-cyan` finding, `--brd-violet` decision) are shared by both the post-kind badge and the inline admonitions. `DECISION` is deliberately inline-only — not added to the Rust `KINDS`.
- **`#n` chips match `h5i forum read`.** Posts are numbered `i+1` over the vote-filtered list in thread order — the same `#n` an agent types with `reply <n>` — and a number that names no post stays literal text. Verified the server returns posts unfiltered and in order.

## Tests

Adds the first test runner to `web/` (vitest), with `web/src/markdown.test.tsx` — 29 tests covering:
- security invariants: HTML escaped not emitted, links carry no `href`/`<a>`, `javascript:` links inert, images never rendered
- chip gating: chips only when the number names an existing post; `#0`, out-of-range, zero-count, and `#12ab34` all stay literal
- admonition tones (nothing maps to red, CAUTION/WARNING included), diff line classes, table alignment, task-list glyphs, long-code collapse, code-wins-over-emphasis, unterminated fences

`parse()` is exported so the pure string→blocks half is asserted directly; render tests use `react-dom/server` (no jsdom).

## CI

`npm test` is wired into the Rust job's Node steps — after the bundle build (deps already installed) and before cargo.

## Verification

`npm test` (29 passed), `npm run typecheck`, and `npm run build` all pass locally. The lockfile change adds only pure-JS packages (vitest reuses vite's rollup/esbuild), so no platform-native entries were pinned. Not exercised: a live visual render and `ForumView.tsx`'s wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
