### PR TITLE
Add h5i-git-hooks to SHOWCASE

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -2,3 +2,4 @@
 
 - [senv](https://github.com/h5i-dev/senv): Sandboxed Python environments, with the workflow of uv.
 - [h5i-fastapi-starter](https://github.com/SumedhAnupSupe/h5i-fastapi-starter): A small FastAPI application with a simple HTML UI, designed to run inside an h5i box.
+- [h5i-git-hooks](https://github.com/VedantMadane/h5i-git-hooks): Git hooks that run your test suite inside an h5i box (pre-commit on the staged tree, pre-push on the whole suite).


### PR DESCRIPTION
## Summary

Adds [h5i-git-hooks](https://github.com/VedantMadane/h5i-git-hooks) to `SHOWCASE.md`.

Fixes #509

## What the companion tool does

- `h5i-git-hooks install --pre-commit` / `--pre-push` — installs hooks that refuse to clobber husky/lefthook
- `h5i-git-hooks run pre-commit` — tests the **staged tree** (via `git write-tree` + dangling `commit-tree`), not HEAD
- `h5i-git-hooks run pre-push` — whole suite against the push tip
- Config via `.h5i-hooks.toml` (command + profile), not shell edits in the hook
- Failure output points at `h5i box inspect` and `--no-verify` bypass
- No-ops when already inside a box (`H5I_ENV_ID`)

Apache-2.0 licensed.

## Test plan

- [x] Companion repo builds (`cargo test` unit tests for config/parse)
- [x] SHOWCASE link resolves to public repo