### PR TITLE
Add h5i-git-hooks to SHOWCASE

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -2,3 +2,4 @@
 
 - [senv](https://github.com/h5i-dev/senv): Sandboxed Python environments, with the workflow of uv.
 - [h5i-fastapi-starter](https://github.com/SumedhAnupSupe/h5i-fastapi-starter): A small FastAPI application with a simple HTML UI, designed to run inside an h5i box.
+- [h5i-git-hooks](https://github.com/VedantMadane/h5i-git-hooks): Git hooks that run your test suite inside an h5i box (pre-commit on the staged tree, pre-push on the tip).


### PR DESCRIPTION
## Summary

Adds [h5i-git-hooks](https://github.com/VedantMadane/h5i-git-hooks) to `SHOWCASE.md`.

The helper installs `pre-commit` / `pre-push` hooks that run the configured suite inside an h5i box:

- **pre-commit** materializes the **staged tree** via `git write-tree` + `commit-tree` (avoids the classic footgun of testing HEAD)
- **pre-push** gates the tip about to leave the machine
- Config lives in `.h5i-hooks.toml` (not shell in the hook)
- `install` refuses to clobber foreign hooks (husky/lefthook can call `h5i-git-hooks run <stage>`)
- No-ops when `H5I_ENV_ID` is set (already inside a box)
- Failure output points at `h5i box inspect` and `git commit --no-verify`

Fixes #509

## Helper repository

- https://github.com/VedantMadane/h5i-git-hooks
- License: Apache-2.0
- Install: `cargo install --git https://github.com/VedantMadane/h5i-git-hooks`

## Test plan

- [x] Helper builds (unit tests for config defaults / TOML parse)
- [ ] On a Linux host with h5i: `h5i-git-hooks install --pre-commit` then fail a staged test and confirm commit refused