### PR TITLE
SHOWCASE: h5i-egress-advisor

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -2,3 +2,4 @@
 
 - [senv](https://github.com/h5i-dev/senv): Sandboxed Python environments, with the workflow of uv.
 - [h5i-fastapi-starter](https://github.com/SumedhAnupSupe/h5i-fastapi-starter): A small FastAPI application with a simple HTML UI, designed to run inside an h5i box.
+- [h5i-egress-advisor](https://github.com/AniketR10/h5i-egress-advisor): Reads a box's receipts and turns the egress its allowlist refused into `h5i box allow` lines to review — or a `[profile.X.net]` block for the tiers `h5i box allow` cannot reach.


### PR DESCRIPTION
Closes #506.

[**h5i-egress-advisor**](https://github.com/AniketR10/h5i-egress-advisor) reads a box's receipts, finds the destinations the egress allowlist refused, and turns each one into a question for a human. MIT, no dependency on h5i itself, opens the store read-only.

```bash
h5i box export mybox --out ./review
h5i-egress-advisor ./review/receipt.json     # an export bundle
h5i-egress-advisor --box mybox               # or the live box's receipt.jsonl
h5i-egress-advisor --box mybox --json
h5i-egress-advisor --box mybox --toml
```

```text
receipt: ./review/receipt.json
box env/claude/fix-auth · profile review · container tier

14 refused across 2 of 2 run(s) with egress verdicts, at 4 destination(s):

registry.npmjs.org:443             11 refused   in 2 runs (a3f1c2, 9b04de)
    while running: npm install
    a package registry or source host — the ordinary reason a build reaches out
    h5i box allow registry.npmjs.org

203.0.113.7:8443                    1 refused   in 1 run (9b04de)
    while running: npm test
    no suggestion: a bare address names nothing you can review — find out what it is first

cache.internal.example.com:6379     1 refused   in 1 run (9b04de)
    while running: npm test
    not a host this tool recognises, and :6379 is not HTTP — check the command that wanted it
    h5i box allow cache.internal.example.com:6379

telemetry.example.net:443           1 refused   in 1 run (a3f1c2)
    while running: npm install
    no suggestion: this looks like a beacon, not a dependency (the 'telemetry' label)

Nothing above has been applied: these are lines to read, decide on, and paste.
`h5i box allow` takes effect at the next run, and only on a profile that already
sets `net.egress` — it never widens a deny-all one.
```

A few things it does deliberately:

- **It suggests, and it refuses to suggest.** Known telemetry endpoints and hosts with a `telemetry`/`analytics`/`beacon` label get a reason instead of a command, as do bare IP addresses. An unrecognised host still gets a line — labelled as unrecognised, next to the command that wanted it — because "I have not heard of this" is not evidence of anything.
- **It prints; it never applies.** Nothing in it runs `h5i`, and it opens the receipt store read-only.
- **`--toml` exists because `h5i box allow` does not reach every box.** The host-side list is merged by the proxy tiers only, and only into a profile that already scopes `net.egress`. So the tool reads the receipt's `isolation_claim` and says which situation the reader is in, rather than printing a command that would silently do nothing on a `supervised` box; `--toml` then emits the `[profile.X.net]` block for `.h5i/env.toml`.
- **It never passes a clamped list off as complete.** `hosts_truncated` and a run whose summary counts refusals with no per-destination detail are both reported as notes.
- Exit `0` clean / `1` refusals / `2` unreadable, so it works in a hook.

The receipt model is a subset of h5i's with every field optional, so a receipt written by a newer h5i still parses; a torn tail line is tolerated the way h5i's own reader tolerates it, and a torn line anywhere else is reported as corruption. 43 tests (unit + end-to-end against fixture receipts and a store in the real layout), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean in CI.