### PR TITLE
browser: the half that parses the page holds none of the decisions

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -365,6 +365,50 @@ the session runs unconfined **and says which**, on the placement line and in the
 record. A sandbox nobody can see is indistinguishable from one that was never
 applied.
 
+### Two processes: the broker and the renderer
+
+A session is two processes, and neither is a command you type. The one h5i
+starts is the **broker**: it holds the allowlist, the HTTP client, the receipt
+sink, the cookie jar, the per-page budget and the credentials. It starts the
+**renderer**, which parses the HTML, runs the cascade, decodes the images and
+fonts, runs the page's script and draws the frame. The renderer holds none of
+the things in that first list. It asks; the broker decides and records.
+
+```
+$ ps -o pid,ppid,args
+  55509  36242  h5i __engine serve https://example.com ...
+  55511  55509  h5i __engine --brokered serve https://example.com ...
+```
+
+The reason is that a browser's parsers are where a stranger's bytes are read. A
+bug in Blitz, Stylo, an image decoder or Boa used to be a bug in the process
+that also held the policy, the jar and every `H5I_SECRET_*` in the environment.
+Now it is a bug in a process whose environment has none of them, and whose only
+route to the network is to ask something else, which writes a receipt first.
+
+**What this buys, exactly:**
+
+- Credentials named with `--secret` are in the broker's environment and not in
+  the renderer's. A page-bound `type` resolves through the broker, so the
+  renderer receives the value for the field it was told to fill and no other.
+- The receipts path, the egress proxy and the allowlist are likewise absent
+  from the renderer.
+- The cookie jar is not in the renderer's memory. Script sees the non-`HttpOnly`
+  subset because it asks for it, which is the same answer it always got, from a
+  place a parser bug cannot reach past.
+- When the renderer dies the broker knows, with a status. When the broker dies
+  the renderer stops, because a renderer that cannot receipt is not a browser.
+
+**What it does not buy yet.** The renderer is in the broker's network namespace,
+so it can still open a socket of its own. The split moved what a compromised
+parser can reach *in memory*. The request log becomes evidence against a
+compromised parser only when the renderer's own profile denies the network,
+which is ROADMAP §B18.7 step 3 and is not built.
+
+`H5I_BROWSER_NO_SPLIT=1` runs the engine as one process, the way it ran before.
+It is there for comparing the two shapes, and for a host where spawning is the
+problem. A spawn that fails falls back to one process on its own, and says so.
+
 ### `--in <box>`: the same session, inside a box
 
 ```bash

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -343,7 +343,25 @@ Two consequences worth knowing before they surprise you:
 
 - **Secrets are not inherited.** Unconfined, the engine reads the whole
   environment, so a compromised one reads every `H5I_SECRET_*` on the machine.
-  Confined it reads none unless named: `h5i browser open <url> --secret ACME_PASS`.
+  Confined it reads none unless named:
+
+        H5I_SECRET_ACME_PASS=... h5i browser open https://acme.test --secret ACME_PASS
+        h5i browser type @e2 '$H5I_SECRET_ACME_PASS'
+
+    `--secret ACME_PASS` and `--secret H5I_SECRET_ACME_PASS` name the same
+    credential. The value is resolved from the environment the command is
+    started in, once, and delivered to that session alone. It lands in the
+    session's broker process, not in the renderer that parses the page.
+
+    Fail-closed: a credential that cannot be resolved refuses the session,
+    rather than starting one that will decline the first `type` that needs it.
+    The same in both shapes, because a host that cannot confine still has to
+    answer `--secret` the same way.
+
+    Not for `--in`. A session placed in a box gets its credentials from that
+    box's policy, declared in `.h5i/env.toml` under the profile it was created
+    with. `--secret` with `--in` is refused rather than ignored.
+
 - **Personal fonts are visible, and nothing else under `$HOME` is.** `~/.fonts`
   and `~/.local/share/fonts` are granted read-only, because a font someone
   installed is not the page's font: the ones a page supplies arrive over

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -407,8 +407,13 @@ route to the network is to ask something else, which writes a receipt first.
 **What this buys, exactly:**
 
 - Credentials named with `--secret` are in the broker's environment and not in
-  the renderer's. A page-bound `type` resolves through the broker, so the
+  the renderer's. A page-bound `type` resolves through the broker, so an intact
   renderer receives the value for the field it was told to fill and no other.
+  A compromised one can ask the broker to resolve any credential **this session
+  was granted**, which is the narrowing the split actually buys: it cannot
+  reach one the session was not granted, and unconfined that would have been
+  every `H5I_SECRET_*` on the machine. Narrowing it further needs the control
+  channel to move to the broker, which is not built.
 - The receipts path, the egress proxy and the allowlist are likewise absent
   from the renderer.
 - The cookie jar is not in the renderer's memory. Script sees the non-`HttpOnly`

--- a/README.md
+++ b/README.md
@@ -258,6 +258,26 @@ a host that cannot confine runs the session unconfined and says so.
 </details>
 
 <details>
+<summary>Why does one session show up as two processes?</summary>
+
+Because the half that parses a stranger's bytes should not be the half that
+holds the decisions. The process h5i starts is the broker: the allowlist, the
+HTTP client, the receipt sink, the cookie jar and the credentials. It starts the
+renderer, which parses the HTML, runs the cascade and the script and draws the
+frame. The renderer holds none of those. Its environment has no `H5I_SECRET_*`
+in it, and its only route to the network is to ask the broker, which records
+first.
+
+Neither half is a command. `h5i browser open` is unchanged, and
+`H5I_BROWSER_NO_SPLIT=1` runs the old single process if you want to compare.
+
+It does not yet make the log evidence against a compromised renderer: the
+renderer is still in the broker's network namespace, so it could open a socket
+of its own. That closes when the renderer's own profile denies the network.
+
+</details>
+
+<details>
 <summary>What do `engine-claimed` and `host-observed` mean?</summary>
 
 `engine-claimed` is the browser's own account of what it fetched: fail-closed,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7098,7 +7098,7 @@ no socket, its profile can move from `net.mode = host` to `deny` — an empty
 network namespace — which is a one-line change to `browser_sandbox::profile_for`
 and the whole reason this ordering is right.
 
-### B18.3 The four cases the table does not settle
+### B18.3 The cases the table does not settle
 
 **Cookies: the gain is narrower than it first looks.** The obvious claim — "the
 renderer would see only the non-HttpOnly subset" — is already true where it
@@ -7122,6 +7122,35 @@ credential that was not typed: today a compromised engine reads all of
 mean injecting at the HTTP layer rather than the DOM layer, which works for a
 form post and not for JS-driven auth. That is the boundary, and it belongs in
 the docs the day this ships.
+
+> **Corrected 2026-08-27, on building it.** "It reads the ones actually used" is
+> not what step 2 delivers, and the docs say the accurate thing instead.
+> `substitute` is an *operation*, so a compromised renderer can resolve every
+> name `secret_names` returns rather than only the one it was told to type. The
+> narrowing is real and it is about the **set**, not the count: the renderer's
+> environment holds no `H5I_SECRET_*` at all, so it reaches what this session
+> was granted and not what the machine has — which unconfined is everything.
+> "The ones actually used" becomes true when the control channel moves to the
+> broker (the §B18.2 table), because only then does the broker know which field
+> is being typed into. Until that, claiming it would be the kind of sentence
+> this section exists to refuse.
+
+**The asker's origin is the renderer's word.** Found on building it, and it
+belongs beside the other four. Half of this engine's policy reasons about *who
+is asking*: the loopback rule refuses a page from the open web reaching the
+box's dev server, and the same-origin check decides whether the document that
+asked may read the answer. Both take the asking document as an argument, and
+after the split that argument arrives from the renderer. A renderer that claims
+"the agent named this URL" gets the answer the agent would have got.
+
+This is not a regression — the same code chose the origin before the split,
+because it was the same code — and it is not fixed by the split either. It is
+the shape of a real tightening: the broker knows every document it has served,
+so it could refuse to attribute a request to one it never answered with. That
+narrows an invented origin to a previously-served one, which is worth having
+and is not what step 2 built. Until then, "the broker decides" is exactly true
+of the allowlist and the address, and true of the origin rules only for a
+renderer that is telling the truth about which page it is on.
 
 **`@ref` resolution stays in the renderer.** Handles are Blitz node ids and live
 with the DOM. The broker keeps the *record* of what it served, for the audit. A
@@ -7264,9 +7293,13 @@ through a named set of operations is a broker whose surface is written down.
   session: no orphan, and `h5i browser close` still reads the record.
 - **Secrets are the measurable gain today.** `H5I_SECRET_*` is removed from the
   renderer's environment, along with the receipts path, the proxy and the
-  allowlist. Substitution is a broker operation, so the renderer receives the
-  value for the field it was told to fill and holds no other. That is the bound
-  §B18.3 promised, and it is now the code rather than the plan.
+  allowlist. Substitution is a broker operation, so an intact renderer receives
+  the value for the field it was told to fill and holds no other — and a
+  compromised one reaches what this session was *granted* rather than what the
+  machine holds, which is the narrowing that is actually delivered. See the
+  correction in §B18.3: "the ones actually used" waits on the control channel
+  moving, and until then saying it would be a sentence this file exists to
+  refuse.
 
   Measuring it turned up that the claim had never been true in the other
   direction either: `--secret NAME` set `profile.secrets` and nothing consumed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7034,8 +7034,20 @@ hit "Save as draft" and "Discard without saving".
 
 ## B18. The broker/renderer split, proposed 2026-08-27
 
-Status: **proposed.** Nothing here is built. §B18.6 is the measured seam, which
-is the part worth trusting; the rest is a design that has not met a compiler.
+Status: **steps 1 and 2 built, 2026-08-27. Step 3 is not.** `h5i browser open`
+runs two processes now: a broker holding the policy, the wire, the receipts, the
+jar, the budget and the secrets, and a renderer holding the DOM, the cascade,
+the decoders and the script realm and none of the rest. The seam is
+`broker::Broker`; the transport is `ipc`; the renderer's environment is scrubbed
+of `H5I_SECRET_*`. Nothing user-visible changed and there is no new subcommand.
+
+**What is still true after step 2, and must keep being said.** The renderer
+holds no socket *of the engine's* — and it is not yet stopped from opening one
+of its own, because its network namespace is still the broker's. So a
+compromised parser cannot read the jar, edit the allowlist, silence the sink or
+enumerate the secrets, and it *can* still connect somewhere and not be in the
+log. The receipt claim upgrades at step 3, not here. §B18.8 is why step 3 is not
+a line in `profile_for`.
 
 The default session sandbox landed first (`h5i-core::browser_sandbox`), and it
 sharpened the case for this rather than replacing it. That sandbox contains what
@@ -7196,27 +7208,114 @@ It was not taken, for two reasons:
   half that parses the page holds no socket and can be given a profile written
   for a process that only parses.
 
-So this is a §B18.7 step 3 concern, not a patch: when the renderer becomes its
-own process, its profile is authored rather than inherited, and `default_fs_read`
-stops being the thing that decides what a hostile page can read. Until then the
-honest statement — the one the CLI already makes — is that the default sandbox
-contains the engine's *writes* and its environment, not its reads.
+So this is a §B18.7 step 3 concern, not a patch: when the renderer's profile is
+*authored* rather than inherited, `default_fs_read` stops being the thing that
+decides what a hostile page can read. Until then the honest statement — the one
+the CLI already makes — is that the default sandbox contains the engine's
+*writes* and its environment, not its reads.
+
+**Updated 2026-08-27, after step 2.** The renderer is its own process now and
+this paragraph is still true, because the renderer's profile is *inherited* and
+not authored: it is the Landlock domain the broker was already in, which
+`execve` carries across unchanged. Becoming a separate process was necessary
+and, on its own, not sufficient — see §B18.8 for why the authoring has to happen
+outside both halves.
 
 ### B18.7 Order
 
-1. **The seam, still one process.** Put the broker behind a trait and make the
-   renderer call it through that. `jar()` becomes operations. Refactoring, with
-   the existing tests as the harness, and nothing user-visible changes.
-2. **Two processes.** The trait's implementation becomes an IPC client;
-   `h5i browser open` spawns the broker, the broker spawns the renderer
-   confined. Both are internal: `h5i browser open` is unchanged, and there is no
-   subcommand or concept for either half — the same conclusion §"The id is not
-   the interface" reached about session ids, applied to processes.
+1. **The seam, still one process.** ✅ Built. `broker::Broker` is the named set
+   of operations; `net::LocalBroker` is the implementation that does the work
+   here. `jar()` became `document_cookie` / `store_cookie` / `keep_only_origin`,
+   which is where the `HttpOnly` split now lives. `budget()` returned a live
+   `&Budget` and returns an `Allowance` — a reading — because there is nothing
+   to borrow across a process. The two streams became one `Channel` trait with
+   `send` / `drain` / `close`, which is exactly the surface `dom_api.rs` was
+   already using.
+2. **Two processes.** ✅ Built. `ipc::BrokerClient` implements the trait over a
+   socket; `cli::become_broker` builds the broker, spawns the renderer, serves
+   until it exits, and exits with its status. Both halves are internal:
+   `h5i browser open` is unchanged and there is no subcommand for either — the
+   same conclusion §"The id is not the interface" reached about session ids,
+   applied to processes.
 3. **Tighten the renderer's profile** to `net.mode = deny`, and add the third
-   lane value with the tests that keep it apart from `host-observed`.
+   lane value with the tests that keep it apart from `host-observed`. Not built,
+   and not for want of a line: see §B18.8.
 
-Step 1 is worth doing whether or not step 2 follows: a broker reachable only
+Step 1 was worth doing whether or not step 2 followed: a broker reachable only
 through a named set of operations is a broker whose surface is written down.
+
+#### What step 2 turned out to cost, and to buy
+
+- **The renderer is spawned by the broker re-execing itself** with a hidden
+  `--brokered` flag and the socket as its standard input. An inherited
+  descriptor rather than a port (nothing on the machine can connect to it) or a
+  path (nothing to clean up). The child's argv is the parent's, unchanged: two
+  halves that parsed different command lines would be two engines that could
+  disagree about what was asked for.
+- **The confinement came for free**, and this was the pleasant surprise. The
+  session sandbox already grants read on the engine's own binary — a confined
+  `execve` needs it — so the broker can start the renderer from inside it, and
+  Landlock's domain is inherited and cannot be relaxed. The renderer is
+  confined exactly as the single process was, with no change to
+  `browser_sandbox` at all.
+- **A dead broker takes the renderer with it.** The reply thread sees EOF and
+  the renderer stops, because a renderer that cannot fetch or receipt and whose
+  parent is gone is not a browser. Verified by killing the broker of a resident
+  session: no orphan, and `h5i browser close` still reads the record.
+- **Secrets are the measurable gain today.** `H5I_SECRET_*` is removed from the
+  renderer's environment, along with the receipts path, the proxy and the
+  allowlist. Substitution is a broker operation, so the renderer receives the
+  value for the field it was told to fill and holds no other. That is the bound
+  §B18.3 promised, and it is now the code rather than the plan.
+- **Redaction had to become a batch.** It runs over every string in every
+  control reply; one round trip per string would have made it the most expensive
+  thing the control channel does. `redact_all` is the operation, and the default
+  implementation is still the loop.
+- **The control channel did not move**, and the table in §B18.2 still says it
+  should. It is renderer-side for now, which means the reply an agent reads is
+  written by the untrusted half. That is a smaller hole than it sounds — the
+  renderer holds the terminal either way — and it is the next thing to move
+  after step 3.
+
+### B18.8 Why step 3 is not one line in `profile_for`
+
+The plan said `net.mode = deny` for the renderer was "a one-line change to
+`browser_sandbox::profile_for`". It is not, and the reason is worth writing down
+before somebody spends an afternoon on it.
+
+The renderer is spawned **by the broker**, and the broker is already inside the
+sandbox. Applying a second, tighter confinement from there needs a new network
+namespace, and `unshare` and `setns` are both on this codebase's own seccomp
+deny-list (`seccomp_deny_program`). The broker cannot make a namespace it is
+denied the syscall for. Landlock could be stacked — domains nest — but the
+network cannot.
+
+So the confinement has to be authored **outside** both halves, and there are two
+shapes:
+
+- **`h5i browser` creates the socket pair and spawns both.** It is unconfined,
+  so it can resolve two policies and start two children — the broker with
+  `net.mode = host`, the renderer with `Deny` and a profile written for a
+  process that only parses (no `/tmp`, no resolver grants, no `/etc` beyond what
+  a font needs). It costs the broker its `wait()` on the renderer, which becomes
+  an EOF instead — the split already treats EOF as the renderer exiting, so the
+  code is there.
+- **A launcher handed to the broker.** `h5i-browser-light` gains a trait, and
+  `h5i __engine` — which links `h5i-core` — registers an implementation that
+  execs the renderer confined. The crate graph allows it (nothing depends on
+  `h5i-browser-light` but the binary), and it keeps "the broker spawns the
+  renderer" literally true. It does not solve the syscall problem: the launcher
+  runs in the broker, and the broker is the process seccomp is filtering.
+
+The first is the one that works. The second is the one that reads better, and
+would only work if the broker were left unconfined — which is the wrong trade,
+because the broker parses server bytes too (TLS records, headers, gzip and
+brotli streams) and wants a sandbox of its own.
+
+Recording this because the honest version of the current state is *"the renderer
+is confined exactly as much as the whole engine was, and no more"* — the split
+moved what a compromised parser can **reach in memory**, not yet what it can
+**reach on the network**.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7267,6 +7267,17 @@ through a named set of operations is a broker whose surface is written down.
   allowlist. Substitution is a broker operation, so the renderer receives the
   value for the field it was told to fill and holds no other. That is the bound
   §B18.3 promised, and it is now the code rather than the plan.
+
+  Measuring it turned up that the claim had never been true in the other
+  direction either: `--secret NAME` set `profile.secrets` and nothing consumed
+  it, so under the default sandbox a named credential never reached the engine
+  at all and `h5i browser env` answered "no credentials" for one it had been
+  told to carry. `browser_sandbox` now declares `secret_grants` beside the name
+  list and `h5i browser` brokers them through `secrets_broker` like any other
+  run, on both the confined and the unconfined path — fail-closed is a property
+  of the promise, not of the sandbox. `--secret` with `--in` is refused rather
+  than ignored: a box declares its grants in `.h5i/env.toml`, and `spawn_in_box`
+  never read the flag.
 - **Redaction had to become a batch.** It runs over every string in every
   control reply; one round trip per string would have made it the most expensive
   thing the control channel does. `redact_all` is the operation, and the default

--- a/crates/h5i-browser-light/Cargo.toml
+++ b/crates/h5i-browser-light/Cargo.toml
@@ -57,7 +57,7 @@ vello_cpu = { version = "=0.0.9", default-features = false, features = ["png"] }
 parley = { version = "0.10", default-features = false, features = ["std"] }
 
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-url = "2.5"
+url = { version = "2.5", features = ["serde"] }
 
 # The operating system's own CSPRNG, for `crypto.getRandomValues`. A browser
 # promises unpredictability there; a seeded generator wearing the name would be

--- a/crates/h5i-browser-light/examples/perf.rs
+++ b/crates/h5i-browser-light/examples/perf.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use h5i_browser_light::engine::{PageFactory, PageOptions};
-use h5i_browser_light::net::Broker;
+use h5i_browser_light::net::LocalBroker;
 use h5i_browser_light::policy::Policy;
 use h5i_browser_light::receipt::MemorySink;
 
@@ -46,10 +46,9 @@ fn document_with_script(rows: usize) -> String {
     html
 }
 
-fn factory(script: bool) -> (PageFactory, Arc<Broker>) {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+fn factory(script: bool) -> (PageFactory, Arc<LocalBroker>) {
+    let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+        .expect("broker");
     let fonts = h5i_browser_light::fonts::load(
         &[],
         &h5i_browser_light::fonts::default_font_dirs(),

--- a/crates/h5i-browser-light/src/broker.rs
+++ b/crates/h5i-browser-light/src/broker.rs
@@ -112,6 +112,17 @@ pub struct CorsAsk {
     pub credentials: Credentials,
 }
 
+/// The whole request log, in the three numbers a windowed read still needs.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogSummary {
+    /// Every record, both phases, over the life of the session.
+    pub total: usize,
+    /// Requests the policy refused.
+    pub denied: usize,
+    /// The cursor to pass back as `since`.
+    pub highest: Option<u64>,
+}
+
 /// What a page has spent, and what it was allowed.
 ///
 /// A reading rather than a live handle. `budget()` used to hand back a
@@ -166,6 +177,43 @@ pub trait Broker: Send + Sync {
     /// mark a verb takes before it runs.
     fn high_water(&self) -> Option<u64> {
         self.records().iter().map(|r| r.seq).max()
+    }
+
+    /// The records after `mark`, which is what a reader polling for what
+    /// changed actually wants.
+    ///
+    /// Separate from [`Self::records`] because this crosses a process boundary:
+    /// answering "what happened since sequence 4000" by shipping four thousand
+    /// records and throwing them away is the shape the `since` cursor exists to
+    /// avoid, and it would grow with the session rather than with the answer.
+    fn records_since(&self, mark: Option<u64>) -> Vec<RequestRecord> {
+        self.records()
+            .into_iter()
+            .filter(|r| mark.is_none_or(|floor| r.seq > floor))
+            .collect()
+    }
+
+    /// The whole log in three numbers.
+    ///
+    /// The counts a windowed read still has to report: "nothing was refused" is
+    /// a claim about the session rather than about the window, and an agent
+    /// that only ever asks for windows should still be able to make it. Three
+    /// numbers rather than the log they are derived from, for the same reason
+    /// [`Self::records_since`] exists.
+    fn log_summary(&self) -> LogSummary {
+        let records = self.records();
+        LogSummary {
+            total: records.len(),
+            denied: records
+                .iter()
+                .filter(|r| r.phase == crate::receipt::Phase::Request && !r.allowed)
+                .count(),
+            // The highest sequence, not the last appended: numbers are taken
+            // before the append and a socket's reader thread appends
+            // concurrently with the page's own fetches, so append order and
+            // sequence order can differ.
+            highest: records.iter().map(|r| r.seq).max(),
+        }
     }
 
     /// Sequence numbers recorded after `mark`, deduplicated and in order.

--- a/crates/h5i-browser-light/src/broker.rs
+++ b/crates/h5i-browser-light/src/broker.rs
@@ -1,0 +1,303 @@
+//! The broker, as a named set of operations rather than a struct.
+//!
+//! Everything that decides and records lives behind this trait: the allowlist,
+//! the wire, the receipt sink, the cookie jar, the per-page budget and the
+//! secrets. Everything that parses a stranger's bytes — the HTML parser, the
+//! cascade, the layout, the image decoders, the script realm — calls *through*
+//! it and holds none of it.
+//!
+//! # Why a trait and not a struct
+//!
+//! Two implementations, and the second is the point:
+//!
+//! * [`crate::net::LocalBroker`] does the work here, in this process. One
+//!   process, exactly as this engine has always run.
+//! * [`crate::ipc::BrokerClient`] asks another process to do it. The renderer
+//!   holds a socket to its parent and nothing else — no policy to edit, no jar
+//!   to read, no sink to silence, no `H5I_SECRET_*` in its environment.
+//!
+//! The claim this engine makes is "a request that is not in the log did not
+//! happen", and in one process that claim is only as strong as the parsers
+//! sharing the address space with the recorder. Splitting moves the recorder
+//! somewhere a compromised parser cannot reach it. See ROADMAP §B18.
+//!
+//! # The rule for adding to this trait
+//!
+//! Every method here becomes a message a hostile renderer may send at will, in
+//! any order, with any arguments. So the operations are the ones that were
+//! measured (§B18.6) and no more: nothing that hands back a live reference to
+//! broker state, and nothing that lets the caller name a *thing* the broker
+//! holds rather than a *request* the broker decides about. The cookie jar is
+//! the worked example — it used to be reachable as `broker.jar()`, which
+//! cannot cross a process boundary and, on this side of it, would have handed
+//! the page's parsers the session. It is three operations now, and
+//! `HttpOnly` is enforced inside them.
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::budget::{Limits, Spent};
+use crate::cors::{Credentials, Mode};
+use crate::receipt::{Initiator, RequestRecord};
+use crate::secrets::Resolved;
+use crate::wsclient::Event;
+
+pub use crate::net::FetchOutcome;
+
+/// One request, with everything the broker needs to decide about it.
+///
+/// A struct rather than eight arguments because it crosses a process boundary:
+/// what the broker is told is exactly this, written down in one place, and a
+/// caller cannot add a field the far side does not know how to police.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Fetch {
+    pub url: Url,
+    pub initiator: Initiator,
+    pub method: String,
+    /// Empty for a GET. Carried out of band on the wire, never in the JSON.
+    #[serde(skip)]
+    pub body: Vec<u8>,
+    pub content_type: Option<String>,
+    /// The document that asked, when a document did.
+    ///
+    /// Load-bearing rather than bookkeeping: without it the policy reads every
+    /// subresource as the agent naming a URL, and a page from the open web
+    /// reaches the box's dev server. See [`crate::policy::Policy::check_from`].
+    pub document: Option<Url>,
+    /// Set when a *page* asked, which is what subjects the answer to the
+    /// same-origin policy. `None` is the agent exercising its own authority
+    /// over a URL it named, which is a different question — see [`crate::cors`].
+    pub cors: Option<CorsAsk>,
+}
+
+impl Fetch {
+    /// A URL the agent named. No document, so the loopback rule treats this as
+    /// an instruction rather than as something a page reached for.
+    pub fn get(url: &Url, initiator: Initiator) -> Self {
+        Self {
+            url: url.clone(),
+            initiator,
+            method: "GET".to_string(),
+            body: Vec::new(),
+            content_type: None,
+            document: None,
+            cors: None,
+        }
+    }
+
+    /// The document that asked for this, for the origin the policy reasons
+    /// about.
+    pub fn from_document(mut self, document: Option<&Url>) -> Self {
+        self.document = document.cloned();
+        self
+    }
+
+    pub fn with_body(mut self, method: &str, body: &[u8], content_type: Option<&str>) -> Self {
+        self.method = method.to_string();
+        self.body = body.to_vec();
+        self.content_type = content_type.map(str::to_string);
+        self
+    }
+}
+
+/// What a page's own `fetch` brings with it, and nothing an agent's navigation
+/// has.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CorsAsk {
+    /// The document whose origin is asking.
+    pub document: Url,
+    pub headers: Vec<(String, String)>,
+    pub mode: Mode,
+    pub credentials: Credentials,
+}
+
+/// What a page has spent, and what it was allowed.
+///
+/// A reading rather than a live handle. `budget()` used to hand back a
+/// `&Budget` the caller could poll; across a process boundary there is nothing
+/// to borrow, so the answer is a value taken at one moment and named as one.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Allowance {
+    pub spent: Spent,
+    pub limits: Limits,
+}
+
+/// A long-lived connection, from the side that does not own it.
+///
+/// WebSocket and server-sent events are the two things in this engine that are
+/// not request-and-answer, and they are the two the split has to carry rather
+/// than transport. The socket itself stays with the broker — it is the wire —
+/// and the renderer holds this: send a message, take what has arrived, stop.
+///
+/// `drain` is a poll rather than a callback deliberately. The renderer's settle
+/// loop already asks "has anything happened" on a tick, and a broker that
+/// pushed would need a queue on the renderer's side that a chatty server could
+/// grow without bound.
+pub trait Channel: Send + Sync {
+    /// Send a text frame. `Err` for a stream that cannot be written to, which
+    /// is what a server-sent event stream is.
+    fn send(&self, text: &str) -> Result<(), String>;
+    /// Everything that has arrived since the last drain.
+    fn drain(&self) -> Vec<Event>;
+    /// Stop. Idempotent, because the page may close a socket the peer already
+    /// did.
+    fn close(&self);
+}
+
+/// The one way bytes enter this engine.
+pub trait Broker: Send + Sync {
+    /// Check policy, record the decision, use the wire — in that order, and
+    /// with no second path. Every other fetch entry point on this trait is a
+    /// convenience over this one.
+    fn send(&self, fetch: &Fetch) -> FetchOutcome;
+
+    /// The requests this broker has decided about, in the order it recorded
+    /// them.
+    ///
+    /// The renderer displays these; it does not own them. The authoritative
+    /// copy is the broker's own sink and the file it writes, which is the
+    /// distinction worth keeping in mind when the renderer prints a table: a
+    /// compromised renderer holds the terminal and can print whatever it likes.
+    /// What it cannot do is change what was written.
+    fn records(&self) -> Vec<RequestRecord>;
+
+    /// The highest sequence recorded so far, or `None` on an empty log. The
+    /// mark a verb takes before it runs.
+    fn high_water(&self) -> Option<u64> {
+        self.records().iter().map(|r| r.seq).max()
+    }
+
+    /// Sequence numbers recorded after `mark`, deduplicated and in order.
+    fn since(&self, mark: Option<u64>) -> Vec<u64> {
+        let mut seen: Vec<u64> = self
+            .records()
+            .iter()
+            .map(|r| r.seq)
+            .filter(|seq| mark.is_none_or(|floor| *seq > floor))
+            .collect();
+        seen.sort_unstable();
+        seen.dedup();
+        seen
+    }
+
+    /// What this page has spent, and what it may.
+    fn budget(&self) -> Allowance;
+
+    /// A navigation is starting, so the page's allowance starts again. See
+    /// [`crate::budget`] for why the ceiling bounds a page rather than a
+    /// session.
+    fn reset_budget(&self);
+
+    /// How many cookies the session holds. A count, never a value.
+    fn cookie_count(&self) -> usize;
+
+    /// What `document.cookie` may see: the non-`HttpOnly` subset for this URL.
+    fn document_cookie(&self, url: &Url) -> String;
+
+    /// Store a cookie script set, subject to the same rules the wire path
+    /// applies — and to one more, since script may not set `HttpOnly`.
+    /// Returns how many were stored.
+    fn store_cookie(&self, url: &Url, header: &str) -> usize;
+
+    /// Leaving an origin drops every other origin's cookies. `true` when
+    /// something was dropped, which the page reports as a note.
+    fn keep_only_origin(&self, origin: &Url) -> bool;
+
+    /// Authorise, record, and dial a WebSocket.
+    fn open_socket(&self, url: &Url, document: Option<&Url>) -> Result<Arc<dyn Channel>, String>;
+
+    /// The same, for an event stream.
+    fn open_event_stream(
+        &self,
+        url: &Url,
+        document: Option<&Url>,
+    ) -> Result<Arc<dyn Channel>, String>;
+
+    /// The credentials this session may substitute, by name. Never values —
+    /// that is the whole of [`crate::secrets`].
+    fn secret_names(&self) -> Vec<String>;
+
+    /// Resolve `$H5I_SECRET_*` placeholders on the way into a field.
+    ///
+    /// The limit is worth stating where the operation is declared, because it
+    /// is easy to oversell: substitution happens on the way *into* the page, so
+    /// the renderer receives the value for the credential that was actually
+    /// used. What the split protects is every credential that was not — a
+    /// compromised renderer no longer holds the environment, so it reads the
+    /// ones it was handed and no others.
+    fn substitute(&self, text: &str) -> Resolved;
+
+    /// Put the placeholder back wherever a value appears in outgoing text.
+    fn redact(&self, text: &str) -> String;
+
+    /// The same, for every string in one reply.
+    ///
+    /// A batch rather than a loop over [`Self::redact`], because a reply is a
+    /// tree with hundreds of strings in it and this crosses a process boundary:
+    /// one round trip per string would make redaction the most expensive thing
+    /// the control channel does. The default is the loop, for the
+    /// implementation where a round trip is a function call.
+    fn redact_all(&self, texts: &[String]) -> Vec<String> {
+        texts.iter().map(|text| self.redact(text)).collect()
+    }
+
+    // ── convenience over `send` ─────────────────────────────────────────────
+    //
+    // Kept as default methods rather than as free functions so the call sites
+    // read the way they did before the trait existed, and so there is exactly
+    // one place each of them turns into a `Fetch`.
+
+    /// Fetch a URL the agent named.
+    fn fetch(&self, url: &Url, initiator: Initiator) -> FetchOutcome {
+        self.send(&Fetch::get(url, initiator))
+    }
+
+    /// Fetch something a *document* asked for.
+    fn fetch_from(&self, url: &Url, initiator: Initiator, document: Option<&Url>) -> FetchOutcome {
+        self.send(&Fetch::get(url, initiator).from_document(document))
+    }
+
+    /// Send a request that may carry a body — what a form submission needs.
+    fn send_from(
+        &self,
+        url: &Url,
+        initiator: Initiator,
+        method: &str,
+        body: &[u8],
+        content_type: Option<&str>,
+        document: Option<&Url>,
+    ) -> FetchOutcome {
+        self.send(
+            &Fetch::get(url, initiator)
+                .with_body(method, body, content_type)
+                .from_document(document),
+        )
+    }
+
+    /// The same send, subject to the same-origin policy: a *page* exercising an
+    /// authority it has to be granted.
+    #[allow(clippy::too_many_arguments)]
+    fn send_script(
+        &self,
+        url: &Url,
+        method: &str,
+        body: &[u8],
+        content_type: Option<&str>,
+        document: &Url,
+        headers: &[(String, String)],
+        mode: Mode,
+        credentials: Credentials,
+    ) -> FetchOutcome {
+        let mut fetch = Fetch::get(url, Initiator::Subresource)
+            .with_body(method, body, content_type)
+            .from_document(Some(document));
+        fetch.cors = Some(CorsAsk {
+            document: document.clone(),
+            headers: headers.to_vec(),
+            mode,
+            credentials,
+        });
+        self.send(&fetch)
+    }
+}

--- a/crates/h5i-browser-light/src/budget.rs
+++ b/crates/h5i-browser-light/src/budget.rs
@@ -39,7 +39,7 @@ use std::time::{Duration, Instant};
 /// Every field is a *ceiling*, and the defaults are chosen to be far above what
 /// a real page does and far below what a runaway one would: a documentation
 /// page makes tens of requests, and a loop makes as many as it can.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Limits {
     pub max_requests: u64,
     /// Bytes as they crossed the wire, so a compressed response is counted at
@@ -53,6 +53,7 @@ pub struct Limits {
     /// Not the same as a per-request timeout: a hundred requests that each take
     /// two seconds are each well within the 30s per-request limit and together
     /// are three minutes an agent is waiting.
+    #[serde(with = "millis")]
     pub max_network_time: Duration,
 }
 
@@ -201,17 +202,32 @@ impl Budget {
 }
 
 /// A reading of what has been spent.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Spent {
     pub requests: u64,
     pub wire_bytes: u64,
     pub decoded_bytes: u64,
-    #[serde(serialize_with = "as_millis")]
+    #[serde(with = "millis")]
     pub network_time: Duration,
 }
 
-fn as_millis<S: serde::Serializer>(value: &Duration, out: S) -> Result<S::Ok, S::Error> {
-    out.serialize_u64(value.as_millis() as u64)
+/// Durations as whole milliseconds, both ways.
+///
+/// The console has always read these as a number of milliseconds, so the
+/// serialized form is fixed by something outside this crate. What is new is the
+/// other direction: a reading of the budget now crosses a process boundary, and
+/// a value that only serializes is a value the renderer cannot be told.
+mod millis {
+    use std::time::Duration;
+
+    pub fn serialize<S: serde::Serializer>(value: &Duration, out: S) -> Result<S::Ok, S::Error> {
+        out.serialize_u64(value.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(input: D) -> Result<Duration, D::Error> {
+        use serde::Deserialize;
+        Ok(Duration::from_millis(u64::deserialize(input)?))
+    }
 }
 
 /// A wall-clock bound on one navigation, from the first byte to the last.

--- a/crates/h5i-browser-light/src/cli.rs
+++ b/crates/h5i-browser-light/src/cli.rs
@@ -23,9 +23,9 @@ use std::sync::Arc;
 
 use clap::{Args, Parser, Subcommand};
 use crate::engine::{Page, PageFactory, PageOptions};
-use crate::net::Broker;
+use crate::broker::Broker;
 use crate::policy::Policy;
-use crate::receipt::{JsonlSink, MemorySink, RequestRecord, Sink};
+use crate::receipt::{JsonlSink, MemorySink, Sink};
 use crate::{fonts, Capabilities};
 use h5i_error::H5iError;
 use url::Url;
@@ -67,6 +67,14 @@ const ACTIONS_VAR: &str = "H5I_BROWSER_ACTIONS";
     about = "A lightweight visual browser for coding agents: every request is policy-checked and receipted before it reaches the wire."
 )]
 struct Cli {
+    /// This process is the renderer half; its broker is on standard input.
+    ///
+    /// Hidden because it is not an interface. Nobody types it: the broker
+    /// spawns the renderer with it, and `h5i browser open` is unchanged. See
+    /// [`crate::ipc`] for what the two halves are and why.
+    #[arg(long = "brokered", hide = true)]
+    brokered: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -779,23 +787,6 @@ struct ViewArgs {
     script: bool,
 }
 
-/// Writes to both sinks, and fails if either refuses.
-///
-/// The display sink is what the CLI prints at the end; the file sink is the
-/// durable record. Requiring both to succeed keeps the fail-closed rule from
-/// quietly weakening when someone passes `--receipts`.
-struct TeeSink {
-    display: Arc<MemorySink>,
-    file: Arc<dyn Sink>,
-}
-
-impl Sink for TeeSink {
-    fn append(&self, record: &RequestRecord) -> Result<(), H5iError> {
-        self.display.append(record)?;
-        self.file.append(record)
-    }
-}
-
 /// Run the engine's CLI over `args`, which must include the program name.
 ///
 /// Exits the process on failure rather than returning, because the caller is a
@@ -817,12 +808,104 @@ where
     }
 }
 
+/// Which half of the engine this process is.
+///
+/// Two processes by default: a broker that decides and records, and a renderer
+/// that parses the page. `Whole` is the shape the engine had before the split,
+/// kept because a host where the second process cannot be started is a host
+/// that should still be able to read a page — and because being able to run
+/// both shapes is what makes them comparable. See [`crate::ipc`].
+enum Half {
+    /// One process, brokering its own requests.
+    Whole,
+    /// This process renders. Everything that decides or records is on the
+    /// other end of this.
+    Renderer(Arc<crate::ipc::BrokerClient>),
+}
+
 fn run<I, T>(args: I) -> Result<(), H5iError>
 where
     I: IntoIterator<Item = T>,
     T: Into<std::ffi::OsString> + Clone,
 {
-    match Cli::parse_from(args).command {
+    let argv: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
+    let cli = Cli::parse_from(&argv);
+    // May not return: a process that becomes the broker spends the rest of its
+    // life answering the renderer, and exits with the renderer's status.
+    let half = half_for(&cli, &argv)?;
+    dispatch(cli.command, &half)
+}
+
+/// Decide which half this process is, and — when it is the broker — never come
+/// back.
+fn half_for(cli: &Cli, argv: &[std::ffi::OsString]) -> Result<Half, H5iError> {
+    if cli.brokered {
+        return Ok(Half::Renderer(crate::ipc::BrokerClient::on_stdin()?));
+    }
+    // Only the two commands that load a page have a broker to split from. The
+    // rest — `capabilities`, `doctor`, the session verbs, `replay` — either
+    // answer from this process or talk to a session that already exists.
+    let Some(net) = cli.command.net() else {
+        return Ok(Half::Whole);
+    };
+    if !crate::ipc::splitting() {
+        return Ok(Half::Whole);
+    }
+    become_broker(net, argv)
+}
+
+/// Build the broker, start the renderer under it, and serve until it exits.
+///
+/// Returns only when the renderer could not be started at all, and then the
+/// engine runs as one process and **says so**. A sandbox nobody can see is
+/// indistinguishable from one that was never applied, and the same is true of
+/// a split.
+#[cfg(unix)]
+fn become_broker(net: &NetArgs, argv: &[std::ffi::OsString]) -> Result<Half, H5iError> {
+    let broker = local_broker(net)?;
+    let (mut renderer, socket) = match crate::ipc::spawn_renderer(argv) {
+        Ok(pair) => pair,
+        Err(error) => {
+            eprintln!(
+                "h5i-browser-light: {error}. Running as one process: the policy, the receipts, \
+                 the cookie jar and the secrets are in the same process as the page's parsers."
+            );
+            return Ok(Half::Whole);
+        }
+    };
+
+    crate::ipc::serve(broker, socket);
+
+    // The renderer closed the socket, which is what exiting looks like from
+    // here. Its status is this process's status: `h5i browser` is waiting on
+    // one child and must not be told a page loaded because the broker's own
+    // work went fine.
+    let status = renderer
+        .wait()
+        .map_err(|e| H5iError::Metadata(format!("the renderer could not be waited for: {e}")))?;
+    std::process::exit(exit_code(&status));
+}
+
+#[cfg(not(unix))]
+fn become_broker(_net: &NetArgs, _argv: &[std::ffi::OsString]) -> Result<Half, H5iError> {
+    Ok(Half::Whole)
+}
+
+/// A child's status as an exit code, including the one a signal produced.
+///
+/// A renderer killed by the kernel's OOM killer is the case worth naming: it
+/// exits with no code at all, and reporting `0` there would say the page loaded.
+#[cfg(unix)]
+fn exit_code(status: &std::process::ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+    status
+        .code()
+        .or_else(|| status.signal().map(|signal| 128 + signal))
+        .unwrap_or(1)
+}
+
+fn dispatch(command: Command, half: &Half) -> Result<(), H5iError> {
+    match command {
         Command::Capabilities { script } => {
             // Reported for the configuration asked about, because what h5i
             // routes on is whether *this* invocation runs script.
@@ -842,7 +925,7 @@ where
             screenshot,
             text,
             json,
-        } => open(&targets, &net, &view, screenshot, text, json),
+        } => open(half, &targets, &net, &view, screenshot, text, json),
         Command::Serve {
             target,
             net,
@@ -855,6 +938,7 @@ where
             actions,
             once,
         } => serve(
+            half,
             &target,
             &net,
             &view,
@@ -869,6 +953,24 @@ where
     }
 }
 
+impl Command {
+    /// The network arguments this command brokers with, when it brokers at all.
+    ///
+    /// The two that load a page have one; the rest either answer from this
+    /// process or speak to a session that already exists. It is also the test
+    /// for whether this invocation splits into two processes, and those are the
+    /// same question: a command with no broker has no halves.
+    fn net(&self) -> Option<&NetArgs> {
+        match self {
+            Command::Open { net, .. } | Command::Serve { net, .. } => Some(net),
+            Command::Capabilities { .. }
+            | Command::Doctor { .. }
+            | Command::Session(_)
+            | Command::Replay { .. } => None,
+        }
+    }
+}
+
 /// Build the factory and load the first page, shared by `open` and `serve`.
 /// Everything a page needs, built once.
 ///
@@ -877,20 +979,37 @@ where
 /// font set — all three are per-*session* facts, and building them per page
 /// meant a run over twenty URLs re-read the font files twenty times and threw
 /// away every keep-alive connection between them.
-fn factory_for(net: &NetArgs, view: &ViewArgs) -> Result<(Arc<MemorySink>, PageFactory), H5iError> {
-    let policy = build_policy(net);
-    let (display, sink) = build_sinks(net)?;
-    let mut broker = Broker::new(policy, sink, proxy_of(net).as_deref())?;
-    broker.set_budget_limits(crate::budget::Limits {
-        max_requests: net.max_requests,
-        max_wire_bytes: net.max_wire_bytes,
-        // The decoded ceiling follows the wire one rather than being its own
-        // flag: it exists to bound what compression expands into, so tying it
-        // to the wire limit keeps the two from being set inconsistently.
-        max_decoded_bytes: net.max_wire_bytes.saturating_mul(4),
-        max_network_time: std::time::Duration::from_secs(net.max_network_seconds),
-    });
-    let broker = Arc::new(broker);
+/// The broker this process would build for itself.
+///
+/// One function, two callers, and that is the point: the broker process builds
+/// exactly what a whole process would have built, so the two shapes cannot
+/// drift into applying different policies or different ceilings.
+fn local_broker(net: &NetArgs) -> Result<Arc<crate::net::LocalBroker>, H5iError> {
+    crate::net::LocalBroker::with_limits(
+        build_policy(net),
+        receipts_sink(net)?,
+        proxy_of(net).as_deref(),
+        crate::budget::Limits {
+            max_requests: net.max_requests,
+            max_wire_bytes: net.max_wire_bytes,
+            // The decoded ceiling follows the wire one rather than being its
+            // own flag: it exists to bound what compression expands into, so
+            // tying it to the wire limit keeps the two from being set
+            // inconsistently.
+            max_decoded_bytes: net.max_wire_bytes.saturating_mul(4),
+            max_network_time: std::time::Duration::from_secs(net.max_network_seconds),
+        },
+    )
+}
+
+fn factory_for(half: &Half, net: &NetArgs, view: &ViewArgs) -> Result<PageFactory, H5iError> {
+    let broker: Arc<dyn Broker> = match half {
+        Half::Whole => local_broker(net)?,
+        // Nothing is built here: no policy, no sink, no jar, no secrets. This
+        // process asks, and the answers come from a process the page cannot
+        // reach.
+        Half::Renderer(client) => client.clone(),
+    };
     let font_setup = load_fonts(view);
     if font_setup.is_empty() {
         eprintln!("h5i-browser-light: no fonts registered; text will not be drawn.");
@@ -909,7 +1028,7 @@ fn factory_for(net: &NetArgs, view: &ViewArgs) -> Result<(Arc<MemorySink>, PageF
             navigation_budget: std::time::Duration::from_secs(view.navigation_seconds),
         },
     );
-    Ok((display, factory))
+    Ok(factory)
 }
 
 /// One page, through a factory that already exists.
@@ -928,17 +1047,19 @@ fn open_target(factory: &PageFactory, target: &str) -> Result<Page, H5iError> {
 }
 
 fn load(
+    half: &Half,
     target: &str,
     net: &NetArgs,
     view: &ViewArgs,
-) -> Result<(Arc<MemorySink>, PageFactory, Page), H5iError> {
-    let (display, factory) = factory_for(net, view)?;
+) -> Result<(PageFactory, Page), H5iError> {
+    let factory = factory_for(half, net, view)?;
     let page = open_target(&factory, target)?;
-    Ok((display, factory, page))
+    Ok((factory, page))
 }
 
 #[allow(clippy::too_many_arguments)]
 fn serve(
+    half: &Half,
     target: &str,
     net: &NetArgs,
     view: &ViewArgs,
@@ -950,7 +1071,7 @@ fn serve(
     action_log: Option<PathBuf>,
     once: bool,
 ) -> Result<(), H5iError> {
-    let (requests, factory, page) = load(target, net, view)?;
+    let (factory, page) = load(half, target, net, view)?;
     let control_socket =
         control_socket.or_else(|| std::env::var(CONTROL_SOCKET_VAR).ok().map(PathBuf::from));
     let stream_file = stream_file.or_else(|| std::env::var(STREAM_FILE_VAR).ok().map(PathBuf::from));
@@ -988,7 +1109,6 @@ fn serve(
             control_socket,
             action_log,
             once,
-            requests,
         },
     )
 }
@@ -1647,22 +1767,21 @@ fn proxy_of(net: &NetArgs) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
-fn build_sinks(net: &NetArgs) -> Result<(Arc<MemorySink>, Arc<dyn Sink>), H5iError> {
-    let display = Arc::new(MemorySink::new());
+/// The durable half of the record, when one was asked for.
+///
+/// The other half is never optional: the broker keeps every record in memory
+/// whatever this returns, which is what `h5i browser open` prints and what the
+/// renderer can ask for. This is the file, and it is the one that can refuse —
+/// which is what makes `--receipts` the flag that puts the fail-closed rule
+/// under h5i's control rather than the caller's.
+fn receipts_sink(net: &NetArgs) -> Result<Arc<dyn Sink>, H5iError> {
     let receipts = net
         .receipts
         .clone()
         .or_else(|| std::env::var(RECEIPTS_VAR).ok().map(PathBuf::from));
     match &receipts {
-        None => Ok((display.clone(), display)),
-        Some(path) => {
-            let file = Arc::new(JsonlSink::create(path)?);
-            let tee = Arc::new(TeeSink {
-                display: display.clone(),
-                file,
-            });
-            Ok((display, tee))
-        }
+        None => Ok(Arc::new(crate::receipt::NullSink)),
+        Some(path) => Ok(Arc::new(JsonlSink::create(path)?)),
     }
 }
 
@@ -1712,12 +1831,13 @@ fn doctor(net: &NetArgs) -> Result<(), H5iError> {
 
     // Prove the client can actually be built with these settings rather than
     // reporting a configuration that fails at the first fetch.
-    Broker::new(policy, Arc::new(MemorySink::new()), proxy.as_deref())?;
+    crate::net::LocalBroker::new(policy, Arc::new(MemorySink::new()), proxy.as_deref())?;
     println!("client     : ok");
     Ok(())
 }
 
 fn open(
+    half: &Half,
     targets: &[String],
     net: &NetArgs,
     view: &ViewArgs,
@@ -1736,7 +1856,7 @@ fn open(
         ));
     }
 
-    let (display, factory) = factory_for(net, view)?;
+    let factory = factory_for(half, net, view)?;
     let mut results: Vec<serde_json::Value> = Vec::new();
     let mut failures = 0usize;
 
@@ -1745,7 +1865,7 @@ fn open(
         // batch — that sharing is the point — so a per-page view has to be cut
         // out of it rather than read whole, or every page after the first would
         // report the requests of the ones before it.
-        let seen_before = display.records().len();
+        let seen_before = factory.broker().records().len();
 
         let page = match open_target(&factory, target) {
             Ok(page) => page,
@@ -1770,7 +1890,7 @@ fn open(
         if targets.len() > 1 && !as_json && at > 0 {
             println!();
         }
-        let page_records = display.records().split_off(seen_before);
+        let page_records = factory.broker().records().split_off(seen_before);
         match one_page(
             page,
             page_records,

--- a/crates/h5i-browser-light/src/cli.rs
+++ b/crates/h5i-browser-light/src/cli.rs
@@ -815,6 +815,7 @@ where
 /// kept because a host where the second process cannot be started is a host
 /// that should still be able to read a page — and because being able to run
 /// both shapes is what makes them comparable. See [`crate::ipc`].
+#[cfg_attr(not(unix), allow(dead_code))]
 enum Half {
     /// One process, brokering its own requests.
     Whole,
@@ -840,7 +841,7 @@ where
 /// back.
 fn half_for(cli: &Cli, argv: &[std::ffi::OsString]) -> Result<Half, H5iError> {
     if cli.brokered {
-        return Ok(Half::Renderer(crate::ipc::BrokerClient::on_stdin()?));
+        return renderer_half();
     }
     // Only the two commands that load a page have a broker to split from. The
     // rest — `capabilities`, `doctor`, the session verbs, `replay` — either
@@ -852,6 +853,28 @@ fn half_for(cli: &Cli, argv: &[std::ffi::OsString]) -> Result<Half, H5iError> {
         return Ok(Half::Whole);
     }
     become_broker(net, argv)
+}
+
+/// This process is the renderer: its broker is on the descriptor it was handed.
+#[cfg(unix)]
+fn renderer_half() -> Result<Half, H5iError> {
+    Ok(Half::Renderer(crate::ipc::BrokerClient::on_stdin()?))
+}
+
+/// There is no renderer half where there is no split.
+///
+/// The transport is a socket pair a child inherits, which is a Unix
+/// arrangement, so everywhere else the engine runs as one process — the way it
+/// always did. A `--brokered` here is a flag h5i itself would never pass on
+/// this platform, and saying so beats adopting whatever standard input happens
+/// to be.
+#[cfg(not(unix))]
+fn renderer_half() -> Result<Half, H5iError> {
+    Err(H5iError::Metadata(
+        "`--brokered` is how the broker starts the renderer, and this platform does not run \
+         the engine as two processes."
+            .to_string(),
+    ))
 }
 
 /// Build the broker, start the renderer under it, and serve until it exits.

--- a/crates/h5i-browser-light/src/cors.rs
+++ b/crates/h5i-browser-light/src/cors.rs
@@ -103,7 +103,7 @@ impl Origin {
 }
 
 /// How a request treats the origin boundary. The `mode` of `fetch`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum Mode {
     /// Refuse to cross it at all.
     SameOrigin,
@@ -125,7 +125,7 @@ impl Mode {
 }
 
 /// Whether cookies ride along. The `credentials` of `fetch`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum Credentials {
     Omit,
     /// Cookies for a same-origin request only. The default, and the reason a

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -21,7 +21,8 @@ use h5i_error::H5iError;
 use url::Url;
 
 use crate::fonts::FontSetup;
-use crate::net::{Broker, BrokerNet};
+use crate::broker::Broker;
+use crate::net::BrokerNet;
 use crate::receipt::Initiator;
 use crate::snapshot::Snapshot;
 
@@ -228,7 +229,7 @@ impl Page {
     /// in the receipt.
     pub fn open(
         url: &Url,
-        broker: Arc<Broker>,
+        broker: Arc<dyn Broker>,
         fonts: FontSetup,
         options: PageOptions,
     ) -> Result<Self, H5iError> {
@@ -362,7 +363,7 @@ impl Page {
         bytes: &[u8],
         content_type: Option<&str>,
         base_url: &Url,
-        broker: Arc<Broker>,
+        broker: Arc<dyn Broker>,
         fonts: FontSetup,
         options: PageOptions,
     ) -> Self {
@@ -392,7 +393,7 @@ impl Page {
     fn parse(
         html: &str,
         base_url: &Url,
-        broker: Arc<Broker>,
+        broker: Arc<dyn Broker>,
         fonts: &FontSetup,
         viewport: Viewport,
         captured: CapturedNavigation,
@@ -435,7 +436,7 @@ impl Page {
     pub fn from_html(
         html: &str,
         base_url: &Url,
-        broker: Arc<Broker>,
+        broker: Arc<dyn Broker>,
         fonts: FontSetup,
         options: PageOptions,
     ) -> Self {
@@ -558,7 +559,7 @@ impl Page {
     /// Obscura, a much larger engine in the same space, drops and recreates its
     /// whole JS runtime on every navigation for exactly this reason. The cost
     /// is real and it is the right one to pay.
-    pub fn run_scripts(&mut self, broker: Arc<Broker>) -> Result<(), H5iError> {
+    pub fn run_scripts(&mut self, broker: Arc<dyn Broker>) -> Result<(), H5iError> {
         // In document order, inline and external together, because execution
         // order is semantics: a bundle that defines a global in one script and
         // uses it in the next breaks if they are reordered.
@@ -1715,14 +1716,14 @@ pub enum WaitTarget {
 /// files again, which costs a few milliseconds per navigation and buys a much
 /// simpler ownership story than sharing a collection across documents.
 pub struct PageFactory {
-    broker: Arc<Broker>,
+    broker: Arc<dyn Broker>,
     font_sources: Vec<std::path::PathBuf>,
     options: PageOptions,
 }
 
 impl PageFactory {
     pub fn new(
-        broker: Arc<Broker>,
+        broker: Arc<dyn Broker>,
         font_sources: Vec<std::path::PathBuf>,
         options: PageOptions,
     ) -> Self {
@@ -1737,7 +1738,7 @@ impl PageFactory {
         &self.options
     }
 
-    pub fn broker(&self) -> &Arc<Broker> {
+    pub fn broker(&self) -> &Arc<dyn Broker> {
         &self.broker
     }
 
@@ -1815,7 +1816,7 @@ impl PageFactory {
     /// The rule itself, on a borrow, so the two infallible constructors can run
     /// it too rather than keeping their own copy of half of it.
     fn finish_page(&self, page: &mut Page) -> Result<(), H5iError> {
-        if self.broker.jar().retain_origin(page.url()) {
+        if self.broker.keep_only_origin(page.url()) {
             page.note(
                 "cookies from the previous origin were dropped on navigation: this engine \
                  holds a session only for the origin currently loaded",
@@ -1825,10 +1826,8 @@ impl PageFactory {
             page.run_scripts(self.broker.clone())?;
         }
         // After everything, so subresources and script fetches are counted.
-        page.budget_spent = Some((
-            self.broker.budget().spent(),
-            self.broker.budget().limits().clone(),
-        ));
+        let allowance = self.broker.budget();
+        page.budget_spent = Some((allowance.spent, allowance.limits));
         Ok(())
     }
 
@@ -1861,7 +1860,7 @@ impl PageFactory {
     /// would give the page that just spent its allowance a clean slate for the
     /// subresources it is about to ask for.
     fn begin_navigation(&self) {
-        self.broker.budget().reset();
+        self.broker.reset_budget();
     }
 
     pub fn open(&self, url: &Url) -> Result<Page, H5iError> {
@@ -2259,7 +2258,7 @@ mod tests {
     use crate::receipt::MemorySink;
 
     fn page_from(html: &str, policy: Policy, sink: Arc<MemorySink>) -> Page {
-        let broker = Arc::new(Broker::new(policy, sink, None).expect("broker"));
+        let broker = crate::net::LocalBroker::new(policy, sink, None).expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(4));
         Page::from_html(
             html,
@@ -2611,14 +2610,12 @@ mod navigation_origin_tests {
     /// pressing a submit button.
     #[test]
     fn a_form_submission_drops_the_previous_origins_cookies() {
-        let broker = Arc::new(
-            Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 Policy::new().allow("bank.example").allow("evil.example"),
                 Arc::new(MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         // A live session on one origin.
         broker.jar().store(
             &Url::parse("https://bank.example/").unwrap(),
@@ -2662,14 +2659,12 @@ mod navigation_origin_tests {
     /// having one.
     #[test]
     fn staying_on_an_origin_keeps_the_session_through_finish() {
-        let broker = Arc::new(
-            Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 Policy::new().allow("bank.example"),
                 Arc::new(MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         broker.jar().store(
             &Url::parse("https://bank.example/").unwrap(),
             ["sid=secret; HttpOnly"],
@@ -2698,9 +2693,7 @@ mod input_tests {
     use crate::receipt::MemorySink;
 
     fn page_with(html: &str) -> Page {
-        let broker = Arc::new(
-            Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-        );
+        let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(4));
         let factory = PageFactory::new(broker, fonts.sources.clone(), PageOptions::default());
         factory.from_html(html, &Url::parse("https://site.example/page").unwrap())

--- a/crates/h5i-browser-light/src/extract.rs
+++ b/crates/h5i-browser-light/src/extract.rs
@@ -310,14 +310,12 @@ mod tests {
     use serde_json::json;
 
     fn doc_of(html: &str) -> (crate::engine::Page, url::Url) {
-        let broker = std::sync::Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new(),
                 std::sync::Arc::new(crate::receipt::MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = crate::engine::PageFactory::new(
             broker,

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -20,16 +20,35 @@
 //! # What a hostile renderer can do here
 //!
 //! Everything this protocol allows, in any order, with any arguments — so what
-//! it allows is the whole of the security argument. It can ask for a URL and be
-//! refused. It can ask what is in the log. It can ask for a cookie header it is
-//! already entitled to (`document.cookie`'s non-`HttpOnly` subset). It cannot
-//! edit the policy, silence the sink, read an `HttpOnly` cookie, enumerate a
-//! secret's value, or reach the network without a receipt being written first,
-//! because none of those is a message.
+//! it allows is the whole of the security argument, and it is worth writing
+//! down in both directions rather than only the flattering one.
 //!
-//! What it *can* still do is lie about what it renders, which is why the split
-//! is described as moving the recorder out of reach rather than as making the
-//! renderer trustworthy.
+//! **What it cannot do**, because none of these is a message: edit the policy,
+//! silence the receipt sink, read an `HttpOnly` cookie, reach the network
+//! without a decision record being written first, or touch a credential this
+//! session was not granted.
+//!
+//! **What it can do**, and this is the part that is easy to oversell away:
+//!
+//! * **Claim any origin as the asker.** `Fetch::document` is the renderer's to
+//!   fill in, and it is what the origin-sensitive half of the policy reasons
+//!   about — the loopback rule, the same-origin check. A renderer that says
+//!   "the agent named this URL" gets the answer the agent would have got. This
+//!   is not new: the same code chose the origin before the split, because it
+//!   was the same process. It is also not fixed by the split, and the tighter
+//!   version — the broker refusing to attribute a request to a document it
+//!   never served — is not built.
+//! * **Ask for any credential this session was granted.** `substitute` is an
+//!   operation, so a renderer can resolve every name `secret_names` returns
+//!   rather than only the one it was told to type. What the split narrows is
+//!   the *set*: the renderer's environment holds none of them, so it reaches
+//!   what this session was granted and not every `H5I_SECRET_*` on the machine
+//!   — which unconfined is all of them. Narrowing it to "the one being typed"
+//!   needs the control channel on this side of the boundary, which is §B18.2's
+//!   table and is not built.
+//! * **Lie about what it renders.** It holds the terminal and the frame. The
+//!   split moves the recorder out of its reach; it does not make the renderer
+//!   trustworthy, and no arrangement of processes could.
 //!
 //! # Framing
 //!
@@ -707,11 +726,21 @@ fn serve_over(
     }
 }
 
-/// Whether answering this means waiting on the network.
+/// Whether answering this can block, and so needs a thread of its own.
+///
+/// The wire, in every form it takes here. `ChannelClose` is on the list for a
+/// reason that is easy to miss: closing a socket sends a close frame and takes
+/// the same lock a `send` holds, so a peer that has stopped reading can stall
+/// it — and answered on the reading thread, that would stop the broker serving
+/// *anything* until the peer relented.
 fn slow(ask: &Ask) -> bool {
     matches!(
         ask,
-        Ask::Send(_) | Ask::OpenSocket { .. } | Ask::OpenEventStream { .. } | Ask::ChannelSend { .. }
+        Ask::Send(_)
+            | Ask::OpenSocket { .. }
+            | Ask::OpenEventStream { .. }
+            | Ask::ChannelSend { .. }
+            | Ask::ChannelClose { .. }
     )
 }
 
@@ -1192,6 +1221,76 @@ mod tests {
         assert!(methods.iter().any(|m| m == "WS-OPEN"), "{methods:?}");
         assert!(methods.iter().any(|m| m == "WS-RECV"), "{methods:?}");
         assert!(methods.iter().any(|m| m == "WS-SEND"), "{methods:?}");
+    }
+
+    /// One request, answered with the body it was sent. Enough HTTP to carry a
+    /// body in each direction, which is the only thing this needs to prove.
+    fn echo_server() -> (u16, std::thread::JoinHandle<()>) {
+        use std::io::{BufRead, BufReader, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let handle = std::thread::spawn(move || {
+            let Ok((stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            let mut length = 0usize;
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    return;
+                }
+                if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                    length = value.trim().parse().unwrap_or(0);
+                }
+                if line == "\r\n" || line == "\n" {
+                    break;
+                }
+            }
+            let mut body = vec![0u8; length];
+            let _ = std::io::Read::read_exact(&mut reader, &mut body);
+            let mut stream = stream;
+            let _ = write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(&body);
+            let _ = stream.flush();
+        });
+        (port, handle)
+    }
+
+    #[test]
+    fn a_body_crosses_in_both_directions() {
+        // Bodies travel beside the message rather than inside it — base64 in
+        // the JSON would pay a third again in bytes on exactly the path a
+        // page's images take — so the framing carries two lengths and two
+        // buffers. This is the test that the second buffer is wired to the
+        // right end at both ends.
+        let (port, server) = echo_server();
+        let (client, broker, _served) = paired();
+        let url = Url::parse(&format!("http://127.0.0.1:{port}/echo")).expect("url");
+
+        let sent = b"a body long enough to be more than a header".to_vec();
+        let outcome = client.send_from(
+            &url,
+            Initiator::Navigation,
+            "POST",
+            &sent,
+            Some("text/plain"),
+            None,
+        );
+        assert!(outcome.is_ok(), "{outcome:?}");
+        assert_eq!(outcome.body, sent, "the answer is what the server was sent");
+
+        // And the receipt is the broker's, written where the bytes moved.
+        let methods: Vec<String> = Broker::records(broker.as_ref())
+            .iter()
+            .map(|r| r.method.clone())
+            .collect();
+        assert!(methods.iter().any(|m| m == "POST"), "{methods:?}");
+        let _ = server.join();
     }
 
     #[test]

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -53,7 +53,7 @@ use h5i_error::H5iError;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::broker::{Allowance, Broker, Channel, Fetch};
+use crate::broker::{Allowance, Broker, Channel, Fetch, LogSummary};
 use crate::net::{FetchOutcome, LocalBroker};
 use crate::receipt::RequestRecord;
 use crate::secrets::Resolved;
@@ -66,13 +66,21 @@ use crate::wsclient::Event;
 /// broker that went away wakes everybody at once.
 type Waiting = Arc<Mutex<HashMap<u64, SyncSender<(Said, Vec<u8>)>>>>;
 
-/// The largest header or body one message may carry.
+/// The largest body one message may carry.
 ///
-/// A ceiling on what either half can make the other allocate. Response bodies
-/// are already capped far below this by the page budget
-/// (`--max-wire-bytes`), so this is the backstop for a message that got past
-/// that or was never subject to it, not the working limit.
-const MAX_FRAME: usize = 256 * 1024 * 1024;
+/// A ceiling on what either half can make the other allocate. It is the page's
+/// decoded-bytes ceiling (`crate::budget::Limits::max_decoded_bytes`) rather
+/// than a number of its own, because the largest legitimate blob is exactly one
+/// response body and that is what bounds one.
+const MAX_BLOB: usize = 256 * 1024 * 1024;
+
+/// The largest header one message may carry.
+///
+/// Smaller than the blob, and separate from it, because a header is JSON about
+/// a request rather than the request's bytes. Not *small*: `Said::Records`
+/// carries a long session's whole log and `Ask::RedactAll` carries every string
+/// in a snapshot reply. This is the ceiling on those, not their working size.
+const MAX_HEADER: usize = 64 * 1024 * 1024;
 
 /// What the renderer asks for. One variant per operation on
 /// [`crate::broker::Broker`], and nothing that is not one.
@@ -81,6 +89,10 @@ enum Ask {
     /// The request body travels in the blob, never in this.
     Send(Fetch),
     Records,
+    RecordsSince {
+        mark: Option<u64>,
+    },
+    LogSummary,
     HighWater,
     Since {
         mark: Option<u64>,
@@ -142,6 +154,7 @@ enum Said {
     /// The response body travels in the blob.
     Outcome(FetchOutcome),
     Records(Vec<RequestRecord>),
+    Summary(LogSummary),
     Seqs(Vec<u64>),
     Mark(Option<u64>),
     Budget(Allowance),
@@ -180,9 +193,17 @@ fn read_frame(input: &mut impl Read) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
     input.read_exact(&mut prefix)?;
     let header_len = u32::from_be_bytes(prefix[..4].try_into().unwrap()) as usize;
     let blob_len = u32::from_be_bytes(prefix[4..].try_into().unwrap()) as usize;
-    if header_len > MAX_FRAME || blob_len > MAX_FRAME {
+    // Checked before either buffer is allocated: the length is the other side's
+    // to write, and reserving what it claims before reading what it sends is
+    // how a number becomes an allocation.
+    if header_len > MAX_HEADER {
         return Err(std::io::Error::other(format!(
-            "a message of {header_len}+{blob_len} bytes is over the {MAX_FRAME}-byte ceiling"
+            "a {header_len}-byte message header is over the {MAX_HEADER}-byte ceiling"
+        )));
+    }
+    if blob_len > MAX_BLOB {
+        return Err(std::io::Error::other(format!(
+            "a {blob_len}-byte message body is over the {MAX_BLOB}-byte ceiling"
         )));
     }
     let mut header = vec![0u8; header_len];
@@ -209,6 +230,19 @@ pub struct BrokerClient {
     next: AtomicU64,
     waiting: Waiting,
     gone: Arc<AtomicBool>,
+    /// Whether this session has any credential at all, asked once.
+    ///
+    /// Redaction runs over every string in every control reply, and with no
+    /// secrets configured it is provably a no-op — `Secrets::redact` iterates
+    /// the values it holds, and there are none. Without this that no-op cost
+    /// two copies of a whole snapshot reply across the socket, on every verb,
+    /// for the overwhelmingly common session that named no credential.
+    ///
+    /// Cached because it cannot change: the broker reads `H5I_SECRET_*` once,
+    /// when it is built, and offers no operation that would add one. That is
+    /// the same property `stream.rs` used to rely on when it read the
+    /// environment once at startup so a later `setenv` could not widen it.
+    has_secrets: std::sync::OnceLock<bool>,
 }
 
 impl BrokerClient {
@@ -232,6 +266,7 @@ impl BrokerClient {
             next: AtomicU64::new(0),
             waiting: waiting.clone(),
             gone: gone.clone(),
+            has_secrets: std::sync::OnceLock::new(),
         });
 
         let _ = std::thread::Builder::new()
@@ -275,6 +310,13 @@ impl BrokerClient {
         // hand fd 0 to whatever opened a file next.
         let stdin = std::io::stdin();
         let socket = unsafe { std::os::unix::net::UnixStream::from_raw_fd(stdin.as_raw_fd()) };
+        // Is this actually the broker? `--brokered` is hidden and nobody types
+        // it, but somebody will, and adopting a terminal as the protocol means
+        // the first fetch blocks on a read from the keyboard with no
+        // explanation. `local_addr` is the cheapest question that distinguishes
+        // a socket from everything else — it answers `ENOTSOCK` for a tty, a
+        // pipe or a file.
+        let is_socket = socket.local_addr().is_ok();
         let reader = socket.try_clone().map_err(|e| {
             H5iError::Metadata(format!("the broker socket could not be cloned: {e}"))
         })?;
@@ -284,6 +326,15 @@ impl BrokerClient {
         let writer = reader.try_clone().map_err(|e| {
             H5iError::Metadata(format!("the broker socket could not be cloned: {e}"))
         })?;
+        if !is_socket {
+            return Err(H5iError::Metadata(
+                "this process was started as the renderer half of the engine, but its standard \
+                 input is not a broker. `--brokered` is not an interface: it is how the broker \
+                 starts the renderer, and the two halves are spawned together by \
+                 `h5i browser open`. Run that instead."
+                    .to_string(),
+            ));
+        }
         Ok(Self::over(Box::new(reader), Box::new(writer), true))
     }
 
@@ -293,12 +344,22 @@ impl BrokerClient {
     /// refusal its own signature can express, because "the broker is gone" is
     /// not a state any of them can render around.
     fn ask(&self, ask: Ask, blob: &[u8]) -> Option<(Said, Vec<u8>)> {
-        if self.gone.load(Ordering::SeqCst) {
-            return None;
-        }
         let id = self.next.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = sync_channel(1);
-        self.waiting.lock().ok()?.insert(id, tx);
+        {
+            // Registered and checked under one lock, in that order, against the
+            // reply thread's `store(gone)` then `clear()`. Checking first and
+            // registering after leaves a window where the broker ends between
+            // the two: the entry lands in a map nobody will look at again, the
+            // write into a closed socket's buffer succeeds, and the caller
+            // waits for an answer that cannot come. The renderer exits on that
+            // path so it was survivable there and nowhere else.
+            let mut waiting = self.waiting.lock().ok()?;
+            if self.gone.load(Ordering::SeqCst) {
+                return None;
+            }
+            waiting.insert(id, tx);
+        }
 
         let header = serde_json::to_vec(&Question { id, ask }).ok()?;
         let written = {
@@ -374,6 +435,24 @@ impl Broker for BrokerClient {
         match self.said(Ask::Records) {
             Some(Said::Records(records)) => records,
             _ => Vec::new(),
+        }
+    }
+
+    fn records_since(&self, mark: Option<u64>) -> Vec<RequestRecord> {
+        match self.said(Ask::RecordsSince { mark }) {
+            Some(Said::Records(records)) => records,
+            _ => Vec::new(),
+        }
+    }
+
+    fn log_summary(&self) -> LogSummary {
+        match self.said(Ask::LogSummary) {
+            Some(Said::Summary(summary)) => summary,
+            _ => LogSummary {
+                total: 0,
+                denied: 0,
+                highest: None,
+            },
         }
     }
 
@@ -481,6 +560,9 @@ impl Broker for BrokerClient {
     }
 
     fn redact(&self, text: &str) -> String {
+        if !self.holds_a_secret() {
+            return text.to_string();
+        }
         match self.said(Ask::Redact {
             text: text.to_string(),
         }) {
@@ -490,6 +572,9 @@ impl Broker for BrokerClient {
     }
 
     fn redact_all(&self, texts: &[String]) -> Vec<String> {
+        if !self.holds_a_secret() {
+            return texts.to_vec();
+        }
         match self.said(Ask::RedactAll {
             texts: texts.to_vec(),
         }) {
@@ -503,6 +588,27 @@ impl Broker for BrokerClient {
 }
 
 impl BrokerClient {
+    /// Whether anything would be redacted, asked once and remembered.
+    ///
+    /// Fails *towards* asking: a broker that cannot answer is treated as
+    /// holding one, so an unanswered question costs a round trip rather than a
+    /// skipped redaction. It is also not cached in that case — `set` is only
+    /// reached on a real answer — so a transient failure does not turn
+    /// redaction off for the rest of the session.
+    fn holds_a_secret(&self) -> bool {
+        if let Some(known) = self.has_secrets.get() {
+            return *known;
+        }
+        match self.said(Ask::SecretNames) {
+            Some(Said::Texts(names)) => {
+                let any = !names.is_empty();
+                let _ = self.has_secrets.set(any);
+                any
+            }
+            _ => true,
+        }
+    }
+
     /// Open one of the two kinds of connection. Both answer the same shape, so
     /// there is one place that turns an id into a handle.
     fn channel(&self, ask: Ask) -> Result<Arc<dyn Channel>, String> {
@@ -548,40 +654,56 @@ fn serve_over(
     mut reader: Box<dyn Read + Send>,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
 ) {
-    let mut workers: Vec<std::thread::JoinHandle<()>> = Vec::new();
     while let Ok((header, blob)) = read_frame(&mut reader) {
         let Ok(question) = serde_json::from_slice::<Question>(&header) else {
             break;
         };
         if slow(&question.ask) {
             let hand = (desk.clone(), writer.clone());
-            match std::thread::Builder::new()
+            if let Err(e) = std::thread::Builder::new()
                 .name("h5i-broker-call".to_string())
                 .spawn(move || answer(&hand.0, question, blob, &hand.1))
             {
-                Ok(worker) => workers.push(worker),
                 // Out of threads is not a reason to leave the renderer waiting
                 // for an answer that will never come. The question is gone with
-                // the closure, so the renderer is told that rather than left to
-                // time out on a message nobody will reply to.
-                Err(e) => eprintln!(
-                    "h5i-browser-light: the broker could not start a worker thread: {e}"
-                ),
+                // the closure, so this is said rather than left to look like a
+                // message nobody replied to.
+                eprintln!("h5i-browser-light: the broker could not start a worker thread: {e}");
             }
-            workers.retain(|w| !w.is_finished());
         } else {
             answer(&desk, question, blob, &writer);
         }
     }
+
+    // The read loop ended, which means the renderer is gone. From here the
+    // broker's only remaining job is to reap it and exit with its status, and
+    // **nothing in this function may block that.**
+    //
     // A renderer that has gone away takes its connections with it: nothing can
     // drain them, and a socket nobody reads is a server left talking to itself.
-    if let Ok(mut channels) = desk.channels.lock() {
-        for (_, channel) in channels.drain() {
-            channel.close();
-        }
-    }
-    for worker in workers {
-        let _ = worker.join();
+    // So they are closed — on a thread of their own, and nobody waits for it.
+    // `Socket::close` takes the same lock a `send` holds, and a send into a
+    // peer that has stopped reading blocks for as long as the peer likes; doing
+    // this inline would hand a hostile server the ability to keep a session's
+    // process alive after its renderer had exited. The same is why the workers
+    // are not joined: one of them may be inside exactly that send.
+    //
+    // Nothing is lost by not waiting. The close frame is politeness; the
+    // process is about to exit, and exit closes every socket the kernel holds
+    // for it.
+    let leaving: Vec<Arc<dyn Channel>> = desk
+        .channels
+        .lock()
+        .map(|mut channels| channels.drain().map(|(_, channel)| channel).collect())
+        .unwrap_or_default();
+    if !leaving.is_empty() {
+        let _ = std::thread::Builder::new()
+            .name("h5i-broker-closing".to_string())
+            .spawn(move || {
+                for channel in leaving {
+                    channel.close();
+                }
+            });
     }
 }
 
@@ -618,6 +740,8 @@ fn answer(
             Said::Outcome(outcome)
         }
         Ask::Records => Said::Records(broker.records()),
+        Ask::RecordsSince { mark } => Said::Records(broker.records_since(mark)),
+        Ask::LogSummary => Said::Summary(broker.log_summary()),
         Ask::HighWater => Said::Mark(broker.high_water()),
         Ask::Since { mark } => Said::Seqs(broker.since(mark)),
         Ask::Budget => Said::Budget(broker.budget()),
@@ -780,6 +904,19 @@ mod tests {
     /// stream socket is too, and what a protocol that read one message per
     /// `read` would get away with here and fail on under load.
     fn paired() -> (Arc<BrokerClient>, Arc<LocalBroker>, std::thread::JoinHandle<()>) {
+        let (client, broker, _desk, served) = paired_with_desk();
+        (client, broker, served)
+    }
+
+    /// The same, plus the broker's own table of open connections, for the
+    /// tests that are about what the *broker* is left holding.
+    #[allow(clippy::type_complexity)]
+    fn paired_with_desk() -> (
+        Arc<BrokerClient>,
+        Arc<LocalBroker>,
+        Arc<Desk>,
+        std::thread::JoinHandle<()>,
+    ) {
         let (to_broker_r, to_broker_w) = std::io::pipe().expect("pipe");
         let (to_client_r, to_client_w) = std::io::pipe().expect("pipe");
 
@@ -790,6 +927,7 @@ mod tests {
             channels: Mutex::new(HashMap::new()),
             next_channel: AtomicU64::new(0),
         });
+        let kept = desk.clone();
         let served = std::thread::spawn(move || {
             let writer: Arc<Mutex<Box<dyn Write + Send>>> =
                 Arc::new(Mutex::new(Box::new(to_client_w)));
@@ -797,7 +935,7 @@ mod tests {
         });
 
         let client = BrokerClient::over(Box::new(to_client_r), Box::new(to_broker_w), false);
-        (client, broker, served)
+        (client, broker, kept, served)
     }
 
     #[test]
@@ -876,6 +1014,117 @@ mod tests {
         assert!(outcome.body.is_empty());
     }
 
+    /// A writer that accepts everything and sends it nowhere, so a call can be
+    /// parked on its answer without the transport failing first. The failure
+    /// under test is the *absence* of an answer, not a broken pipe.
+    struct Discard;
+    impl Write for Discard {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_call_already_waiting_when_the_broker_ends_is_woken() {
+        // The half of "does not hang" that a check on entry cannot cover: this
+        // caller was already parked when the broker went away. It is woken by
+        // the reply thread dropping every waiting sender, and if that stopped
+        // happening the renderer would sit on an answer that cannot come — with
+        // no timeout anywhere in this protocol to rescue it.
+        let (reader, writer) = std::io::pipe().expect("pipe");
+        let client = BrokerClient::over(Box::new(reader), Box::new(Discard), false);
+
+        let asking = {
+            let client = client.clone();
+            std::thread::spawn(move || {
+                let url = Url::parse("https://docs.test/").expect("url");
+                client.send(&Fetch::get(&url, Initiator::Navigation))
+            })
+        };
+
+        // Wait until the call is registered, so the broker ends *after* it
+        // parked rather than before it started.
+        for _ in 0..200 {
+            if client.waiting.lock().map(|w| !w.is_empty()).unwrap_or(false) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            client.waiting.lock().map(|w| !w.is_empty()).unwrap_or(false),
+            "the call never registered, so this proves nothing"
+        );
+
+        // The broker ends.
+        drop(writer);
+
+        let outcome = asking.join().expect("the caller returned");
+        assert!(!outcome.is_ok(), "{outcome:?}");
+    }
+
+    #[test]
+    fn a_call_started_after_the_broker_ended_refuses_at_once() {
+        let (reader, writer) = std::io::pipe().expect("pipe");
+        let client = BrokerClient::over(Box::new(reader), Box::new(Discard), false);
+        drop(writer);
+        // The reply thread has to notice before this means anything.
+        for _ in 0..200 {
+            if client.gone.load(Ordering::SeqCst) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(client.gone.load(Ordering::SeqCst), "the reply thread never saw the end");
+
+        // Registration and the `gone` check share a lock, so this cannot land
+        // in a map that has already been cleared. The transport would accept
+        // the write — `Discard` always does, and so does a socket whose peer
+        // has gone but whose buffer has room — so nothing else would catch it.
+        let url = Url::parse("https://docs.test/").expect("url");
+        let outcome = client.send(&Fetch::get(&url, Initiator::Navigation));
+        assert!(!outcome.is_ok(), "{outcome:?}");
+        assert!(
+            client.waiting.lock().map(|w| w.is_empty()).unwrap_or(false),
+            "a refused call left an entry behind"
+        );
+    }
+
+    #[test]
+    fn dropping_the_pages_handle_closes_the_brokers_socket() {
+        // In one process this was ownership: the page's map held the only
+        // `Socket` a caller could reach, and dropping it shut the connection
+        // down. Across the boundary the socket belongs to the broker and the
+        // page holds an id, so the same property has to be *sent* — which is
+        // what `RemoteChannel::drop` does. Without it a page that navigated
+        // away would leave the broker holding an open socket, reading frames
+        // and receipting them, for a document that no longer exists.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _ = crate::ws::accept(&mut stream);
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        });
+
+        let (client, _broker, desk, _served) = paired_with_desk();
+        let url = Url::parse(&format!("ws://127.0.0.1:{port}/hmr")).expect("url");
+        let channel = client.open_socket(&url, None).expect("the socket opened");
+        assert_eq!(desk.channels.lock().unwrap().len(), 1);
+
+        // No `close()`. Just the page letting go of it, which is what a
+        // navigation does.
+        drop(channel);
+        assert!(
+            desk.channels.lock().unwrap().is_empty(),
+            "the broker is still holding a socket for a page that dropped it"
+        );
+        let _ = server.join();
+    }
+
     #[test]
     fn a_connection_the_renderer_invented_is_not_one_it_holds() {
         let (client, _broker, _served) = paired();
@@ -943,6 +1192,61 @@ mod tests {
         assert!(methods.iter().any(|m| m == "WS-OPEN"), "{methods:?}");
         assert!(methods.iter().any(|m| m == "WS-RECV"), "{methods:?}");
         assert!(methods.iter().any(|m| m == "WS-SEND"), "{methods:?}");
+    }
+
+    #[test]
+    fn a_windowed_read_of_the_log_stays_a_window() {
+        use crate::receipt::Sink as _;
+        let (client, broker, _served) = paired();
+        for seq in 0..6u64 {
+            broker
+                .log()
+                .append(&RequestRecord::request(
+                    seq,
+                    Initiator::Navigation,
+                    "GET",
+                    "https://docs.test/",
+                ))
+                .expect("appended");
+        }
+
+        // The window is what crosses, and the counts still describe the whole
+        // log: an agent that only ever asks for windows must still be able to
+        // say "nothing was refused in this session".
+        let tail = client.records_since(Some(3));
+        assert_eq!(tail.len(), 2, "{tail:?}");
+        assert!(tail.iter().all(|r| r.seq > 3));
+
+        let summary = client.log_summary();
+        assert_eq!(summary.total, 6);
+        assert_eq!(summary.highest, Some(5));
+        assert_eq!(summary.denied, 0);
+
+        // And a denial is counted from the far side, where the decision was
+        // made rather than where it is displayed.
+        let url = Url::parse("https://denied.test/").expect("url");
+        client.send(&Fetch::get(&url, Initiator::Navigation));
+        assert_eq!(client.log_summary().denied, 1);
+    }
+
+    #[test]
+    fn redaction_with_nothing_to_redact_costs_nothing() {
+        let (client, _broker, _served) = paired();
+        // The common session names no credential, and redaction over it is a
+        // no-op that used to cost two copies of every control reply across the
+        // socket. The answer has to still be correct, and it has to be reached
+        // without asking.
+        let texts = vec!["nothing secret here".to_string(), "nor here".to_string()];
+        assert_eq!(client.redact_all(&texts), texts);
+
+        let before = client.next.load(Ordering::SeqCst);
+        assert_eq!(client.redact_all(&texts), texts);
+        assert_eq!(client.redact("still nothing"), "still nothing");
+        assert_eq!(
+            client.next.load(Ordering::SeqCst),
+            before,
+            "a second redaction asked the broker again"
+        );
     }
 
     #[test]

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -1,0 +1,965 @@
+//! The wire between the two halves.
+//!
+//! `h5i browser open` runs one process today and two after this: a **broker**
+//! that holds the policy, the receipts, the jar, the budget and the secrets,
+//! and a **renderer** that parses the page and holds none of them. The renderer
+//! reaches the broker through [`crate::broker::Broker`], and this module is
+//! that trait spoken over a socket.
+//!
+//! # Which process is which
+//!
+//! The broker is the parent. `h5i browser` spawns it exactly as it always
+//! spawned the engine, and the broker spawns the renderer as a child with the
+//! socket as its **standard input** — an ordinary inherited file descriptor, so
+//! no library is needed to pass one, and no port exists for anything else on
+//! the machine to connect to. Neither half is a subcommand: `h5i browser open`
+//! is unchanged and there is nothing new to type, which is the same conclusion
+//! §"The id is not the interface" reached about session ids, applied to
+//! processes.
+//!
+//! # What a hostile renderer can do here
+//!
+//! Everything this protocol allows, in any order, with any arguments — so what
+//! it allows is the whole of the security argument. It can ask for a URL and be
+//! refused. It can ask what is in the log. It can ask for a cookie header it is
+//! already entitled to (`document.cookie`'s non-`HttpOnly` subset). It cannot
+//! edit the policy, silence the sink, read an `HttpOnly` cookie, enumerate a
+//! secret's value, or reach the network without a receipt being written first,
+//! because none of those is a message.
+//!
+//! What it *can* still do is lie about what it renders, which is why the split
+//! is described as moving the recorder out of reach rather than as making the
+//! renderer trustworthy.
+//!
+//! # Framing
+//!
+//! Each message is a length-prefixed JSON header and an optional blob:
+//!
+//! ```text
+//! u32 header_len | u32 blob_len | header | blob
+//! ```
+//!
+//! The blob carries request and response bodies. They are the only large thing
+//! that crosses, and base64 inside the JSON would pay a third again in bytes
+//! and all of it in allocation, on exactly the path a page's images take.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::{Arc, Mutex};
+
+use h5i_error::H5iError;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::broker::{Allowance, Broker, Channel, Fetch};
+use crate::net::{FetchOutcome, LocalBroker};
+use crate::receipt::RequestRecord;
+use crate::secrets::Resolved;
+use crate::wsclient::Event;
+
+/// Callers waiting for an answer, by the id they asked under.
+///
+/// The reply thread is the only reader of the socket, so every caller parks a
+/// one-shot here and takes its own answer off it. Dropping the map is how a
+/// broker that went away wakes everybody at once.
+type Waiting = Arc<Mutex<HashMap<u64, SyncSender<(Said, Vec<u8>)>>>>;
+
+/// The largest header or body one message may carry.
+///
+/// A ceiling on what either half can make the other allocate. Response bodies
+/// are already capped far below this by the page budget
+/// (`--max-wire-bytes`), so this is the backstop for a message that got past
+/// that or was never subject to it, not the working limit.
+const MAX_FRAME: usize = 256 * 1024 * 1024;
+
+/// What the renderer asks for. One variant per operation on
+/// [`crate::broker::Broker`], and nothing that is not one.
+#[derive(Debug, Serialize, Deserialize)]
+enum Ask {
+    /// The request body travels in the blob, never in this.
+    Send(Fetch),
+    Records,
+    HighWater,
+    Since {
+        mark: Option<u64>,
+    },
+    Budget,
+    ResetBudget,
+    CookieCount,
+    DocumentCookie {
+        url: Url,
+    },
+    StoreCookie {
+        url: Url,
+        header: String,
+    },
+    KeepOnlyOrigin {
+        origin: Url,
+    },
+    OpenSocket {
+        url: Url,
+        document: Option<Url>,
+    },
+    OpenEventStream {
+        url: Url,
+        document: Option<Url>,
+    },
+    ChannelSend {
+        channel: u64,
+        text: String,
+    },
+    ChannelDrain {
+        channel: u64,
+    },
+    ChannelClose {
+        channel: u64,
+    },
+    SecretNames,
+    Substitute {
+        text: String,
+    },
+    Redact {
+        text: String,
+    },
+    RedactAll {
+        texts: Vec<String>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Question {
+    id: u64,
+    ask: Ask,
+}
+
+/// What the broker answers. Never volunteered: there is one of these per
+/// question, which is what lets the renderer poll rather than hold a queue a
+/// chatty server could grow.
+#[derive(Debug, Serialize, Deserialize)]
+enum Said {
+    /// The response body travels in the blob.
+    Outcome(FetchOutcome),
+    Records(Vec<RequestRecord>),
+    Seqs(Vec<u64>),
+    Mark(Option<u64>),
+    Budget(Allowance),
+    Count(usize),
+    Text(String),
+    Flag(bool),
+    Texts(Vec<String>),
+    Resolved(Resolved),
+    /// A channel id, or why there is none.
+    Channel(Result<u64, String>),
+    Events(Vec<Event>),
+    Sent(Result<(), String>),
+    Done,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Answer {
+    id: u64,
+    said: Said,
+}
+
+// ── framing ──────────────────────────────────────────────────────────────────
+
+fn write_frame(out: &mut impl Write, header: &[u8], blob: &[u8]) -> std::io::Result<()> {
+    let mut prefix = [0u8; 8];
+    prefix[..4].copy_from_slice(&(header.len() as u32).to_be_bytes());
+    prefix[4..].copy_from_slice(&(blob.len() as u32).to_be_bytes());
+    out.write_all(&prefix)?;
+    out.write_all(header)?;
+    out.write_all(blob)?;
+    out.flush()
+}
+
+fn read_frame(input: &mut impl Read) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    let mut prefix = [0u8; 8];
+    input.read_exact(&mut prefix)?;
+    let header_len = u32::from_be_bytes(prefix[..4].try_into().unwrap()) as usize;
+    let blob_len = u32::from_be_bytes(prefix[4..].try_into().unwrap()) as usize;
+    if header_len > MAX_FRAME || blob_len > MAX_FRAME {
+        return Err(std::io::Error::other(format!(
+            "a message of {header_len}+{blob_len} bytes is over the {MAX_FRAME}-byte ceiling"
+        )));
+    }
+    let mut header = vec![0u8; header_len];
+    input.read_exact(&mut header)?;
+    let mut blob = vec![0u8; blob_len];
+    input.read_exact(&mut blob)?;
+    Ok((header, blob))
+}
+
+// ── the renderer's side ──────────────────────────────────────────────────────
+
+/// What the renderer holds instead of a broker.
+///
+/// Every method is a round trip. Calls are multiplexed rather than serialized:
+/// the script realm starts several fetches at once and a lock held across a
+/// whole request would turn them back into a queue — and worse, would let one
+/// slow fetch stall the drain of a socket that was answering fine.
+pub struct BrokerClient {
+    /// A handle to itself, for the two operations that hand back something the
+    /// caller keeps: an open connection needs the client for as long as the
+    /// page holds it, and the trait method that opens one has only `&self`.
+    me: std::sync::Weak<BrokerClient>,
+    out: Mutex<Box<dyn Write + Send>>,
+    next: AtomicU64,
+    waiting: Waiting,
+    gone: Arc<AtomicBool>,
+}
+
+impl BrokerClient {
+    /// The renderer's broker, on the descriptor it was handed.
+    ///
+    /// `fatal` is what a real renderer wants: a renderer whose broker has gone
+    /// away cannot fetch, cannot receipt, and has a parent that is no longer
+    /// waiting for it, so it stops rather than carrying on as a browser that
+    /// can no longer say what it did. Tests pass `false` and get an error per
+    /// call instead of an exit.
+    fn over(
+        reader: Box<dyn Read + Send>,
+        writer: Box<dyn Write + Send>,
+        fatal: bool,
+    ) -> Arc<Self> {
+        let waiting: Waiting = Arc::new(Mutex::new(HashMap::new()));
+        let gone = Arc::new(AtomicBool::new(false));
+        let client = Arc::new_cyclic(|me| Self {
+            me: me.clone(),
+            out: Mutex::new(writer),
+            next: AtomicU64::new(0),
+            waiting: waiting.clone(),
+            gone: gone.clone(),
+        });
+
+        let _ = std::thread::Builder::new()
+            .name("h5i-broker-replies".to_string())
+            .spawn(move || {
+                let mut reader = reader;
+                while let Ok((header, blob)) = read_frame(&mut reader) {
+                    let Ok(answer) = serde_json::from_slice::<Answer>(&header) else {
+                        break;
+                    };
+                    let waiter = waiting.lock().ok().and_then(|mut w| w.remove(&answer.id));
+                    if let Some(waiter) = waiter {
+                        let _ = waiter.send((answer.said, blob));
+                    }
+                }
+                gone.store(true, Ordering::SeqCst);
+                // Waking every caller: dropping the senders makes each blocked
+                // `recv` return an error rather than wait for an answer that is
+                // never coming.
+                if let Ok(mut waiting) = waiting.lock() {
+                    waiting.clear();
+                }
+                if fatal {
+                    eprintln!(
+                        "h5i-browser-light: the broker process ended; this renderer cannot fetch \
+                         or receipt without it, so it is stopping."
+                    );
+                    std::process::exit(70);
+                }
+            });
+
+        client
+    }
+
+    /// The renderer's broker is its standard input: the broker spawned this
+    /// process with one end of a socket pair there.
+    #[cfg(unix)]
+    pub fn on_stdin() -> Result<Arc<Self>, H5iError> {
+        use std::os::unix::io::{AsRawFd, FromRawFd};
+        // Borrowed, never owned: closing stdin out from under the process would
+        // hand fd 0 to whatever opened a file next.
+        let stdin = std::io::stdin();
+        let socket = unsafe { std::os::unix::net::UnixStream::from_raw_fd(stdin.as_raw_fd()) };
+        let reader = socket.try_clone().map_err(|e| {
+            H5iError::Metadata(format!("the broker socket could not be cloned: {e}"))
+        })?;
+        // The original is deliberately leaked rather than dropped, for the same
+        // reason: it *is* fd 0, and its destructor would close it.
+        std::mem::forget(socket);
+        let writer = reader.try_clone().map_err(|e| {
+            H5iError::Metadata(format!("the broker socket could not be cloned: {e}"))
+        })?;
+        Ok(Self::over(Box::new(reader), Box::new(writer), true))
+    }
+
+    /// Ask, and wait for the one answer.
+    ///
+    /// `None` when the broker is gone. Every caller turns that into the
+    /// refusal its own signature can express, because "the broker is gone" is
+    /// not a state any of them can render around.
+    fn ask(&self, ask: Ask, blob: &[u8]) -> Option<(Said, Vec<u8>)> {
+        if self.gone.load(Ordering::SeqCst) {
+            return None;
+        }
+        let id = self.next.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = sync_channel(1);
+        self.waiting.lock().ok()?.insert(id, tx);
+
+        let header = serde_json::to_vec(&Question { id, ask }).ok()?;
+        let written = {
+            let mut out = self.out.lock().ok()?;
+            write_frame(&mut *out, &header, blob)
+        };
+        if written.is_err() {
+            self.waiting.lock().ok()?.remove(&id);
+            return None;
+        }
+        rx.recv().ok()
+    }
+
+    /// The answers whose shape is a single value, unwrapped.
+    fn said(&self, ask: Ask) -> Option<Said> {
+        self.ask(ask, &[]).map(|(said, _)| said)
+    }
+}
+
+/// A connection the broker holds and this process may use.
+struct RemoteChannel {
+    client: Arc<BrokerClient>,
+    id: u64,
+}
+
+impl Channel for RemoteChannel {
+    fn send(&self, text: &str) -> Result<(), String> {
+        match self.client.said(Ask::ChannelSend {
+            channel: self.id,
+            text: text.to_string(),
+        }) {
+            Some(Said::Sent(result)) => result,
+            _ => Err("the broker is no longer running".to_string()),
+        }
+    }
+
+    fn drain(&self) -> Vec<Event> {
+        match self.client.said(Ask::ChannelDrain { channel: self.id }) {
+            Some(Said::Events(events)) => events,
+            _ => Vec::new(),
+        }
+    }
+
+    fn close(&self) {
+        let _ = self.client.said(Ask::ChannelClose { channel: self.id });
+    }
+}
+
+/// Dropping the page's last handle closes the connection, which is what the
+/// same handle did when the socket lived in this process. Without it the broker
+/// would hold an open socket for a page that has navigated away.
+impl Drop for RemoteChannel {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl Broker for BrokerClient {
+    fn send(&self, fetch: &Fetch) -> FetchOutcome {
+        match self.ask(Ask::Send(fetch.clone()), &fetch.body) {
+            Some((Said::Outcome(mut outcome), body)) => {
+                outcome.body = body;
+                outcome
+            }
+            _ => FetchOutcome::refused(
+                fetch.url.clone(),
+                "the broker is no longer running, so nothing was fetched".to_string(),
+            ),
+        }
+    }
+
+    fn records(&self) -> Vec<RequestRecord> {
+        match self.said(Ask::Records) {
+            Some(Said::Records(records)) => records,
+            _ => Vec::new(),
+        }
+    }
+
+    fn high_water(&self) -> Option<u64> {
+        match self.said(Ask::HighWater) {
+            Some(Said::Mark(mark)) => mark,
+            _ => None,
+        }
+    }
+
+    fn since(&self, mark: Option<u64>) -> Vec<u64> {
+        match self.said(Ask::Since { mark }) {
+            Some(Said::Seqs(seqs)) => seqs,
+            _ => Vec::new(),
+        }
+    }
+
+    fn budget(&self) -> Allowance {
+        match self.said(Ask::Budget) {
+            Some(Said::Budget(allowance)) => allowance,
+            _ => Allowance {
+                spent: crate::budget::Budget::default().spent(),
+                limits: crate::budget::Limits::default(),
+            },
+        }
+    }
+
+    fn reset_budget(&self) {
+        let _ = self.said(Ask::ResetBudget);
+    }
+
+    fn cookie_count(&self) -> usize {
+        match self.said(Ask::CookieCount) {
+            Some(Said::Count(n)) => n,
+            _ => 0,
+        }
+    }
+
+    fn document_cookie(&self, url: &Url) -> String {
+        match self.said(Ask::DocumentCookie { url: url.clone() }) {
+            Some(Said::Text(text)) => text,
+            _ => String::new(),
+        }
+    }
+
+    fn store_cookie(&self, url: &Url, header: &str) -> usize {
+        match self.said(Ask::StoreCookie {
+            url: url.clone(),
+            header: header.to_string(),
+        }) {
+            Some(Said::Count(n)) => n,
+            _ => 0,
+        }
+    }
+
+    fn keep_only_origin(&self, origin: &Url) -> bool {
+        match self.said(Ask::KeepOnlyOrigin {
+            origin: origin.clone(),
+        }) {
+            Some(Said::Flag(dropped)) => dropped,
+            _ => false,
+        }
+    }
+
+    fn open_socket(&self, url: &Url, document: Option<&Url>) -> Result<Arc<dyn Channel>, String> {
+        self.channel(Ask::OpenSocket {
+            url: url.clone(),
+            document: document.cloned(),
+        })
+    }
+
+    fn open_event_stream(
+        &self,
+        url: &Url,
+        document: Option<&Url>,
+    ) -> Result<Arc<dyn Channel>, String> {
+        self.channel(Ask::OpenEventStream {
+            url: url.clone(),
+            document: document.cloned(),
+        })
+    }
+
+    fn secret_names(&self) -> Vec<String> {
+        match self.said(Ask::SecretNames) {
+            Some(Said::Texts(names)) => names,
+            _ => Vec::new(),
+        }
+    }
+
+    fn substitute(&self, text: &str) -> Resolved {
+        match self.said(Ask::Substitute {
+            text: text.to_string(),
+        }) {
+            Some(Said::Resolved(resolved)) => resolved,
+            // The text unchanged, and nothing claimed as used. A placeholder
+            // that resolved to nothing is already a case this engine handles —
+            // it is left as written — so a broker that cannot answer degrades
+            // into it rather than into a value nobody checked.
+            _ => Resolved {
+                text: text.to_string(),
+                used: Vec::new(),
+                missing: Vec::new(),
+            },
+        }
+    }
+
+    fn redact(&self, text: &str) -> String {
+        match self.said(Ask::Redact {
+            text: text.to_string(),
+        }) {
+            Some(Said::Text(redacted)) => redacted,
+            _ => text.to_string(),
+        }
+    }
+
+    fn redact_all(&self, texts: &[String]) -> Vec<String> {
+        match self.said(Ask::RedactAll {
+            texts: texts.to_vec(),
+        }) {
+            // Length-checked: the strings are put back into a reply by
+            // position, and a short answer would shift every value after the
+            // gap into the wrong field.
+            Some(Said::Texts(redacted)) if redacted.len() == texts.len() => redacted,
+            _ => texts.to_vec(),
+        }
+    }
+}
+
+impl BrokerClient {
+    /// Open one of the two kinds of connection. Both answer the same shape, so
+    /// there is one place that turns an id into a handle.
+    fn channel(&self, ask: Ask) -> Result<Arc<dyn Channel>, String> {
+        // A second `Arc` around this client would not do: the reply thread
+        // belongs to the first one, so the handle has to reach the same client
+        // the caller already holds. See `me`.
+        let client = self
+            .me
+            .upgrade()
+            .ok_or_else(|| "the broker connection is closing".to_string())?;
+        match self.said(ask) {
+            Some(Said::Channel(Ok(id))) => Ok(Arc::new(RemoteChannel { client, id })),
+            Some(Said::Channel(Err(why))) => Err(why),
+            _ => Err("the broker is no longer running".to_string()),
+        }
+    }
+}
+
+// ── the broker's side ────────────────────────────────────────────────────────
+
+/// Answer questions until the renderer stops asking.
+///
+/// Returns when the socket closes, which is what a renderer that exited looks
+/// like from here. Cheap answers are given on this thread; the ones that touch
+/// the wire get one of their own, because a fetch that took thirty seconds
+/// would otherwise stall every drain and every cookie read behind it.
+pub fn serve(broker: Arc<LocalBroker>, socket: std::os::unix::net::UnixStream) {
+    let Ok(reader) = socket.try_clone() else {
+        return;
+    };
+    let writer: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(Box::new(socket)));
+    let desk = Arc::new(Desk {
+        broker,
+        channels: Mutex::new(HashMap::new()),
+        next_channel: AtomicU64::new(0),
+    });
+    serve_over(desk, Box::new(reader), writer);
+}
+
+/// The transport-independent half, so the protocol can be tested over a pipe.
+fn serve_over(
+    desk: Arc<Desk>,
+    mut reader: Box<dyn Read + Send>,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+) {
+    let mut workers: Vec<std::thread::JoinHandle<()>> = Vec::new();
+    while let Ok((header, blob)) = read_frame(&mut reader) {
+        let Ok(question) = serde_json::from_slice::<Question>(&header) else {
+            break;
+        };
+        if slow(&question.ask) {
+            let hand = (desk.clone(), writer.clone());
+            match std::thread::Builder::new()
+                .name("h5i-broker-call".to_string())
+                .spawn(move || answer(&hand.0, question, blob, &hand.1))
+            {
+                Ok(worker) => workers.push(worker),
+                // Out of threads is not a reason to leave the renderer waiting
+                // for an answer that will never come. The question is gone with
+                // the closure, so the renderer is told that rather than left to
+                // time out on a message nobody will reply to.
+                Err(e) => eprintln!(
+                    "h5i-browser-light: the broker could not start a worker thread: {e}"
+                ),
+            }
+            workers.retain(|w| !w.is_finished());
+        } else {
+            answer(&desk, question, blob, &writer);
+        }
+    }
+    // A renderer that has gone away takes its connections with it: nothing can
+    // drain them, and a socket nobody reads is a server left talking to itself.
+    if let Ok(mut channels) = desk.channels.lock() {
+        for (_, channel) in channels.drain() {
+            channel.close();
+        }
+    }
+    for worker in workers {
+        let _ = worker.join();
+    }
+}
+
+/// Whether answering this means waiting on the network.
+fn slow(ask: &Ask) -> bool {
+    matches!(
+        ask,
+        Ask::Send(_) | Ask::OpenSocket { .. } | Ask::OpenEventStream { .. } | Ask::ChannelSend { .. }
+    )
+}
+
+/// What the broker keeps on behalf of one renderer.
+struct Desk {
+    broker: Arc<LocalBroker>,
+    /// Connections opened for the renderer, by the id it holds. The renderer
+    /// names an id; it never holds a socket.
+    channels: Mutex<HashMap<u64, Arc<dyn Channel>>>,
+    next_channel: AtomicU64,
+}
+
+fn answer(
+    desk: &Desk,
+    question: Question,
+    blob: Vec<u8>,
+    writer: &Mutex<Box<dyn Write + Send>>,
+) {
+    let broker: &dyn Broker = desk.broker.as_ref();
+    let mut body = Vec::new();
+    let said = match question.ask {
+        Ask::Send(mut fetch) => {
+            fetch.body = blob;
+            let mut outcome = broker.send(&fetch);
+            body = std::mem::take(&mut outcome.body);
+            Said::Outcome(outcome)
+        }
+        Ask::Records => Said::Records(broker.records()),
+        Ask::HighWater => Said::Mark(broker.high_water()),
+        Ask::Since { mark } => Said::Seqs(broker.since(mark)),
+        Ask::Budget => Said::Budget(broker.budget()),
+        Ask::ResetBudget => {
+            broker.reset_budget();
+            Said::Done
+        }
+        Ask::CookieCount => Said::Count(broker.cookie_count()),
+        Ask::DocumentCookie { url } => Said::Text(broker.document_cookie(&url)),
+        Ask::StoreCookie { url, header } => Said::Count(broker.store_cookie(&url, &header)),
+        Ask::KeepOnlyOrigin { origin } => Said::Flag(broker.keep_only_origin(&origin)),
+        Ask::OpenSocket { url, document } => {
+            Said::Channel(desk.open(broker.open_socket(&url, document.as_ref())))
+        }
+        Ask::OpenEventStream { url, document } => {
+            Said::Channel(desk.open(broker.open_event_stream(&url, document.as_ref())))
+        }
+        Ask::ChannelSend { channel, text } => Said::Sent(match desk.channel(channel) {
+            Some(channel) => channel.send(&text),
+            None => Err("that connection is not open".to_string()),
+        }),
+        Ask::ChannelDrain { channel } => Said::Events(match desk.channel(channel) {
+            Some(channel) => channel.drain(),
+            None => Vec::new(),
+        }),
+        Ask::ChannelClose { channel } => {
+            let taken = desk.channels.lock().ok().and_then(|mut c| c.remove(&channel));
+            if let Some(channel) = taken {
+                channel.close();
+            }
+            Said::Done
+        }
+        Ask::SecretNames => Said::Texts(broker.secret_names()),
+        Ask::Substitute { text } => Said::Resolved(broker.substitute(&text)),
+        Ask::Redact { text } => Said::Text(broker.redact(&text)),
+        Ask::RedactAll { texts } => Said::Texts(broker.redact_all(&texts)),
+    };
+
+    let Ok(header) = serde_json::to_vec(&Answer {
+        id: question.id,
+        said,
+    }) else {
+        return;
+    };
+    if let Ok(mut writer) = writer.lock() {
+        let _ = write_frame(&mut *writer, &header, &body);
+    }
+}
+
+impl Desk {
+    fn open(&self, opened: Result<Arc<dyn Channel>, String>) -> Result<u64, String> {
+        let channel = opened?;
+        let id = self.next_channel.fetch_add(1, Ordering::Relaxed);
+        self.channels
+            .lock()
+            .map_err(|_| "the broker's connection table is poisoned".to_string())?
+            .insert(id, channel);
+        Ok(id)
+    }
+
+    fn channel(&self, id: u64) -> Option<Arc<dyn Channel>> {
+        self.channels.lock().ok()?.get(&id).cloned()
+    }
+}
+
+// ── starting the renderer ────────────────────────────────────────────────────
+
+/// The subcommand `h5i` hides the engine behind. The broker re-execs the binary
+/// it is already running, so there is no second file to find, no version skew
+/// between the halves, and no path to get wrong.
+const ENGINE_SUBCOMMAND: &str = "__engine";
+
+/// The flag that tells the child it is the renderer. Hidden, and not an
+/// interface: nobody types it, and `h5i browser open` is unchanged.
+pub const RENDERER_FLAG: &str = "--brokered";
+
+/// Set to anything to run the engine as one process, the way it ran before the
+/// split. An escape hatch for a host where spawning is the problem, and a way
+/// to compare the two halves against one.
+pub const NO_SPLIT_VAR: &str = "H5I_BROWSER_NO_SPLIT";
+
+/// Environment the renderer does not get.
+///
+/// The concrete half of what the split buys, and the part that is true the
+/// moment the second process exists. A compromised engine used to read every
+/// `H5I_SECRET_*` on the machine because it *was* the process holding them;
+/// now it reads the values it was handed for the fields it was told to fill.
+/// The other three are configuration a renderer has no use for: the receipts
+/// path names a file only the broker writes, the proxy is the broker's wire,
+/// and the allowlist is the broker's decision.
+fn scrubbed(name: &str) -> bool {
+    name.starts_with(crate::secrets::PREFIX)
+        || matches!(
+            name,
+            "H5I_BROWSER_RECEIPTS" | "H5I_EGRESS_PROXY" | "H5I_BROWSER_ALLOW"
+        )
+}
+
+/// Whether this host and this invocation will run the two halves as two
+/// processes.
+#[cfg(unix)]
+pub fn splitting() -> bool {
+    std::env::var_os(NO_SPLIT_VAR).is_none()
+}
+
+#[cfg(not(unix))]
+pub fn splitting() -> bool {
+    false
+}
+
+/// Start the renderer, and hand back the socket to speak to it over.
+///
+/// `argv` is the engine's own command line, program name included: the child runs
+/// the same command this process was given, with the flag that says which half
+/// it is. Passing the arguments through unchanged is deliberate — two halves
+/// that parsed different command lines would be two engines that could disagree
+/// about what was asked for.
+#[cfg(unix)]
+pub fn spawn_renderer(
+    argv: &[std::ffi::OsString],
+) -> Result<(std::process::Child, std::os::unix::net::UnixStream), H5iError> {
+    use std::os::unix::net::UnixStream;
+    use std::process::{Command, Stdio};
+
+    let exe = std::env::current_exe()
+        .map_err(|e| H5iError::Metadata(format!("this binary could not name itself: {e}")))?;
+    let (mine, theirs) = UnixStream::pair()
+        .map_err(|e| H5iError::Metadata(format!("the broker socket could not be made: {e}")))?;
+
+    let mut command = Command::new(exe);
+    command.arg(ENGINE_SUBCOMMAND).arg(RENDERER_FLAG);
+    command.args(argv.iter().skip(1));
+    // The socket arrives as the renderer's standard input. An inherited
+    // descriptor rather than a path or a port: there is nothing on the machine
+    // that could connect to it, and nothing to clean up if either half dies.
+    command.stdin(Stdio::from(std::os::fd::OwnedFd::from(theirs)));
+    for (name, _) in std::env::vars_os() {
+        if scrubbed(&name.to_string_lossy()) {
+            command.env_remove(&name);
+        }
+    }
+
+    let child = command
+        .spawn()
+        .map_err(|e| H5iError::Metadata(format!("the renderer could not be started: {e}")))?;
+    Ok((child, mine))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::broker::Fetch;
+    use crate::policy::Policy;
+    use crate::receipt::{Initiator, MemorySink};
+
+    /// A client and a broker in one process, talking over two pipes.
+    ///
+    /// Pipes rather than a socket pair, so the framing is exercised on a
+    /// transport with no message boundaries of its own — which is what a
+    /// stream socket is too, and what a protocol that read one message per
+    /// `read` would get away with here and fail on under load.
+    fn paired() -> (Arc<BrokerClient>, Arc<LocalBroker>, std::thread::JoinHandle<()>) {
+        let (to_broker_r, to_broker_w) = std::io::pipe().expect("pipe");
+        let (to_client_r, to_client_w) = std::io::pipe().expect("pipe");
+
+        let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+            .expect("broker builds");
+        let desk = Arc::new(Desk {
+            broker: broker.clone(),
+            channels: Mutex::new(HashMap::new()),
+            next_channel: AtomicU64::new(0),
+        });
+        let served = std::thread::spawn(move || {
+            let writer: Arc<Mutex<Box<dyn Write + Send>>> =
+                Arc::new(Mutex::new(Box::new(to_client_w)));
+            serve_over(desk, Box::new(to_broker_r), writer);
+        });
+
+        let client = BrokerClient::over(Box::new(to_client_r), Box::new(to_broker_w), false);
+        (client, broker, served)
+    }
+
+    #[test]
+    fn a_refusal_crosses_the_wire_as_a_refusal() {
+        let (client, broker, _served) = paired();
+        // The allowlist is empty, so this is denied — and the point is that the
+        // *broker* denied it: the renderer asked, and what came back is the
+        // refusal plus a receipt written on the far side.
+        let url = Url::parse("https://denied.test/page").expect("url");
+        let outcome = client.send(&Fetch::get(&url, Initiator::Navigation));
+        assert!(!outcome.is_ok(), "{outcome:?}");
+        assert!(
+            outcome.error.as_deref().unwrap_or_default().contains("policy"),
+            "{outcome:?}"
+        );
+
+        // Recorded where the recorder lives, and readable from the renderer's
+        // side only by asking.
+        let records = Broker::records(broker.as_ref());
+        assert!(!records.is_empty(), "the broker recorded the refusal");
+        assert_eq!(client.records().len(), records.len());
+    }
+
+    #[test]
+    fn the_jar_answers_operations_and_not_a_reference() {
+        let (client, broker, _served) = paired();
+        let url = Url::parse("https://acme.test/").expect("url");
+        broker
+            .jar()
+            .store(&url, ["sid=secret; HttpOnly", "theme=dark"]);
+
+        // Two cookies are held; one is visible to script. The renderer can
+        // learn the count and the visible subset, and there is no message that
+        // would hand it `sid`.
+        assert_eq!(client.cookie_count(), 2);
+        let visible = client.document_cookie(&url);
+        assert!(visible.contains("theme=dark"), "{visible}");
+        assert!(!visible.contains("secret"), "{visible}");
+    }
+
+    #[test]
+    fn secrets_resolve_on_the_broker_side() {
+        let (client, _broker, _served) = paired();
+        // Nothing is set in this process's environment, so the placeholder
+        // resolves to nothing and is left as written — the documented shape for
+        // a name that means nothing here.
+        let resolved = client.substitute("$H5I_SECRET_NOTHING");
+        assert_eq!(resolved.text, "$H5I_SECRET_NOTHING");
+        assert!(!resolved.substituted());
+    }
+
+    #[test]
+    fn a_broker_that_went_away_refuses_rather_than_hangs() {
+        // A client whose broker never answers: the read end sees EOF the
+        // moment the write end is dropped. A renderer must not park on an
+        // answer that is not coming — in the real one this is fatal and the
+        // process stops, which is why the refusal has to be reachable at all.
+        let (reader, writer) = std::io::pipe().expect("pipe");
+        drop(writer);
+        let (_unread, sink) = std::io::pipe().expect("pipe");
+        let client = BrokerClient::over(Box::new(reader), Box::new(sink), false);
+
+        let url = Url::parse("https://docs.test/").expect("url");
+        let outcome = client.send(&Fetch::get(&url, Initiator::Navigation));
+        assert!(!outcome.is_ok());
+        assert!(
+            outcome
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("no longer running"),
+            "{outcome:?}"
+        );
+        // And nothing was fetched, which is the half that matters: a renderer
+        // with no broker is a renderer with no network.
+        assert!(outcome.body.is_empty());
+    }
+
+    #[test]
+    fn a_connection_the_renderer_invented_is_not_one_it_holds() {
+        let (client, _broker, _served) = paired();
+        // Channel ids come from the broker. A renderer naming one it was never
+        // given is the shape of every "guess the handle" attack, and the answer
+        // is that there is nothing at that id rather than a panic or a stray
+        // socket.
+        let invented = RemoteChannel {
+            client: client.clone(),
+            id: 4242,
+        };
+        assert!(invented.send("hello").is_err());
+        assert!(invented.drain().is_empty());
+        // Closing one that does not exist is not an error either: a page may
+        // close a socket the broker already dropped.
+        invented.close();
+    }
+
+    #[test]
+    fn a_socket_is_the_brokers_and_the_renderer_holds_a_handle() {
+        // The streaming half of the seam, which is the part that could not be
+        // transported as a call. The socket is dialled, held and receipted on
+        // the broker's side; the renderer sends on it and drains it by naming
+        // an id, and every frame is in the broker's log because that is where
+        // the wire is.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept()
+                && crate::ws::accept(&mut stream).is_ok()
+            {
+                let _ = crate::ws::send_text(&mut stream, "hello from the server");
+                std::thread::sleep(std::time::Duration::from_millis(300));
+            }
+        });
+
+        let (client, broker, _served) = paired();
+        let url = Url::parse(&format!("ws://127.0.0.1:{port}/hmr")).expect("url");
+        let channel = client.open_socket(&url, None).expect("the socket opened");
+
+        // The greeting arrives on real time, so this waits for it rather than
+        // assuming a schedule.
+        let mut seen: Vec<Event> = Vec::new();
+        for _ in 0..40 {
+            seen.extend(channel.drain());
+            if seen.iter().any(|e| matches!(e, Event::Message(_))) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(
+            seen.contains(&Event::Message("hello from the server".to_string())),
+            "{seen:?}"
+        );
+        assert!(channel.send("and back").is_ok());
+        channel.close();
+        let _ = server.join();
+
+        // WS-OPEN, then a frame in each direction: the receipts are the
+        // broker's, written where the bytes actually crossed.
+        let methods: Vec<String> = Broker::records(broker.as_ref())
+            .iter()
+            .map(|r| r.method.clone())
+            .collect();
+        assert!(methods.iter().any(|m| m == "WS-OPEN"), "{methods:?}");
+        assert!(methods.iter().any(|m| m == "WS-RECV"), "{methods:?}");
+        assert!(methods.iter().any(|m| m == "WS-SEND"), "{methods:?}");
+    }
+
+    #[test]
+    fn a_credential_is_not_in_the_renderers_environment() {
+        // The concrete thing the second process buys, pinned as a list. Every
+        // name here is one a compromised parser used to be able to read simply
+        // by being the process that held it.
+        assert!(scrubbed("H5I_SECRET_ACME_PASSWORD"));
+        assert!(scrubbed("H5I_BROWSER_RECEIPTS"));
+        assert!(scrubbed("H5I_EGRESS_PROXY"));
+        assert!(scrubbed("H5I_BROWSER_ALLOW"));
+
+        // And the ones the renderer still needs, because it is the half that
+        // draws the page and serves the control channel.
+        assert!(!scrubbed("H5I_BROWSER_STREAM_FILE"));
+        assert!(!scrubbed("H5I_BROWSER_CONTROL_SOCKET"));
+        assert!(!scrubbed("HOME"));
+        assert!(!scrubbed("PATH"));
+    }
+}

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -61,6 +61,17 @@
 //! The blob carries request and response bodies. They are the only large thing
 //! that crosses, and base64 inside the JSON would pay a third again in bytes
 //! and all of it in allocation, on exactly the path a page's images take.
+//!
+//! # Where this runs
+//!
+//! The split is a Unix arrangement: the transport is a socket pair the child
+//! inherits as its standard input, and there is no second implementation. What
+//! is gated is only the part that touches one — spawning, adopting, serving.
+//! The protocol, the framing and the client stay *compiled* everywhere the
+//! engine builds, so the portable half cannot rot behind a `cfg` nobody
+//! exercises; on a platform that cannot spawn a renderer it is simply
+//! unreachable, and the engine runs as one process the way it always did.
+#![cfg_attr(not(unix), allow(dead_code, unused_imports))]
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -650,10 +661,17 @@ impl BrokerClient {
 
 /// Answer questions until the renderer stops asking.
 ///
+/// Unix only, and so is the split: the transport is a socket pair the child
+/// inherits, and there is no second implementation. Everything above this line
+/// is portable, which is what keeps the trait and the framing testable
+/// everywhere the engine builds.
+///
 /// Returns when the socket closes, which is what a renderer that exited looks
 /// like from here. Cheap answers are given on this thread; the ones that touch
 /// the wire get one of their own, because a fetch that took thirty seconds
 /// would otherwise stall every drain and every cookie read behind it.
+#[cfg(unix)]
+#[cfg(unix)]
 pub fn serve(broker: Arc<LocalBroker>, socket: std::os::unix::net::UnixStream) {
     let Ok(reader) = socket.try_clone() else {
         return;
@@ -841,6 +859,7 @@ impl Desk {
 /// The subcommand `h5i` hides the engine behind. The broker re-execs the binary
 /// it is already running, so there is no second file to find, no version skew
 /// between the halves, and no path to get wrong.
+#[cfg(unix)]
 const ENGINE_SUBCOMMAND: &str = "__engine";
 
 /// The flag that tells the child it is the renderer. Hidden, and not an
@@ -861,6 +880,7 @@ pub const NO_SPLIT_VAR: &str = "H5I_BROWSER_NO_SPLIT";
 /// The other three are configuration a renderer has no use for: the receipts
 /// path names a file only the broker writes, the proxy is the broker's wire,
 /// and the allowlist is the broker's decision.
+#[cfg(unix)]
 fn scrubbed(name: &str) -> bool {
     name.starts_with(crate::secrets::PREFIX)
         || matches!(
@@ -1075,8 +1095,11 @@ mod tests {
         };
 
         // Wait until the call is registered, so the broker ends *after* it
-        // parked rather than before it started.
-        for _ in 0..200 {
+        // parked rather than before it started. Ten seconds because this is a
+        // *liveness* budget on a shared CI runner, not a latency assertion: it
+        // exits the moment the condition holds, so a generous ceiling costs a
+        // passing run nothing and costs a flake everything.
+        for _ in 0..2000 {
             if client.waiting.lock().map(|w| !w.is_empty()).unwrap_or(false) {
                 break;
             }
@@ -1100,7 +1123,7 @@ mod tests {
         let client = BrokerClient::over(Box::new(reader), Box::new(Discard), false);
         drop(writer);
         // The reply thread has to notice before this means anything.
-        for _ in 0..200 {
+        for _ in 0..2000 {
             if client.gone.load(Ordering::SeqCst) {
                 break;
             }
@@ -1195,9 +1218,10 @@ mod tests {
         let channel = client.open_socket(&url, None).expect("the socket opened");
 
         // The greeting arrives on real time, so this waits for it rather than
-        // assuming a schedule.
+        // assuming a schedule. Generous for the same reason as above: the
+        // question is whether the message arrives at all.
         let mut seen: Vec<Event> = Vec::new();
-        for _ in 0..40 {
+        for _ in 0..400 {
             seen.extend(channel.drain());
             if seen.iter().any(|e| matches!(e, Event::Message(_))) {
                 break;

--- a/crates/h5i-browser-light/src/lib.rs
+++ b/crates/h5i-browser-light/src/lib.rs
@@ -11,9 +11,15 @@
 //!
 //! What that buys, concretely:
 //!
-//! - **Fail-closed by construction.** [`net::Broker`] appends the decision
+//! - **Fail-closed by construction.** [`net::LocalBroker`] appends the decision
 //!   before the wire and the outcome after it. A sink that refuses to record
 //!   is a sink that refuses to fetch (see [`receipt::Sink`]).
+//! - **The recorder is not in the parsers' process.** The engine runs as two:
+//!   a broker holding the policy, the wire, the receipts, the jar and the
+//!   secrets, and a renderer holding the DOM, the cascade, the decoders and the
+//!   script realm. [`broker::Broker`] is the seam between them and [`ipc`] is
+//!   the transport. A bug in Blitz, Stylo, an image decoder or Boa is a bug in
+//!   the half that holds none of the above.
 //! - **Every hop is a decision.** Redirects are followed manually and each hop
 //!   is policy-checked and receipted, so an allowed origin cannot bounce a
 //!   request to a denied one.
@@ -30,6 +36,7 @@
 //! keeps Chromium for the agent's own dev server, and docs-grade pages are this
 //! engine's compatibility bar.
 
+pub mod broker;
 pub mod cli;
 pub mod encoding;
 pub mod canvas;
@@ -40,6 +47,7 @@ pub mod engine;
 pub mod extract;
 pub mod fonts;
 pub mod markdown;
+pub mod ipc;
 pub mod net;
 pub mod policy;
 pub mod receipt;
@@ -55,6 +63,7 @@ pub mod verbs;
 pub mod ws;
 pub mod wsclient;
 
+pub use broker::Broker;
 pub use engine::{Page, PageFactory, PageOptions};
 pub use policy::{Policy, Verdict};
 pub use receipt::{JsonlSink, MemorySink, RequestRecord, Sink};

--- a/crates/h5i-browser-light/src/markdown.rs
+++ b/crates/h5i-browser-light/src/markdown.rs
@@ -491,14 +491,12 @@ mod tests {
     use super::*;
 
     fn md(html: &str) -> String {
-        let broker = std::sync::Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new(),
                 std::sync::Arc::new(crate::receipt::MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = crate::engine::PageFactory::new(
             broker,
@@ -640,14 +638,12 @@ mod tests {
     #[test]
     fn truncation_is_announced_rather_than_silent() {
         let long = "<p>".to_string() + &"word ".repeat(20_000) + "</p>";
-        let broker = std::sync::Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new(),
                 std::sync::Arc::new(crate::receipt::MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = crate::engine::PageFactory::new(
             broker,

--- a/crates/h5i-browser-light/src/net.rs
+++ b/crates/h5i-browser-light/src/net.rs
@@ -1,7 +1,7 @@
 //! The broker: the only way bytes enter this engine.
 //!
 //! Every fetch — the page itself, every stylesheet, every image, every
-//! redirect hop — goes through [`Broker::fetch`], which does the same three
+//! redirect hop — goes through [`crate::broker::Broker::send`], which does the same three
 //! things in the same order: check policy, record the decision, then use the
 //! wire. There is no second path, which is what lets the receipt be the
 //! network rather than a report about it.
@@ -71,7 +71,7 @@ fn accept_for(initiator: Initiator) -> &'static str {
 
 /// What a fetch produced. A denied or failed fetch is still an outcome, with
 /// an empty body and a reason — never an absence.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FetchOutcome {
     /// The receipt sequence number this request was recorded under.
     ///
@@ -86,6 +86,10 @@ pub struct FetchOutcome {
     /// rather than unsupported.
     pub headers: Vec<(String, String)>,
     pub final_url: Url,
+    /// Carried beside the message rather than inside it when this crosses a
+    /// process boundary: a page's images are megabytes, and base64 in JSON
+    /// would pay a third again for the privilege of being unreadable.
+    #[serde(skip)]
     pub body: Vec<u8>,
     pub status: Option<u16>,
     pub error: Option<String>,
@@ -200,9 +204,37 @@ struct CorsContext {
     credentials: crate::cors::Credentials,
 }
 
-pub struct Broker {
+pub struct LocalBroker {
+    /// A handle to itself, for the two operations that hand out something with
+    /// a life of its own.
+    ///
+    /// A WebSocket's reader thread receipts every frame for as long as the
+    /// connection is open, so it holds the broker rather than borrowing it —
+    /// and [`crate::broker::Broker::open_socket`] takes `&self`, because a
+    /// trait method that took `Arc<Self>` could not be called through
+    /// `dyn Broker`. `Arc::new_cyclic` closes that: the broker is built already
+    /// knowing the handle it will be reached through.
+    me: std::sync::Weak<LocalBroker>,
     policy: Policy,
     sink: Arc<dyn Sink>,
+    /// Every record, kept in memory as well as sent to the sink.
+    ///
+    /// The engine's own copy, and the only one a renderer can ask for. It is
+    /// here rather than threaded in beside the sink because the record-keeper
+    /// and the thing being asked "what did you record" have to be the same
+    /// component, or the answer is somebody's report about it.
+    log: Arc<crate::receipt::MemorySink>,
+    /// Credentials the agent may use and may not read.
+    ///
+    /// **Read here and nowhere else.** This is the process that holds
+    /// `H5I_SECRET_*`; the renderer's environment is scrubbed of them, so a
+    /// compromised parser reads the values that were substituted into a field
+    /// it was told to fill and no others.
+    ///
+    /// Read once, when the broker is built, so a later `setenv` cannot widen
+    /// what the session can reach. See [`crate::secrets`] for why the namespace
+    /// is narrower than `H5I_*`.
+    secrets: crate::secrets::Secrets,
     client: reqwest::blocking::Client,
     seq: AtomicU64,
     /// The session's cookies. Attached here rather than by the HTTP client so
@@ -233,14 +265,61 @@ pub struct Broker {
     pinned: Option<Arc<Pinned>>,
 }
 
-impl Broker {
+impl LocalBroker {
     /// Build a broker.
     ///
     /// `proxy` is h5i's egress proxy (`H5I_EGRESS_PROXY`). It is not required —
     /// the engine is useful on a bare host — but inside a box it is how the
     /// sandbox's own allowlist stays in the path. Loopback bypasses it, because
     /// the dev server is not egress.
-    pub fn new(policy: Policy, sink: Arc<dyn Sink>, proxy: Option<&str>) -> Result<Self, H5iError> {
+    pub fn new(
+        policy: Policy,
+        sink: Arc<dyn Sink>,
+        proxy: Option<&str>,
+    ) -> Result<Arc<Self>, H5iError> {
+        Self::build(
+            policy,
+            sink,
+            proxy,
+            crate::budget::Limits::default(),
+            crate::secrets::Secrets::from_env(),
+        )
+    }
+
+    /// The same, with the credentials named rather than read from the
+    /// environment. For a caller that resolves them somewhere else, and for
+    /// tests, which must not depend on what is exported around them.
+    pub fn with_secrets(
+        policy: Policy,
+        sink: Arc<dyn Sink>,
+        proxy: Option<&str>,
+        secrets: crate::secrets::Secrets,
+    ) -> Result<Arc<Self>, H5iError> {
+        Self::build(policy, sink, proxy, crate::budget::Limits::default(), secrets)
+    }
+
+    /// The same, with the page ceiling the caller wants.
+    ///
+    /// Separate from [`Self::new`] because the limits have to be in place
+    /// before the broker is shared: it is handed out as an `Arc` — a socket's
+    /// reader thread holds one for the life of the connection — and there is no
+    /// later moment at which it can be borrowed mutably.
+    pub fn with_limits(
+        policy: Policy,
+        sink: Arc<dyn Sink>,
+        proxy: Option<&str>,
+        limits: crate::budget::Limits,
+    ) -> Result<Arc<Self>, H5iError> {
+        Self::build(policy, sink, proxy, limits, crate::secrets::Secrets::from_env())
+    }
+
+    fn build(
+        policy: Policy,
+        sink: Arc<dyn Sink>,
+        proxy: Option<&str>,
+        limits: crate::budget::Limits,
+        secrets: crate::secrets::Secrets,
+    ) -> Result<Arc<Self>, H5iError> {
         let mut builder = reqwest::blocking::Client::builder()
             // Redirects are followed by hand so each hop is a policy decision
             // and a receipt line. Letting the client follow them would hide
@@ -277,32 +356,53 @@ impl Broker {
             .build()
             .map_err(|e| H5iError::Metadata(format!("failed to build the http client: {e}")))?;
 
-        Ok(Self {
+        Ok(Arc::new_cyclic(|me| Self {
+            me: me.clone(),
             policy,
             sink,
+            log: Arc::new(crate::receipt::MemorySink::new()),
+            secrets,
             client,
-            budget: crate::budget::Budget::default(),
+            budget: crate::budget::Budget::new(limits),
             pinned,
             seq: AtomicU64::new(0),
             jar: crate::cookies::Jar::new(),
             proxied,
-        })
+        }))
+    }
+
+    /// This broker's own copy of the record, for the broker process's use.
+    ///
+    /// Not on [`crate::broker::Broker`], which offers `records()` — a reading,
+    /// not the sink. Appending is not something a renderer gets to ask for:
+    /// the whole claim is that the log is written by the component that made
+    /// the decision.
+    pub fn log(&self) -> &crate::receipt::MemorySink {
+        &self.log
+    }
+
+    /// Append to the sink, and to this broker's own copy.
+    ///
+    /// One method rather than two calls at thirty sites, and the order matters:
+    /// the sink is the one that can refuse, and a refusal is what stops the
+    /// request. The in-memory copy never fails, so writing it first cannot
+    /// change whether a fetch happens.
+    fn append(&self, record: &RequestRecord) -> Result<(), H5iError> {
+        let _ = self.log.append(record);
+        self.sink.append(record)
     }
 
     pub fn policy(&self) -> &Policy {
         &self.policy
     }
 
-    /// What this page has spent, and what it may.
-    pub fn budget(&self) -> &crate::budget::Budget {
+    /// What this page has spent, and what it may. The live object, for the
+    /// broker's own use; [`crate::broker::Broker::budget`] hands callers a
+    /// reading of it instead.
+    pub fn spending(&self) -> &crate::budget::Budget {
         &self.budget
     }
 
-    /// Replace the limits. For a caller that wants a tighter page than the
-    /// default, and for tests that want a reachable one.
-    pub fn set_budget_limits(&mut self, limits: crate::budget::Limits) {
-        self.budget = crate::budget::Budget::new(limits);
-    }
 
     /// Ask a server, before the real request, whether it will accept one.
     ///
@@ -339,7 +439,7 @@ impl Broker {
         }
 
         let record = RequestRecord::request(seq, Initiator::Subresource, "OPTIONS", url.as_str());
-        if let Err(e) = self.sink.append(&record) {
+        if let Err(e) = self.append(&record) {
             return Err(format!(
                 "refusing to preflight: the receipt could not be written: {e}"
             ));
@@ -366,7 +466,7 @@ impl Broker {
                 let mut outcome = record.response();
                 outcome.duration_ms = Some(elapsed);
                 outcome.error = Some(e.to_string());
-                let _ = self.sink.append(&outcome);
+                let _ = self.append(&outcome);
                 return Err(format!("the preflight could not be sent: {e}"));
             }
         };
@@ -387,7 +487,7 @@ impl Broker {
         let mut outcome = record.response();
         outcome.status = Some(status.as_u16());
         outcome.duration_ms = Some(elapsed);
-        let _ = self.sink.append(&outcome);
+        let _ = self.append(&outcome);
 
         if !status.is_success() {
             return Err(format!(
@@ -455,114 +555,21 @@ impl Broker {
         Ok(())
     }
 
-    /// The session's jar, for the things that may legitimately touch it:
-    /// counting it, and clearing it. There is deliberately no accessor that
-    /// returns a cookie's value.
+    /// The session's jar, for the broker's own use.
+    ///
+    /// Not on [`crate::broker::Broker`], and that is the point of §B18.6's
+    /// hardest case: this returns a live reference, which cannot cross a
+    /// process boundary and, in one process, put the session in reach of the
+    /// parsers. Callers get three operations instead — `document_cookie`,
+    /// `store_cookie`, `keep_only_origin` — each of which enforces `HttpOnly`
+    /// and origin scoping on the way through.
     pub fn jar(&self) -> &crate::cookies::Jar {
         &self.jar
     }
 
-    /// Fetch a URL, following redirects by hand and checking policy on each hop.
-    ///
-    /// No document, so the loopback rule treats this as the agent naming a URL.
-    /// Anything a *page* reaches for — a subresource, a script `src`, a form's
-    /// action — must use [`Self::fetch_from`] instead, or it is trusted like an
-    /// instruction the agent typed.
-    pub fn fetch(&self, url: &Url, initiator: Initiator) -> FetchOutcome {
-        self.send(url, initiator, "GET", &[], None)
-    }
-
-    /// [`Self::fetch`] for something a *document* asked for, so the policy can
-    /// tell a page reaching for loopback from the agent naming it. See
-    /// [`Policy::check_from`].
-    pub fn fetch_from(
-        &self,
-        url: &Url,
-        initiator: Initiator,
-        document: Option<&Url>,
-    ) -> FetchOutcome {
-        self.send_from(url, initiator, "GET", &[], None, document)
-    }
-
-    /// Send a request that may carry a body — what a form submission needs.
-    ///
-    /// One function rather than a second path beside [`Self::fetch`], because
-    /// every guarantee this broker makes lives in that loop: the policy check,
-    /// the record before the wire, the hand-followed redirects. A POST that
-    /// took a shortcut around it would be the one request in the engine with no
-    /// receipt, which is precisely the hole the whole design exists to close.
-    ///
-    /// The redirect rule is the browser's, and it is a security rule rather
-    /// than a convenience: a 301/302/303 turns a POST into a GET and drops the
-    /// body, so a form's credentials are not replayed to wherever a server
-    /// points next. 307/308 preserve the method, and each hop is still checked
-    /// against the allowlist like any other.
-    pub fn send(
-        &self,
-        url: &Url,
-        initiator: Initiator,
-        method: &str,
-        body: &[u8],
-        content_type: Option<&str>,
-    ) -> FetchOutcome {
-        self.send_from(url, initiator, method, body, content_type, None)
-    }
-
-    /// Send a request a *document* made, so the policy can reason about origin.
-    ///
-    /// The document is threaded through rather than stored on the broker because
-    /// one broker serves a whole session and the page underneath it changes.
-    #[allow(clippy::too_many_arguments)]
-    pub fn send_from(
-        &self,
-        url: &Url,
-        initiator: Initiator,
-        method: &str,
-        body: &[u8],
-        content_type: Option<&str>,
-        document: Option<&Url>,
-    ) -> FetchOutcome {
-        // No origin context: the agent asked for this by name, so there is no
-        // document whose boundary could be crossed. See `cors::plan`.
-        self.send_with_cors(url, initiator, method, body, content_type, document, None)
-    }
-
-    /// The same send, subject to the same-origin policy.
-    ///
-    /// Separate entry rather than a flag, because the two callers are asking
-    /// different questions. A navigation is the *agent* exercising its own
-    /// authority over a URL it named; a `fetch` is a *page* exercising an
-    /// authority it has to be granted. Answering both through one door with no
-    /// argument between them is how the second was going unasked.
-    #[allow(clippy::too_many_arguments)]
-    pub fn send_script(
-        &self,
-        url: &Url,
-        method: &str,
-        body: &[u8],
-        content_type: Option<&str>,
-        document: &Url,
-        headers: &[(String, String)],
-        mode: crate::cors::Mode,
-        credentials: crate::cors::Credentials,
-    ) -> FetchOutcome {
-        let context = CorsContext {
-            document: crate::cors::Origin::of(document),
-            headers: headers.to_vec(),
-            mode,
-            credentials,
-        };
-        self.send_with_cors(
-            url,
-            Initiator::Subresource,
-            method,
-            body,
-            content_type,
-            Some(document),
-            Some(&context),
-        )
-    }
-
+    /// The four public entry points are [`crate::broker::Broker`]'s, and they
+    /// all arrive here: check policy, record the decision, then use the wire,
+    /// following redirects by hand so every hop is a decision of its own.
     #[allow(clippy::too_many_arguments)]
     fn send_with_cors(
         &self,
@@ -720,7 +727,7 @@ impl Broker {
             //    written, the fetch does not happen — this is the fail-closed
             //    guarantee, and it is why `Sink::append` returns a Result.
             let record = RequestRecord::request(seq, initiator, &method, current.as_str());
-            if let Err(e) = self.sink.append(&record) {
+            if let Err(e) = self.append(&record) {
                 return FetchOutcome::failed(
                     current,
                     format!("refusing to fetch: the receipt could not be written: {e}"),
@@ -786,7 +793,7 @@ impl Broker {
                     outcome_record.duration_ms = Some(elapsed);
                     outcome_record.cookies_sent = Some(cookies_sent);
                     outcome_record.error = Some(e.to_string());
-                    let _ = self.sink.append(&outcome_record);
+                    let _ = self.append(&outcome_record);
                     return FetchOutcome::failed_at(current, e.to_string(), Some(seq));
                 }
             };
@@ -827,7 +834,7 @@ impl Broker {
                 if location.is_none() {
                     outcome_record.error = Some("redirect without a usable Location".to_string());
                 }
-                let _ = self.sink.append(&outcome_record);
+                let _ = self.append(&outcome_record);
 
                 match location {
                     Some(next) if hop < self.policy.max_redirects() => {
@@ -903,7 +910,7 @@ impl Broker {
                     refused.cookies_sent = Some(cookies_sent);
                     refused.cookies_stored = Some(cookies_stored);
                     refused.error = Some(format!("blocked by the same-origin policy: {why}"));
-                    let _ = self.sink.append(&refused);
+                    let _ = self.append(&refused);
                     return FetchOutcome::failed_at(
                         current,
                         format!("blocked by the same-origin policy: {why}"),
@@ -987,7 +994,7 @@ impl Broker {
             return match body {
                 Ok(body) => {
                     outcome_record.bytes = Some(body.len() as u64);
-                    let _ = self.sink.append(&outcome_record);
+                    let _ = self.append(&outcome_record);
                     // What the caller may see of this. Same-origin sees
                     // everything; a cross-origin CORS response is filtered to
                     // the safelist plus whatever the server exposed; a no-cors
@@ -1007,7 +1014,7 @@ impl Broker {
                 }
                 Err(e) => {
                     outcome_record.error = Some(e.to_string());
-                    let _ = self.sink.append(&outcome_record);
+                    let _ = self.append(&outcome_record);
                     FetchOutcome::failed_at(current, e.to_string(), Some(seq))
                 }
             };
@@ -1112,7 +1119,7 @@ impl Broker {
 
     /// Authorise a long-lived connection and record the decision.
     ///
-    /// The front half of [`Broker::send_from`] — policy, then the record,
+    /// The front half of [`crate::broker::Broker::send_from`] — policy, then the record,
     /// *then* the caller may dial — for a connection that has no single body to
     /// read and so cannot use the rest of that loop. Returns the sequence the
     /// handshake was recorded under.
@@ -1144,7 +1151,7 @@ impl Broker {
         }
 
         let record = RequestRecord::request(seq, Initiator::Subresource, "WS-OPEN", url.as_str());
-        if let Err(e) = self.sink.append(&record) {
+        if let Err(e) = self.append(&record) {
             return Err(format!(
                 "refusing to connect: the receipt could not be written: {e}"
             ));
@@ -1179,20 +1186,23 @@ impl Broker {
             direction.as_method(),
             url.as_str(),
         );
-        self.sink.append(&record)?;
+        self.append(&record)?;
         let mut outcome = record.response();
         outcome.bytes = Some(bytes);
         // No status. 101 is the WebSocket upgrade's, and stamping it on every
         // frame said "switching protocols" four hundred times on one
         // connection — and said it on event streams, which never switched
         // anything. A frame is not an exchange with a status of its own.
-        self.sink.append(&outcome)
+        self.append(&outcome)
     }
 
     /// Authorise and begin an event stream, handing back the open response.
     ///
+    /// The half that touches the wire. [`crate::broker::Broker::open_event_stream`]
+    /// is the operation callers reach for; this is what it is built on.
+    ///
     /// The second exit from the receipt path, and the reason it exists:
-    /// [`Broker::send_from`] reads a whole body before it returns and writes
+    /// [`crate::broker::Broker::send_from`] reads a whole body before it returns and writes
     /// one response record with a final byte count. An event stream never
     /// completes, so it would hit the response cap or the client timeout and be
     /// reported as an error.
@@ -1200,7 +1210,7 @@ impl Broker {
     /// The front half is identical — policy, then the decision record, *then*
     /// the wire — because that is the half the fail-closed rule lives in, and
     /// two copies of it would be two rules.
-    pub fn open_event_stream(
+    pub fn begin_event_stream(
         &self,
         url: &Url,
         document: Option<&Url>,
@@ -1230,7 +1240,7 @@ impl Broker {
         }
 
         let record = RequestRecord::request(seq, Initiator::Subresource, "SSE-OPEN", url.as_str());
-        if let Err(e) = self.sink.append(&record) {
+        if let Err(e) = self.append(&record) {
             return Err(format!(
                 "refusing to connect: the receipt could not be written: {e}"
             ));
@@ -1262,7 +1272,7 @@ impl Broker {
                 // what flows after it is receipted per event.
                 let mut outcome = record.response();
                 outcome.status = Some(response.status().as_u16());
-                if let Err(e) = self.sink.append(&outcome) {
+                if let Err(e) = self.append(&outcome) {
                     return Err(format!(
                         "refusing to stream: the receipt could not be written: {e}"
                     ));
@@ -1272,7 +1282,7 @@ impl Broker {
             Err(error) => {
                 let mut outcome = record.response();
                 outcome.error = Some(error.to_string());
-                let _ = self.sink.append(&outcome);
+                let _ = self.append(&outcome);
                 Err(format!("could not open the event stream: {error}"))
             }
         }
@@ -1280,14 +1290,95 @@ impl Broker {
 
     /// Write both phases for a request that never reaches the wire.
     fn record_pair(&self, record: &RequestRecord) -> Result<(), H5iError> {
-        self.sink.append(record)?;
-        self.sink.append(&record.response())
+        self.append(record)?;
+        self.append(&record.response())
+    }
+}
+
+impl crate::broker::Broker for LocalBroker {
+    fn send(&self, fetch: &crate::broker::Fetch) -> FetchOutcome {
+        let context = fetch.cors.as_ref().map(|ask| CorsContext {
+            document: crate::cors::Origin::of(&ask.document),
+            headers: ask.headers.clone(),
+            mode: ask.mode,
+            credentials: ask.credentials,
+        });
+        self.send_with_cors(
+            &fetch.url,
+            fetch.initiator,
+            &fetch.method,
+            &fetch.body,
+            fetch.content_type.as_deref(),
+            fetch.document.as_ref(),
+            context.as_ref(),
+        )
+    }
+
+    fn records(&self) -> Vec<RequestRecord> {
+        self.log.records()
+    }
+
+    fn budget(&self) -> crate::broker::Allowance {
+        crate::broker::Allowance {
+            spent: self.budget.spent(),
+            limits: self.budget.limits().clone(),
+        }
+    }
+
+    fn reset_budget(&self) {
+        self.budget.reset();
+    }
+
+    fn cookie_count(&self) -> usize {
+        self.jar.len()
+    }
+
+    fn document_cookie(&self, url: &Url) -> String {
+        self.jar.document_cookie(url)
+    }
+
+    fn store_cookie(&self, url: &Url, header: &str) -> usize {
+        self.jar.store_from_script(url, header)
+    }
+
+    fn keep_only_origin(&self, origin: &Url) -> bool {
+        self.jar.retain_origin(origin)
+    }
+
+    fn open_socket(
+        &self,
+        url: &Url,
+        document: Option<&Url>,
+    ) -> Result<Arc<dyn crate::broker::Channel>, String> {
+        let me = self.me.upgrade().ok_or("the broker is no longer running")?;
+        Ok(Arc::new(crate::wsclient::Socket::open(me, url, document)?))
+    }
+
+    fn open_event_stream(
+        &self,
+        url: &Url,
+        document: Option<&Url>,
+    ) -> Result<Arc<dyn crate::broker::Channel>, String> {
+        let me = self.me.upgrade().ok_or("the broker is no longer running")?;
+        Ok(Arc::new(crate::sse::EventStream::open(me, url, document)?))
+    }
+
+    fn secret_names(&self) -> Vec<String> {
+        self.secrets.names().into_iter().map(str::to_string).collect()
+    }
+
+    fn substitute(&self, text: &str) -> crate::secrets::Resolved {
+        self.secrets.substitute(text)
+    }
+
+    fn redact(&self, text: &str) -> String {
+        self.secrets.redact(text)
     }
 }
 
 /// Adapts the broker to Blitz's [`NetProvider`].
 pub struct BrokerNet {
-    broker: Arc<Broker>,
+    broker: Arc<dyn crate::broker::Broker>,
     /// The document whose subresources these are.
     ///
     /// Load-bearing, not bookkeeping. Every image, stylesheet and font on the
@@ -1300,7 +1391,7 @@ pub struct BrokerNet {
 }
 
 impl BrokerNet {
-    pub fn new(broker: Arc<Broker>, document: Option<Url>) -> Self {
+    pub fn new(broker: Arc<dyn crate::broker::Broker>, document: Option<Url>) -> Self {
         Self { broker, document }
     }
 }
@@ -1322,11 +1413,12 @@ impl NetProvider for BrokerNet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::broker::Broker;
     use crate::receipt::{MemorySink, Phase};
     use std::sync::atomic::AtomicBool;
 
-    fn broker_with(policy: Policy, sink: Arc<dyn Sink>) -> Arc<Broker> {
-        Arc::new(Broker::new(policy, sink, None).expect("broker builds"))
+    fn broker_with(policy: Policy, sink: Arc<dyn Sink>) -> Arc<LocalBroker> {
+        LocalBroker::new(policy, sink, None).expect("broker builds")
     }
 
     fn url(s: &str) -> Url {
@@ -1498,7 +1590,7 @@ mod tests {
     #[test]
     fn a_bad_proxy_url_is_refused_at_construction_not_at_first_fetch() {
         let sink = Arc::new(MemorySink::new());
-        let result = Broker::new(Policy::new(), sink, Some("not a url"));
+        let result = LocalBroker::new(Policy::new(), sink, Some("not a url"));
         assert!(result.is_err(), "a malformed proxy must fail loudly, early");
     }
 }
@@ -1506,6 +1598,7 @@ mod tests {
 #[cfg(test)]
 mod cookie_wire_tests {
     use super::*;
+    use crate::broker::Broker;
     use crate::receipt::MemorySink;
     use std::io::{BufRead, BufReader, Write};
     use std::net::TcpListener;
@@ -1549,11 +1642,16 @@ mod cookie_wire_tests {
     fn a_page_that_keeps_asking_is_eventually_refused() {
         let port = always_answers(20);
         let sink = Arc::new(MemorySink::new());
-        let mut broker = Broker::new(Policy::new(), sink.clone(), None).expect("broker");
-        broker.set_budget_limits(crate::budget::Limits {
-            max_requests: 3,
-            ..Default::default()
-        });
+        let broker = LocalBroker::with_limits(
+            Policy::new(),
+            sink.clone(),
+            None,
+            crate::budget::Limits {
+                max_requests: 3,
+                ..Default::default()
+            },
+        )
+        .expect("broker");
         let url = Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
 
         for at in 1..=3 {
@@ -1585,11 +1683,16 @@ mod cookie_wire_tests {
     fn navigating_gives_the_next_page_its_own_allowance() {
         let port = always_answers(20);
         let sink = Arc::new(MemorySink::new());
-        let mut broker = Broker::new(Policy::new(), sink, None).expect("broker");
-        broker.set_budget_limits(crate::budget::Limits {
-            max_requests: 2,
-            ..Default::default()
-        });
+        let broker = LocalBroker::with_limits(
+            Policy::new(),
+            sink,
+            None,
+            crate::budget::Limits {
+                max_requests: 2,
+                ..Default::default()
+            },
+        )
+        .expect("broker");
         let url = Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
 
         for _ in 0..2 {
@@ -1597,7 +1700,7 @@ mod cookie_wire_tests {
         }
         assert!(broker.fetch_from(&url, Initiator::Subresource, None).error.is_some());
 
-        broker.budget().reset();
+        broker.reset_budget();
         assert!(
             broker.fetch_from(&url, Initiator::Subresource, None).error.is_none(),
             "a navigation restores the allowance"
@@ -1663,7 +1766,7 @@ mod cookie_wire_tests {
         let (port, seen) = gzip_server(BODY, 1);
         let sink = Arc::new(MemorySink::new());
         let broker =
-            Broker::new(Policy::new(), sink.clone(), None).expect("broker");
+            LocalBroker::new(Policy::new(), sink.clone(), None).expect("broker");
         let url = Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
 
         let outcome = broker.fetch_from(&url, Initiator::Navigation, None);
@@ -1701,7 +1804,7 @@ mod cookie_wire_tests {
     #[test]
     fn a_response_that_decompresses_past_the_cap_is_refused() {
         let sink = Arc::new(MemorySink::new());
-        let broker = Broker::new(
+        let broker = LocalBroker::new(
             Policy::new().set_max_response_bytes(64 * 1024),
             sink,
             None,
@@ -1731,7 +1834,7 @@ mod cookie_wire_tests {
     #[test]
     fn an_encoding_this_engine_did_not_ask_for_is_an_error() {
         let sink = Arc::new(MemorySink::new());
-        let broker = Broker::new(Policy::new(), sink, None).expect("broker");
+        let broker = LocalBroker::new(Policy::new(), sink, None).expect("broker");
         let why = broker
             .decode_capped(b"whatever", "exotic-zip")
             .expect_err("an unknown encoding is an error");
@@ -1741,7 +1844,7 @@ mod cookie_wire_tests {
     #[test]
     fn every_encoding_this_engine_advertises_round_trips() {
         let sink = Arc::new(MemorySink::new());
-        let broker = Broker::new(Policy::new(), sink, None).expect("broker");
+        let broker = LocalBroker::new(Policy::new(), sink, None).expect("broker");
         let body = b"round trip me".repeat(50);
 
         let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
@@ -1834,11 +1937,9 @@ mod cookie_wire_tests {
         (port, seen)
     }
 
-    fn cors_broker() -> (Arc<Broker>, Arc<MemorySink>) {
+    fn cors_broker() -> (Arc<LocalBroker>, Arc<MemorySink>) {
         let sink = Arc::new(MemorySink::new());
-        let broker = Arc::new(
-            Broker::new(Policy::new(), sink.clone(), None).expect("broker"),
-        );
+        let broker = LocalBroker::new(Policy::new(), sink.clone(), None).expect("broker");
         (broker, sink)
     }
 
@@ -2175,15 +2276,16 @@ Connection: close
         // not re-sent to wherever that server points next.
         for status in [301u16, 302, 303] {
             let (port, server) = redirecting_server(status);
-            let broker = Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
+            let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
             let target = Url::parse(&format!("http://127.0.0.1:{port}/login")).unwrap();
 
-            let outcome = broker.send(
+            let outcome = broker.send_from(
                 &target,
                 Initiator::Navigation,
                 "POST",
                 b"password=hunter2",
                 Some("application/x-www-form-urlencoded"),
+                None,
             );
             assert!(outcome.is_ok(), "{status}: {:?}", outcome.error);
 
@@ -2198,15 +2300,16 @@ Connection: close
     #[test]
     fn a_307_keeps_the_method_because_the_server_asked_for_that_explicitly() {
         let (port, server) = redirecting_server(307);
-        let broker = Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
+        let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
         let target = Url::parse(&format!("http://127.0.0.1:{port}/login")).unwrap();
 
-        broker.send(
+        broker.send_from(
             &target,
             Initiator::Navigation,
             "POST",
             b"password=hunter2",
             Some("application/x-www-form-urlencoded"),
+            None,
         );
 
         let followed = server.join().unwrap();
@@ -2217,7 +2320,7 @@ Connection: close
     fn a_session_survives_between_requests_and_never_reaches_the_log() {
         let (port, server) = login_server();
         let sink = Arc::new(MemorySink::new());
-        let broker = Broker::new(Policy::new(), sink.clone(), None).unwrap();
+        let broker = LocalBroker::new(Policy::new(), sink.clone(), None).unwrap();
 
         // Loopback is reachable without an allowlist entry, which is what lets
         // this test exercise the wire without inventing a policy.

--- a/crates/h5i-browser-light/src/receipt.rs
+++ b/crates/h5i-browser-light/src/receipt.rs
@@ -2,7 +2,7 @@
 //!
 //! A record is written *before* the wire and again after it. The first write
 //! is what makes the fail-closed claim true rather than aspirational: if the
-//! sink refuses the decision record, [`crate::net::Broker`] refuses the fetch,
+//! sink refuses the decision record, [`crate::net::LocalBroker`] refuses the fetch,
 //! so there is no path from "the engine made a request" to "nobody recorded
 //! it". The second write carries the outcome (status, bytes, duration), which
 //! is the part a human actually reads.
@@ -223,6 +223,20 @@ impl Sink for JsonlSink {
         // has not recorded anything if the process dies mid-request.
         writeln!(file, "{line}").map_err(H5iError::Io)?;
         file.flush().map_err(H5iError::Io)?;
+        Ok(())
+    }
+}
+
+/// A sink that accepts everything and keeps nothing.
+///
+/// Not the same as having no sink. The broker always has one, and the
+/// fail-closed rule is about what happens when a sink *refuses* — this one
+/// never does. It is what a session without `--receipts` writes to: the
+/// broker's own in-memory log is still kept, and still printed at the end.
+pub struct NullSink;
+
+impl Sink for NullSink {
+    fn append(&self, _record: &RequestRecord) -> Result<(), H5iError> {
         Ok(())
     }
 }

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -2145,7 +2145,7 @@ fn viewport(_this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResu
 /// the DOM.
 fn read_cookies(_this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let host = host(context)?;
-    Ok(js_string!(host.broker.jar().document_cookie(&host.base)).into())
+    Ok(js_string!(host.broker.document_cookie(&host.base)).into())
 }
 
 /// `document.cookie = "..."`: store one cookie as the current document.
@@ -2154,7 +2154,7 @@ fn write_cookie(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsR
     let host = host(context)?;
     // Not `store`: see `Jar::store_from_script`. Script may not overwrite an
     // `HttpOnly` cookie, nor set one.
-    let stored = host.broker.jar().store_from_script(&host.base, &header);
+    let stored = host.broker.store_cookie(&host.base, &header);
     Ok(JsValue::from(stored as f64))
 }
 
@@ -2205,13 +2205,11 @@ fn socket_open(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRe
         boa_engine::JsNativeError::syntax().with_message(format!("`{raw}` is not a URL: {e}"))
     })?;
 
-    match crate::wsclient::Socket::open(host.broker.clone(), &url, Some(&host.base)) {
+    match host.broker.open_socket(&url, Some(&host.base)) {
         Ok(socket) => {
             let id = host.next_socket.get();
             host.next_socket.set(id + 1);
-            host.sockets
-                .borrow_mut()
-                .insert(id, std::sync::Arc::new(socket));
+            host.sockets.borrow_mut().insert(id, socket);
             Ok(JsValue::from(id as f64))
         }
         // A refusal is an answer the page can see, the same as a refused fetch.
@@ -2276,13 +2274,11 @@ fn sse_open(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
         boa_engine::JsNativeError::syntax().with_message(format!("`{raw}` is not a URL: {e}"))
     })?;
 
-    match crate::sse::EventStream::open(host.broker.clone(), &url, Some(&host.base)) {
+    match host.broker.open_event_stream(&url, Some(&host.base)) {
         Ok(stream) => {
             let id = host.next_socket.get();
             host.next_socket.set(id + 1);
-            host.streams
-                .borrow_mut()
-                .insert(id, std::sync::Arc::new(stream));
+            host.streams.borrow_mut().insert(id, stream);
             Ok(JsValue::from(id as f64))
         }
         Err(error) => Err(boa_engine::JsNativeError::error().with_message(error).into()),

--- a/crates/h5i-browser-light/src/script/host.rs
+++ b/crates/h5i-browser-light/src/script/host.rs
@@ -14,7 +14,7 @@ use boa_engine::JsData;
 use boa_gc::{Finalize, Trace};
 
 use crate::engine::Dom;
-use crate::net::Broker;
+use crate::broker::Broker;
 
 /// One line a page wrote to the console.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,7 +107,7 @@ pub struct Host {
     /// is the whole reason script belongs in *this* engine: nothing a page does
     /// reaches the wire without a record, including the traffic every other
     /// engine's evidence is thinnest about.
-    pub broker: std::sync::Arc<Broker>,
+    pub broker: std::sync::Arc<dyn Broker>,
 
     /// The page this document was loaded from, for resolving relative fetches.
     pub base: url::Url,
@@ -175,14 +175,15 @@ pub struct Host {
 
     /// Sockets this page has open, by the id the prelude holds.
     ///
-    /// `Arc` because the reader thread holds one too. The map is the only
-    /// owner the page can reach: closing a `WebSocket` removes it from here,
-    /// and dropping the last handle shuts the connection down.
-    pub sockets: RefCell<std::collections::BTreeMap<u64, std::sync::Arc<crate::wsclient::Socket>>>,
-    /// Event streams, in a second map for the same reason they are a second
+    /// [`crate::broker::Channel`] rather than the socket itself: the connection
+    /// belongs to the broker, and what the page holds is the right to send on
+    /// it, take what has arrived, and stop. Closing a `WebSocket` removes it
+    /// from here, and dropping the last handle shuts the connection down.
+    pub sockets: RefCell<std::collections::BTreeMap<u64, std::sync::Arc<dyn crate::broker::Channel>>>,
+    /// Event streams, in a second map for the same reason they were a second
     /// type: one can be sent to and the other cannot, and merging them would
     /// mean a `send` that is meaningful for half the values it accepts.
-    pub streams: RefCell<std::collections::BTreeMap<u64, std::sync::Arc<crate::sse::EventStream>>>,
+    pub streams: RefCell<std::collections::BTreeMap<u64, std::sync::Arc<dyn crate::broker::Channel>>>,
     /// Shared, so an id names exactly one connection of either kind.
     pub next_socket: std::cell::Cell<u64>,
 }
@@ -252,7 +253,7 @@ impl std::ops::Deref for HostHandle {
 }
 
 impl Host {
-    pub fn new(dom: Dom, broker: std::sync::Arc<Broker>, base: url::Url) -> Self {
+    pub fn new(dom: Dom, broker: std::sync::Arc<dyn Broker>, base: url::Url) -> Self {
         Self {
             dom,
             broker,

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -366,7 +366,7 @@ impl Script {
     /// Build a realm over `dom`, install the primitives and run the prelude.
     pub fn new(
         dom: Dom,
-        broker: std::sync::Arc<crate::net::Broker>,
+        broker: std::sync::Arc<dyn crate::broker::Broker>,
         base: &url::Url,
     ) -> Result<Self, String> {
         let url = base.to_string();

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -1,14 +1,12 @@
 use super::*;
 use crate::engine::{PageFactory, PageOptions};
-use crate::net::Broker;
+use crate::broker::Broker;
 use crate::policy::Policy;
 use crate::receipt::MemorySink;
 use std::sync::Arc;
 
 fn page_and_script(html: &str) -> (crate::engine::Page, Script) {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker, fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse("https://app.example/").unwrap();
@@ -20,10 +18,8 @@ fn page_and_script(html: &str) -> (crate::engine::Page, Script) {
 /// A page taken all the way through loading, which is what `page_and_script`
 /// deliberately is not: it builds a bare realm, so anything installed *by*
 /// `run_scripts` — the document lifecycle, named access — is not there.
-fn run_page(html: &str) -> (crate::engine::Page, Arc<Broker>) {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+fn run_page(html: &str) -> (crate::engine::Page, Arc<dyn Broker>) {
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse("https://app.example/").unwrap();
@@ -519,9 +515,7 @@ fn css_supports_answers_from_the_engine_that_would_have_to_do_it() {
 fn a_documents_encoding_reaches_both_its_text_and_its_urls() {
     // Two things follow from a document's encoding and they must not disagree:
     // how the bytes become text, and how a URL's query becomes bytes again.
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..PageOptions::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -817,9 +811,7 @@ fn a_page_can_open_a_socket_read_a_message_and_the_receipt_holds_every_frame() {
     let (port, server) = socket_server("hello from the server");
 
     let sink = std::sync::Arc::new(crate::receipt::MemorySink::new());
-    let broker = std::sync::Arc::new(
-        crate::net::Broker::new(crate::policy::Policy::new(), sink.clone(), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(crate::policy::Policy::new(), sink.clone(), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = crate::engine::PageFactory::new(
         broker.clone(),
@@ -900,9 +892,7 @@ fn a_peer_that_closes_releases_the_engine_side_too() {
     let (port, server) = socket_server("bye");
 
     let sink = std::sync::Arc::new(crate::receipt::MemorySink::new());
-    let broker = std::sync::Arc::new(
-        crate::net::Broker::new(crate::policy::Policy::new(), sink, None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(crate::policy::Policy::new(), sink, None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = crate::engine::PageFactory::new(
         broker.clone(),
@@ -960,9 +950,7 @@ fn an_open_socket_does_not_make_a_page_look_permanently_busy() {
 
     let (page, broker) = {
         let sink = std::sync::Arc::new(crate::receipt::MemorySink::new());
-        let broker = std::sync::Arc::new(
-            crate::net::Broker::new(crate::policy::Policy::new(), sink, None).expect("broker"),
-        );
+        let broker = crate::net::LocalBroker::new(crate::policy::Policy::new(), sink, None).expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = crate::engine::PageFactory::new(
             broker.clone(),
@@ -1022,9 +1010,7 @@ fn a_page_can_read_an_event_stream_end_to_end() {
     });
 
     let sink = std::sync::Arc::new(crate::receipt::MemorySink::new());
-    let broker = std::sync::Arc::new(
-        crate::net::Broker::new(crate::policy::Policy::new(), sink.clone(), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(crate::policy::Policy::new(), sink.clone(), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = crate::engine::PageFactory::new(
         broker.clone(),
@@ -1237,9 +1223,7 @@ fn a_click_runs_script_that_fetches_and_the_agent_sees_the_result() {
     // DOM changes, and the change is in the outline the agent reads.
     let (port, server) = api_server();
     let sink = Arc::new(MemorySink::new());
-    let broker = Arc::new(
-        Broker::new(Policy::new(), sink.clone(), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), sink.clone(), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
@@ -1322,7 +1306,7 @@ fn an_external_script_is_fetched_through_the_broker_before_it_runs() {
     });
 
     let sink = Arc::new(MemorySink::new());
-    let broker = Arc::new(Broker::new(Policy::new(), sink.clone(), None).expect("broker"));
+    let broker = crate::net::LocalBroker::new(Policy::new(), sink.clone(), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -1347,7 +1331,7 @@ fn an_external_script_is_fetched_through_the_broker_before_it_runs() {
 fn script_is_off_unless_it_is_asked_for() {
     // The gate ROADMAP §12.5 asks for: a page whose script would change it is
     // left alone, and the outline shows what the server actually sent.
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker, fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse("https://app.example/").unwrap();
@@ -1367,7 +1351,7 @@ fn script_is_off_unless_it_is_asked_for() {
 fn the_snapshot_says_when_a_page_needed_an_api_this_engine_lacks() {
     // The routing signal. Without it an agent sees a thin outline and cannot
     // tell an empty page from one that needed the other engine.
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -1389,7 +1373,7 @@ fn the_snapshot_says_when_a_page_needed_an_api_this_engine_lacks() {
 
 #[test]
 fn a_page_that_never_settles_says_so_in_the_outline() {
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -1412,7 +1396,7 @@ fn a_page_that_never_settles_says_so_in_the_outline() {
 /// for the same reason — but it must not say the page is unfinished.
 #[test]
 fn a_looping_page_says_it_is_looping_rather_than_unfinished() {
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -1812,7 +1796,7 @@ fn typing_fires_input_and_change_because_it_is_a_user_edit() {
     // its own write would loop — but a person typing must. The handlers write
     // into the DOM so the assertion reads the same tree the agent would, rather
     // than trusting a value the engine already knew.
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -1875,7 +1859,7 @@ fn response_headers_reach_the_page() {
         let _ = stream.flush();
     });
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
@@ -1965,7 +1949,7 @@ fn a_web_page_cannot_read_the_dev_server_and_never_reaches_the_wire() {
     let (port, hits) = counting_server();
 
     let sink = Arc::new(MemorySink::new());
-    let broker = Arc::new(Broker::new(Policy::new(), sink.clone(), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), sink.clone(), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
 
@@ -2003,7 +1987,7 @@ fn the_dev_servers_own_page_still_reaches_it() {
     use std::sync::atomic::Ordering;
     let (port, hits) = counting_server();
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
 
@@ -2025,7 +2009,7 @@ fn leaving_an_origin_drops_the_session_and_the_agent_is_told() {
     // `localhost` and `127.0.0.1` are different hosts and both loopback, which
     // makes a genuine cross-origin navigation testable without two machines.
     let (port, _hits) = counting_server();
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
 
@@ -2137,7 +2121,7 @@ fn scripts_run_in_document_order_inline_and_external_together() {
         let _ = stream.flush();
     });
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -2162,7 +2146,7 @@ fn scripts_run_in_document_order_inline_and_external_together() {
 
 #[test]
 fn a_script_that_throws_is_reported_and_the_rest_of_the_page_still_runs() {
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -2188,7 +2172,7 @@ fn a_script_that_throws_is_reported_and_the_rest_of_the_page_still_runs() {
 
 #[test]
 fn a_refused_script_src_is_reported_and_the_page_survives() {
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker, fonts.sources.clone(), options);
@@ -2253,7 +2237,7 @@ fn module_server(
     (port, asked)
 }
 
-fn scripted_factory(broker: Arc<Broker>) -> PageFactory {
+fn scripted_factory(broker: Arc<dyn Broker>) -> PageFactory {
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     PageFactory::new(broker, fonts.sources.clone(), options)
@@ -2271,7 +2255,7 @@ fn a_module_graph_loads_and_evaluates() {
         ("/lib/punctuation.js", "export default '!';"),
     ]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
 
@@ -2303,7 +2287,7 @@ fn a_module_imported_twice_is_fetched_once() {
         ("/shared.js", "globalThis.__loads = (globalThis.__loads || 0) + 1;"),
     ]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
     let _page = factory.from_html(
@@ -2325,7 +2309,7 @@ fn every_module_is_fetched_through_the_broker_and_receipted() {
     ]);
 
     let sink = Arc::new(MemorySink::new());
-    let broker = Arc::new(Broker::new(Policy::new(), sink.clone(), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), sink.clone(), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
     let _page = factory.from_html(
@@ -2344,7 +2328,7 @@ fn a_bare_specifier_is_refused_and_the_page_is_told_why() {
     // never named, and the failure must be legible rather than an empty page.
     let (port, asked) = module_server(vec![("/entry.js", "import _ from 'lodash';")]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
     let page = factory.from_html(
@@ -2379,7 +2363,7 @@ fn an_inline_module_resolves_imports_against_the_page() {
         "export const value = 'from the module';",
     )]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/index.html")).unwrap();
 
@@ -2404,7 +2388,7 @@ fn an_inline_module_resolves_imports_against_the_page() {
 fn modules_run_after_classic_scripts_because_they_are_deferred() {
     // `type="module"` is deferred by definition: it never runs before a classic
     // script that follows it in the markup.
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
 
     let page = factory.from_html(
@@ -2427,7 +2411,7 @@ fn modules_run_after_classic_scripts_because_they_are_deferred() {
 fn a_module_that_fails_to_load_is_reported_rather_than_leaving_a_blank() {
     let (port, _asked) = module_server(vec![("/entry.js", "import './missing.js';")]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
     let page = factory.from_html(
@@ -2449,7 +2433,7 @@ fn a_module_may_not_reach_the_dev_server_from_a_page_the_web_served() {
     // through the same broker rather than a loader-local client.
     let (port, asked) = module_server(vec![("/secret.js", "globalThis.leaked = true;")]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker.clone());
     let evil = url::Url::parse("https://evil.example/page").unwrap();
 
@@ -2480,7 +2464,7 @@ fn a_click_is_credited_only_with_what_it_caused() {
         ("/clicked", "{}"),
     ]);
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
 
@@ -2516,7 +2500,7 @@ fn a_script_element_that_is_not_javascript_is_not_executed() {
     // `text/template` for markup — and the spec says those never execute.
     // Running them parses JSON as JavaScript and fills the console with syntax
     // errors that blame the page. Found by pointing the corpus at github.com.
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
 
     let page = factory.from_html(
@@ -2645,7 +2629,7 @@ fn an_http_error_page_is_not_presented_as_the_page_that_was_asked_for() {
         let _ = stream.flush();
     });
 
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let page = factory
         .open(&url::Url::parse(&format!("http://127.0.0.1:{port}/gone")).unwrap())
@@ -2663,7 +2647,7 @@ fn an_http_error_page_is_not_presented_as_the_page_that_was_asked_for() {
 #[test]
 fn an_empty_page_says_it_is_empty_rather_than_saying_nothing() {
     // Silence is the one answer an agent cannot act on.
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let factory = scripted_factory(broker);
     let page = factory.from_html(
         "<html><head><title>t</title></head><body></body></html>",
@@ -2731,7 +2715,7 @@ fn match_media_answers_from_the_viewport_the_engine_renders_at() {
 
 #[test]
 fn document_cookie_shows_what_a_browser_would_and_withholds_the_session() {
-    let broker = Arc::new(Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap());
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).unwrap();
     let base = url::Url::parse("https://app.example/page").unwrap();
     broker.jar().store(&base, ["sid=secret; HttpOnly", "theme=dark"]);
 
@@ -3058,9 +3042,7 @@ fn document_identity_properties_answer_from_the_page() {
 
 #[test]
 fn current_script_names_the_running_element_and_only_then() {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), options);
@@ -3611,9 +3593,7 @@ fn a_global_missing_because_a_script_was_refused_is_not_called_an_engine_gap() {
 
 #[test]
 fn an_uncaught_error_says_which_script_it_came_from() {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), options);
@@ -3704,9 +3684,7 @@ fn a_scoped_tag_search_only_sees_the_subtree() {
 
 #[test]
 fn a_script_that_threw_explains_the_globals_it_never_defined() {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let options = PageOptions { script: true, ..Default::default() };
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), options);
@@ -3789,9 +3767,7 @@ fn requests_overlap_instead_of_queueing_behind_each_other() {
     use std::sync::atomic::Ordering;
     let (port, peak) = slow_server(std::time::Duration::from_millis(120));
 
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
@@ -3828,9 +3804,7 @@ fn more_requests_than_slots_still_all_finish() {
     use std::sync::atomic::Ordering;
     let (port, peak) = slow_server(std::time::Duration::from_millis(30));
 
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
@@ -3885,9 +3859,7 @@ fn the_wire_says_what_this_engine_is_and_what_it_will_accept() {
         seen
     });
 
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let url = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();
     let _ = broker.fetch(&url, crate::receipt::Initiator::Navigation);
 
@@ -4154,9 +4126,7 @@ fn the_old_request_object_goes_through_the_same_broker() {
     use std::sync::atomic::Ordering;
     let (port, hits) = counting_server();
 
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
     let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
     let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
     let base = url::Url::parse(&format!("http://127.0.0.1:{port}/")).unwrap();

--- a/crates/h5i-browser-light/src/secrets.rs
+++ b/crates/h5i-browser-light/src/secrets.rs
@@ -186,7 +186,7 @@ impl Secrets {
 }
 
 /// What a substitution did.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Resolved {
     /// The text to hand to the page.
     pub text: String,

--- a/crates/h5i-browser-light/src/selector.rs
+++ b/crates/h5i-browser-light/src/selector.rs
@@ -269,14 +269,12 @@ mod tests {
     use super::*;
 
     fn page(html: &str) -> crate::engine::Page {
-        let broker = std::sync::Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new(),
                 std::sync::Arc::new(crate::receipt::MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = crate::engine::PageFactory::new(
             broker,

--- a/crates/h5i-browser-light/src/sse.rs
+++ b/crates/h5i-browser-light/src/sse.rs
@@ -8,13 +8,13 @@
 //!
 //! ## Why it needed a second exit from the broker
 //!
-//! [`crate::net::Broker::send_from`] reads a whole body before it returns
+//! [`crate::broker::Broker::send_from`] reads a whole body before it returns
 //! (`read_capped`), and writes one response record with a final byte count.
 //! That is the right shape for a document and the wrong shape for a stream: an
 //! event stream never completes, so it would hit the response cap or the
 //! client timeout, whichever came first, and be reported as an error.
 //!
-//! So there is a second path — [`crate::net::Broker::open_event_stream`] —
+//! So there is a second path — [`crate::net::LocalBroker::begin_event_stream`] —
 //! which shares the front half exactly (policy, then the decision record,
 //! *then* the wire) and hands back the response to be read incrementally.
 //! Sharing the front half is the point: a stream is authorised and receipted by
@@ -31,7 +31,7 @@ use std::sync::{Arc, Mutex};
 
 use url::Url;
 
-use crate::net::Broker;
+use crate::net::LocalBroker;
 use crate::wsclient::{Direction, Event};
 
 /// Cap on one event's data, so a server cannot grow this without bound.
@@ -51,7 +51,7 @@ pub struct EventStream {
 
 impl EventStream {
     /// Open one, or say why not.
-    pub fn open(broker: Arc<Broker>, url: &Url, document: Option<&Url>) -> Result<Self, String> {
+    pub fn open(broker: Arc<LocalBroker>, url: &Url, document: Option<&Url>) -> Result<Self, String> {
         if !matches!(url.scheme(), "http" | "https") {
             return Err(format!(
                 "{url} is not an event-stream address: `EventSource` takes http or https."
@@ -60,7 +60,7 @@ impl EventStream {
 
         // Policy, then the record, then the wire — the same order and the same
         // code as every other request here.
-        let response = broker.open_event_stream(url, document)?;
+        let response = broker.begin_event_stream(url, document)?;
 
         let (tx, rx) = std::sync::mpsc::sync_channel(MAX_QUEUED);
         let _ = tx.send(Event::Open);
@@ -122,6 +122,23 @@ impl EventStream {
     }
 }
 
+/// An event stream is read-only, and says so rather than quietly dropping what
+/// a page tried to send. `EventSource` has no `send` in any browser; a page
+/// calling one is a page with a bug, and an error is what tells it so.
+impl crate::broker::Channel for EventStream {
+    fn send(&self, _text: &str) -> Result<(), String> {
+        Err("an event stream is read-only: there is nothing to send on".to_string())
+    }
+
+    fn drain(&self) -> Vec<Event> {
+        EventStream::drain(self)
+    }
+
+    fn close(&self) {
+        EventStream::close(self)
+    }
+}
+
 impl Drop for EventStream {
     fn drop(&mut self) {
         self.close();
@@ -139,7 +156,7 @@ impl Drop for EventStream {
 fn read_loop(
     response: reqwest::blocking::Response,
     tx: SyncSender<Event>,
-    broker: Arc<Broker>,
+    broker: Arc<LocalBroker>,
     url: Url,
     stop: Arc<std::sync::atomic::AtomicBool>,
 ) {
@@ -302,10 +319,8 @@ mod tests {
         (port, handle)
     }
 
-    fn broker_with(sink: Arc<crate::receipt::MemorySink>) -> Arc<Broker> {
-        Arc::new(
-            Broker::new(crate::policy::Policy::new(), sink, None).expect("broker"),
-        )
+    fn broker_with(sink: Arc<crate::receipt::MemorySink>) -> Arc<LocalBroker> {
+        LocalBroker::new(crate::policy::Policy::new(), sink, None).expect("broker")
     }
 
     #[test]

--- a/crates/h5i-browser-light/src/stream.rs
+++ b/crates/h5i-browser-light/src/stream.rs
@@ -1072,6 +1072,21 @@ fn put_strings(value: Value, redacted: &mut impl Iterator<Item = String>) -> Val
     }
 }
 
+/// What the page currently loaded spent on the network, and against what.
+///
+/// One reading rather than three. `Broker::budget` is a call across a process
+/// boundary now, and asking three times for three fields of one answer also
+/// meant the three could come from three different moments while a page was
+/// still fetching.
+fn budget_of(session: &Session) -> Value {
+    let allowance = session.factory.broker().budget();
+    json!({
+        "spent": allowance.spent,
+        "max_requests": allowance.limits.max_requests,
+        "max_wire_bytes": allowance.limits.max_wire_bytes,
+    })
+}
+
 /// Handle one control request against the resident page.
 ///
 /// Returns the reply and whether the page moved, because the caller is the only
@@ -1198,11 +1213,7 @@ fn control_verb_inner(
                 // against what. An agent that hit a budget should be able to
                 // see how close it came rather than inferring it from a
                 // refusal in the request log.
-                "budget": {
-                    "spent": session.factory.broker().budget().spent,
-                    "max_requests": session.factory.broker().budget().limits.max_requests,
-                    "max_wire_bytes": session.factory.broker().budget().limits.max_wire_bytes,
-                },
+                "budget": budget_of(session),
             }),
             false,
         ),
@@ -1690,37 +1701,28 @@ fn control_verb_inner(
         // the network — it is the decision record the broker wrote before the
         // bytes moved. If it is not here, it did not happen.
         Verb::Requests => {
-            let all = session.factory.broker().records();
-
             // `since` lets an agent ask what happened after its last look, the
             // same shape `snapshot --delta` has and for the same reason: the
             // whole log re-read after every click is the wrong size for a loop.
+            //
+            // Asked *of the broker* as a window rather than filtered here. The
+            // log lives in another process now, and reading it whole to hand
+            // back a tail would put the thing the cursor exists to avoid back
+            // on the wire, where it would grow with the session instead of with
+            // the answer.
             let since = request.get("since").and_then(Value::as_u64);
-            let rows: Vec<&crate::receipt::RequestRecord> = all
-                .iter()
-                .filter(|r| since.is_none_or(|floor| r.seq > floor))
-                .collect();
-
-            // Counted over the *whole* log rather than the window, because
-            // "nothing was refused" is a claim about the session and an agent
-            // that only ever asks for windows should still be able to make it.
-            let denied = all
-                .iter()
-                .filter(|r| r.phase == crate::receipt::Phase::Request && !r.allowed)
-                .count();
+            let rows = session.factory.broker().records_since(since);
+            // The counts are over the *whole* log rather than the window,
+            // because "nothing was refused" is a claim about the session and an
+            // agent that only ever asks for windows should still be able to
+            // make it. Three numbers, not the log they came from.
+            let summary = session.factory.broker().log_summary();
 
             let text = rows
                 .iter()
                 .map(|r| r.render())
                 .collect::<Vec<_>>()
                 .join("\n");
-            // The highest seq, not the last appended. Sequence numbers are
-            // taken before the append, and a socket reader thread appends
-            // concurrently with the page's own fetches — so append order and
-            // seq order can differ, and `last()` would either re-show a row or
-            // skip one permanently. A hole in a log this verb documents as
-            // complete by construction is the worst of the two.
-            let highest = all.iter().map(|r| r.seq).max();
 
             (
                 json!({
@@ -1728,11 +1730,15 @@ fn control_verb_inner(
                     "requests": rows,
                     // The cursor to pass back as `since`. Named rather than
                     // left to be derived from the last row, which is absent
-                    // when the window is empty.
-                    "cursor": highest,
+                    // when the window is empty. The highest sequence, not the
+                    // last appended: numbers are taken before the append and a
+                    // socket's reader thread appends concurrently with the
+                    // page's own fetches, so `last()` would either re-show a
+                    // row or skip one permanently.
+                    "cursor": summary.highest,
                     "shown": rows.len(),
-                    "total": all.len(),
-                    "denied": denied,
+                    "total": summary.total,
+                    "denied": summary.denied,
                     "text": text,
                 }),
                 false,

--- a/crates/h5i-browser-light/src/stream.rs
+++ b/crates/h5i-browser-light/src/stream.rs
@@ -45,7 +45,6 @@ use std::net::{TcpListener, TcpStream};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Arc;
 use std::thread;
 
 use base64::Engine as _;
@@ -116,13 +115,6 @@ pub struct ServeOptions {
     /// Serve one viewer and exit, which is what the tests and a one-shot
     /// demo want.
     pub once: bool,
-    /// The in-memory half of the receipt sink, so the session can answer
-    /// `requests` without reading back the file it just wrote.
-    ///
-    /// This is the same sink the fail-closed rule runs through, not a copy kept
-    /// alongside it: what the verb reports is what the broker recorded, or the
-    /// fetch did not happen.
-    pub requests: Arc<crate::receipt::MemorySink>,
 }
 
 impl Default for ServeOptions {
@@ -135,7 +127,6 @@ impl Default for ServeOptions {
             control_socket: None,
             action_log: None,
             once: false,
-            requests: Arc::new(crate::receipt::MemorySink::new()),
         }
     }
 }
@@ -203,20 +194,6 @@ struct Session {
     /// answers about one thing.
     last_snapshot: Option<crate::snapshot::Snapshot>,
 
-    /// Credentials this session may substitute on the way to the page.
-    ///
-    /// Read once at startup so a later `setenv` cannot widen what the agent can
-    /// reach. See [`crate::secrets`] for why the namespace is narrower than
-    /// `H5I_*`.
-    secrets: crate::secrets::Secrets,
-
-    /// The request log, live.
-    ///
-    /// See [`ServeOptions::requests`]. Held rather than reached through the
-    /// broker because `Sink` is deliberately a one-method trait — `append` and
-    /// nothing else — and widening it to be readable would weaken the thing
-    /// that makes the guarantee simple to state.
-    requests: Arc<crate::receipt::MemorySink>,
 
     /// The refs this session last handed to a control client.
     ///
@@ -426,8 +403,6 @@ pub fn serve(factory: PageFactory, page: Page, options: ServeOptions) -> Result<
         served_refs: None,
         unknown_verbs: std::collections::BTreeMap::new(),
         recording: crate::replay::Recording::default(),
-        requests: options.requests.clone(),
-        secrets: crate::secrets::Secrets::from_env(),
         login: false,
     };
     run_session(session, rx, options.once);
@@ -984,7 +959,7 @@ fn recorded_verb(session: &mut Session, request: &Value) -> (Value, bool) {
         if reply.get("ok").and_then(Value::as_bool) == Some(true) {
             record_step(session, request, &reply);
         }
-        return (redact_reply(&session.secrets, reply), changed);
+        return (redact_reply(session.factory.broker().as_ref(), reply), changed);
     };
 
     let seq = match log.begin(verb, target.as_deref()) {
@@ -1006,7 +981,7 @@ fn recorded_verb(session: &mut Session, request: &Value) -> (Value, bool) {
     // it belongs to this verb's window — which is the join a reviewer needs and
     // the thing the old implementation got exactly backwards (see
     // `ActionRecord::requests`).
-    let mark = session.requests.high_water();
+    let mark = session.factory.broker().high_water();
 
     let (answer, changed) = control_verb(session, request);
 
@@ -1016,7 +991,7 @@ fn recorded_verb(session: &mut Session, request: &Value) -> (Value, bool) {
     }
     let url = answer.get("url").and_then(Value::as_str);
     let error = answer.get("error").and_then(Value::as_str);
-    let caused = session.requests.since(mark);
+    let caused = session.factory.broker().since(mark);
     if let Some(log) = &session.actions {
         log.finish(
             seq,
@@ -1032,7 +1007,7 @@ fn recorded_verb(session: &mut Session, request: &Value) -> (Value, bool) {
     }
     // Redacted after the action log is written, so the log keeps the engine's
     // own account and only what leaves for the agent is scrubbed.
-    (redact_reply(&session.secrets, answer), changed)
+    (redact_reply(session.factory.broker().as_ref(), answer), changed)
 }
 
 /// Put credential placeholders back into anything on its way out.
@@ -1050,19 +1025,47 @@ fn recorded_verb(session: &mut Session, request: &Value) -> (Value, bool) {
 ///
 /// The cost is a string scan per reply against a handful of values, on a path
 /// that has already done a policy check and a layout pass.
-fn redact_reply(secrets: &crate::secrets::Secrets, value: Value) -> Value {
+fn redact_reply(broker: &dyn crate::broker::Broker, value: Value) -> Value {
+    // One pass to collect, one call, one pass to put back. The middle step is
+    // the reason for the shape: redaction happens where the values are, which
+    // after the split is another process, and a round trip per string in a
+    // snapshot reply would cost more than the snapshot did.
+    let mut texts: Vec<String> = Vec::new();
+    collect_strings(&value, &mut texts);
+    if texts.is_empty() {
+        return value;
+    }
+    let mut redacted = broker.redact_all(&texts).into_iter();
+    put_strings(value, &mut redacted)
+}
+
+fn collect_strings(value: &Value, out: &mut Vec<String>) {
     match value {
-        Value::String(text) => Value::String(secrets.redact(&text)),
+        Value::String(text) => out.push(text.clone()),
+        Value::Array(items) => items.iter().for_each(|item| collect_strings(item, out)),
+        // Values, not keys: a field *name* is this engine's own vocabulary, and
+        // a secret that happened to look like one would be a stranger thing
+        // than a leak.
+        Value::Object(fields) => fields.values().for_each(|item| collect_strings(item, out)),
+        _ => {}
+    }
+}
+
+/// The same traversal, in the same order, putting each answer back where its
+/// question came from.
+fn put_strings(value: Value, redacted: &mut impl Iterator<Item = String>) -> Value {
+    match value {
+        Value::String(text) => Value::String(redacted.next().unwrap_or(text)),
         Value::Array(items) => Value::Array(
             items
                 .into_iter()
-                .map(|item| redact_reply(secrets, item))
+                .map(|item| put_strings(item, redacted))
                 .collect(),
         ),
         Value::Object(fields) => Value::Object(
             fields
                 .into_iter()
-                .map(|(name, item)| (name, redact_reply(secrets, item)))
+                .map(|(name, item)| (name, put_strings(item, redacted)))
                 .collect(),
         ),
         other => other,
@@ -1182,7 +1185,7 @@ fn control_verb_inner(
                 // without being able to read the credential that makes it so,
                 // which is what keeps a stolen snapshot worth less than a
                 // stolen jar.
-                "cookies": session.factory.broker().jar().len(),
+                "cookies": session.factory.broker().cookie_count(),
                 "login": session.login,
                 "open_sockets": session.page.open_sockets(),
                 // What was asked for and does not exist. Empty on almost every
@@ -1196,9 +1199,9 @@ fn control_verb_inner(
                 // see how close it came rather than inferring it from a
                 // refusal in the request log.
                 "budget": {
-                    "spent": session.factory.broker().budget().spent(),
-                    "max_requests": session.factory.broker().budget().limits().max_requests,
-                    "max_wire_bytes": session.factory.broker().budget().limits().max_wire_bytes,
+                    "spent": session.factory.broker().budget().spent,
+                    "max_requests": session.factory.broker().budget().limits.max_requests,
+                    "max_wire_bytes": session.factory.broker().budget().limits.max_wire_bytes,
                 },
             }),
             false,
@@ -1228,7 +1231,7 @@ fn control_verb_inner(
                 json!({
                     "ok": true,
                     "login": on,
-                    "cookies": session.factory.broker().jar().len(),
+                    "cookies": session.factory.broker().cookie_count(),
                     "message": if on {
                         "login mode is on: the page is no longer readable by the agent, and the \
                          live view is yours. Type the credential there, then end this mode."
@@ -1393,7 +1396,7 @@ fn control_verb_inner(
             // The one place a credential is resolved, guarded by the predicate
             // rather than by this call site remembering to ask.
             let resolved = if Verb::Type.substitutes_secrets() {
-                session.secrets.substitute(text)
+                session.factory.broker().substitute(text)
             } else {
                 crate::secrets::Resolved {
                     text: text.to_string(),
@@ -1687,7 +1690,7 @@ fn control_verb_inner(
         // the network — it is the decision record the broker wrote before the
         // bytes moved. If it is not here, it did not happen.
         Verb::Requests => {
-            let all = session.requests.records();
+            let all = session.factory.broker().records();
 
             // `since` lets an agent ask what happened after its last look, the
             // same shape `snapshot --delta` has and for the same reason: the
@@ -2014,7 +2017,7 @@ fn control_verb_inner(
         }
 
         Verb::Env => {
-            let names = session.secrets.names();
+            let names = session.factory.broker().secret_names();
             (
                 json!({
                     "ok": true,
@@ -2414,15 +2417,34 @@ fn scroll_for_key(key: &str, viewport_height: f64) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::net::Broker;
     use crate::policy::Policy;
     use crate::receipt::MemorySink;
     use std::sync::Arc;
 
     fn session_with(html: &str) -> Session {
+        session_and_broker(html, crate::secrets::Secrets::default()).0
+    }
+
+    /// The same session, plus the broker underneath it.
+    ///
+    /// A session holds a `dyn Broker` and can only ask it things; a test that
+    /// wants to *put* something in the log, or to name a credential the broker
+    /// will substitute, needs the local one. Building it here rather than
+    /// reaching for it through the session is the point: after the split there
+    /// is no way back from the renderer's side, and a test that pretended
+    /// otherwise would be testing a shape the product does not have.
+    fn session_and_broker(
+        html: &str,
+        secrets: crate::secrets::Secrets,
+    ) -> (Session, Arc<crate::net::LocalBroker>) {
         let requests = Arc::new(MemorySink::new());
-        let broker =
-            Arc::new(Broker::new(Policy::new(), requests.clone(), None).expect("broker"));
+        let broker = crate::net::LocalBroker::with_secrets(
+            Policy::new(),
+            requests.clone(),
+            None,
+            secrets,
+        )
+        .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(4));
         let sources = fonts.sources.clone();
         let options = crate::engine::PageOptions {
@@ -2430,9 +2452,9 @@ mod tests {
             height: 200,
             ..Default::default()
         };
-        let factory = PageFactory::new(broker, sources, options);
+        let factory = PageFactory::new(broker.clone(), sources, options);
         let page = factory.from_html(html, &Url::parse("https://example.com/").unwrap());
-        Session {
+        let session = Session {
             factory,
             page,
             quality: 70,
@@ -2441,11 +2463,10 @@ mod tests {
             last_snapshot: None,
             served_refs: None,
             unknown_verbs: std::collections::BTreeMap::new(),
-        recording: crate::replay::Recording::default(),
-            requests,
-            secrets: crate::secrets::Secrets::default(),
+            recording: crate::replay::Recording::default(),
             login: false,
-        }
+        };
+        (session, broker)
     }
 
     /// Serves one page per connection, so a fused navigation has somewhere to
@@ -3164,9 +3185,8 @@ mod tests {
     /// A session whose page runs its own scripts, for the verbs that behave
     /// differently once script is present.
     fn scripted_session_with(html: &str) -> Session {
-        let requests = Arc::new(MemorySink::new());
-        let broker =
-            Arc::new(Broker::new(Policy::new(), requests.clone(), None).expect("broker"));
+        let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+            .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let options = crate::engine::PageOptions {
             width: 400,
@@ -3185,9 +3205,7 @@ mod tests {
             last_snapshot: None,
             served_refs: None,
             unknown_verbs: std::collections::BTreeMap::new(),
-        recording: crate::replay::Recording::default(),
-            requests,
-            secrets: crate::secrets::Secrets::default(),
+            recording: crate::replay::Recording::default(),
             login: false,
         }
     }
@@ -3549,13 +3567,14 @@ mod tests {
         // been reading the exact opposite of what happened.
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("actions.jsonl");
-        let mut session = session_with(tall_page());
+        let (mut session, broker) =
+            session_and_broker(tall_page(), crate::secrets::Secrets::default());
         session.actions = Some(ActionLog::create(&path).expect("log"));
 
         // Put something in the request log that this verb plainly did not do.
         use crate::receipt::Sink as _;
-        session
-            .requests
+        broker
+            .log()
             .append(&crate::receipt::RequestRecord::request(
                 7,
                 crate::receipt::Initiator::Navigation,
@@ -3581,14 +3600,15 @@ mod tests {
     fn a_verb_carries_the_receipts_written_while_it_ran() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("actions.jsonl");
-        let mut session = session_with(tall_page());
+        let (mut session, broker) =
+            session_and_broker(tall_page(), crate::secrets::Secrets::default());
         session.actions = Some(ActionLog::create(&path).expect("log"));
 
         // One receipt from before the verb, one from during it. Only the second
         // belongs to the window.
         use crate::receipt::Sink as _;
-        session
-            .requests
+        broker
+            .log()
             .append(&crate::receipt::RequestRecord::request(
                 1,
                 crate::receipt::Initiator::Navigation,
@@ -3597,10 +3617,10 @@ mod tests {
             ))
             .expect("appended");
 
-        let mark = session.requests.high_water();
+        let mark = session.factory.broker().high_water();
         assert_eq!(mark, Some(1));
-        session
-            .requests
+        broker
+            .log()
             .append(&crate::receipt::RequestRecord::request(
                 2,
                 crate::receipt::Initiator::Navigation,
@@ -3610,13 +3630,13 @@ mod tests {
             .expect("appended");
 
         assert_eq!(
-            session.requests.since(mark),
+            session.factory.broker().since(mark),
             vec![2],
             "the window starts at the mark, not at the beginning of the session"
         );
         // A request and its response share a number, so the pair is one entry.
-        session
-            .requests
+        broker
+            .log()
             .append(&crate::receipt::RequestRecord::request(
                 2,
                 crate::receipt::Initiator::Navigation,
@@ -3624,7 +3644,7 @@ mod tests {
                 "https://example.com/during",
             ))
             .expect("appended");
-        assert_eq!(session.requests.since(mark), vec![2]);
+        assert_eq!(session.factory.broker().since(mark), vec![2]);
     }
 
     #[test]
@@ -3866,12 +3886,11 @@ mod tests {
     fn a_credential_reaches_the_field_and_never_the_reply() {
         // The whole claim, in one test. The agent names a credential, the value
         // lands in the page, and nothing the agent can read ever holds it.
-        let mut session = session_with(
+        let (mut session, _broker) = session_and_broker(
             "<html><body><form action='/in' method='post'>\
              <input name='pass' type='password'></form></body></html>",
+            crate::secrets::Secrets::from_pairs(&[("H5I_SECRET_ACME_PASS", "hunter2")]),
         );
-        session.secrets =
-            crate::secrets::Secrets::from_pairs(&[("H5I_SECRET_ACME_PASS", "hunter2")]);
 
         let refs = serve_refs(&mut session);
         let (reply, changed) = control_verb(
@@ -3918,11 +3937,10 @@ mod tests {
         // validation message, a title — puts the value in the DOM, and the next
         // snapshot would hand it to the agent the indirection exists to keep it
         // from.
-        let mut session = session_with(
+        let (session, _broker) = session_and_broker(
             "<html><body><p id='echo'>nothing yet</p></body></html>",
+            crate::secrets::Secrets::from_pairs(&[("H5I_SECRET_ACME", "hunter2-secret")]),
         );
-        session.secrets =
-            crate::secrets::Secrets::from_pairs(&[("H5I_SECRET_ACME", "hunter2-secret")]);
 
         // Stand in for the page having reflected it: put the value where a
         // read verb will find it.
@@ -3933,7 +3951,7 @@ mod tests {
             assert!(node.is_some(), "the fixture needs the node");
         }
         let reply = redact_reply(
-            &session.secrets,
+            session.factory.broker().as_ref(),
             json!({
                 "ok": true,
                 "text": "the form said hunter2-secret back",
@@ -3953,11 +3971,13 @@ mod tests {
 
     #[test]
     fn env_lists_names_and_the_engine_has_no_verb_that_returns_a_value() {
-        let mut session = session_with("<html><body><p>hi</p></body></html>");
-        session.secrets = crate::secrets::Secrets::from_pairs(&[
-            ("H5I_SECRET_A", "aaaa-secret"),
-            ("H5I_SECRET_B", "bbbb-secret"),
-        ]);
+        let (mut session, _broker) = session_and_broker(
+            "<html><body><p>hi</p></body></html>",
+            crate::secrets::Secrets::from_pairs(&[
+                ("H5I_SECRET_A", "aaaa-secret"),
+                ("H5I_SECRET_B", "bbbb-secret"),
+            ]),
+        );
 
         let (reply, changed) = control_verb(&mut session, &json!({"verb": "env"}));
         assert_eq!(reply["ok"], true, "{reply:?}");
@@ -4414,11 +4434,12 @@ mod delta_and_login_tests {
     use super::*;
 
     fn page_session(html: &str) -> Session {
-        let requests = std::sync::Arc::new(crate::receipt::MemorySink::new());
-        let broker = std::sync::Arc::new(
-            crate::net::Broker::new(crate::policy::Policy::new(), requests.clone(), None)
-                .expect("broker"),
-        );
+        let broker = crate::net::LocalBroker::new(
+            crate::policy::Policy::new(),
+            std::sync::Arc::new(crate::receipt::MemorySink::new()),
+            None,
+        )
+        .expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = crate::engine::PageFactory::new(
             broker,
@@ -4436,9 +4457,7 @@ mod delta_and_login_tests {
             last_snapshot: None,
             served_refs: None,
             unknown_verbs: std::collections::BTreeMap::new(),
-        recording: crate::replay::Recording::default(),
-            requests,
-            secrets: crate::secrets::Secrets::default(),
+            recording: crate::replay::Recording::default(),
             login: false,
         }
     }

--- a/crates/h5i-browser-light/src/structured.rs
+++ b/crates/h5i-browser-light/src/structured.rs
@@ -253,15 +253,12 @@ fn fence_json(value: serde_json::Value) -> serde_json::Value {
 mod tests {
     use super::*;
     use crate::engine::{PageFactory, PageOptions};
-    use crate::net::Broker;
     use crate::policy::Policy;
     use crate::receipt::MemorySink;
     use std::sync::Arc;
 
     fn structured_of(html: &str) -> Structured {
-        let broker = Arc::new(
-            Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-        );
+        let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
         let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
         let factory = PageFactory::new(broker, fonts.sources.clone(), PageOptions::default());
         let page = factory.from_html(

--- a/crates/h5i-browser-light/src/wsclient.rs
+++ b/crates/h5i-browser-light/src/wsclient.rs
@@ -31,7 +31,7 @@
 //! how the sandbox's own allowlist stays in the path. Rather than quietly open a
 //! hole in it, a non-loopback socket is refused whenever `$H5I_EGRESS_PROXY` is
 //! set. Loopback is exempt because the proxy already excludes it
-//! (`NoProxy::from_string("localhost,127.0.0.1,::1")` in [`crate::net::Broker`]),
+//! (`NoProxy::from_string("localhost,127.0.0.1,::1")` in [`crate::net::LocalBroker`]),
 //! so nothing is being bypassed that was ever in the path.
 //!
 //! ## Every frame is receipted
@@ -56,7 +56,7 @@ use std::sync::{Arc, Mutex};
 use h5i_error::H5iError;
 use url::Url;
 
-use crate::net::Broker;
+use crate::net::LocalBroker;
 use crate::ws::{self, Incoming};
 
 /// The bytes underneath a socket, plain or encrypted.
@@ -222,7 +222,7 @@ const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10
 const MAX_QUEUED: usize = 512;
 
 /// What a socket hands the page.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Event {
     Open,
     Message(String),
@@ -250,7 +250,7 @@ pub struct Socket {
     /// attributed to the connection that carried them.
     pub seq: u64,
     pub url: Url,
-    broker: Arc<Broker>,
+    broker: Arc<LocalBroker>,
     closed: Mutex<bool>,
 }
 
@@ -258,9 +258,9 @@ impl Socket {
     /// Open one, or say why not.
     ///
     /// The policy check and the decision record happen *before* the TCP
-    /// connect, the same order [`Broker::send_from`] uses and for the same
+    /// connect, the same order [`crate::broker::Broker::send_from`] uses and for the same
     /// reason: no receipt, no connection.
-    pub fn open(broker: Arc<Broker>, url: &Url, document: Option<&Url>) -> Result<Socket, String> {
+    pub fn open(broker: Arc<LocalBroker>, url: &Url, document: Option<&Url>) -> Result<Socket, String> {
         let secure = match url.scheme() {
             "ws" => false,
             "wss" => true,
@@ -434,11 +434,25 @@ impl Direction {
     }
 }
 
+impl crate::broker::Channel for Socket {
+    fn send(&self, text: &str) -> Result<(), String> {
+        Socket::send(self, text)
+    }
+
+    fn drain(&self) -> Vec<Event> {
+        Socket::drain(self)
+    }
+
+    fn close(&self) {
+        Socket::close(self)
+    }
+}
+
 /// Read frames until the socket ends, receipting each one.
 fn read_loop(
     mut reader: BufReader<Wire>,
     tx: SyncSender<Event>,
-    broker: Arc<Broker>,
+    broker: Arc<LocalBroker>,
     url: Url,
 ) {
     loop {
@@ -638,14 +652,12 @@ mod tests {
     /// property; what is left is the allowlist doing its job.
     #[test]
     fn wss_is_a_scheme_this_engine_has_and_is_judged_by_the_allowlist() {
-        let broker = Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new(),
                 Arc::new(crate::receipt::MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let url = Url::parse("wss://example.com/socket").unwrap();
         let error = match Socket::open(broker, &url, None) {
             Err(error) => error,
@@ -665,14 +677,12 @@ mod tests {
     /// and says which schemes are.
     #[test]
     fn a_non_socket_scheme_is_still_refused() {
-        let broker = Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new(),
                 Arc::new(crate::receipt::MemorySink::new()),
                 None,
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let url = Url::parse("https://example.com/socket").unwrap();
         let error = match Socket::open(broker, &url, None) {
             Err(error) => error,
@@ -687,14 +697,12 @@ mod tests {
     /// the proxy.
     #[test]
     fn tls_does_not_buy_a_way_past_the_proxy_rule() {
-        let broker = Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new().allow_all_of(&["example.com".to_string()]),
                 Arc::new(crate::receipt::MemorySink::new()),
                 Some("http://127.0.0.1:9"),
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let url = Url::parse("wss://example.com/socket").unwrap();
         let error = match Socket::open(broker, &url, None) {
             Err(error) => error,
@@ -708,14 +716,12 @@ mod tests {
         // The containment point. A WebSocket is a raw socket and does not go
         // through the proxy, so opening a remote one would step around the
         // allowlist the proxy enforces inside a box.
-        let broker = Arc::new(
-            crate::net::Broker::new(
+        let broker = crate::net::LocalBroker::new(
                 crate::policy::Policy::new().allow_all_of(&["example.com".to_string()]),
                 Arc::new(crate::receipt::MemorySink::new()),
                 Some("http://127.0.0.1:3128"),
             )
-            .expect("broker"),
-        );
+            .expect("broker");
         let url = Url::parse("ws://example.com/socket").unwrap();
         let error = match Socket::open(broker, &url, None) {
             Err(error) => error,

--- a/crates/h5i-browser-light/tests/corpus.rs
+++ b/crates/h5i-browser-light/tests/corpus.rs
@@ -20,15 +20,14 @@
 use std::sync::Arc;
 
 use h5i_browser_light::engine::{PageFactory, PageOptions};
-use h5i_browser_light::net::Broker;
+use h5i_browser_light::net::LocalBroker;
 use h5i_browser_light::policy::Policy;
 use h5i_browser_light::receipt::MemorySink;
 
 /// Load a fixture with script enabled and settle it, as `open --script` does.
 fn read(html: &str) -> Reading {
-    let broker = Arc::new(
-        Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-    );
+    let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+        .expect("broker");
     let fonts = h5i_browser_light::fonts::load(
         &[],
         &h5i_browser_light::fonts::default_font_dirs(),
@@ -816,9 +815,8 @@ struct Driver {
 
 impl Driver {
     fn open(html: &str) -> Self {
-        let broker = Arc::new(
-            Broker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker"),
-        );
+        let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+            .expect("broker");
         let fonts = h5i_browser_light::fonts::load(
             &[],
             &h5i_browser_light::fonts::default_font_dirs(),

--- a/crates/h5i-core/src/browser_sandbox.rs
+++ b/crates/h5i-core/src/browser_sandbox.rs
@@ -48,7 +48,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::H5iError;
-use crate::sandbox::{self, HostCaps, IsolationClaim, NetMode, Profile, ResolvedPolicy};
+use crate::sandbox::{
+    self, HostCaps, IsolationClaim, NetMode, Profile, ResolvedPolicy, SecretGrant,
+};
 
 /// What is holding the engine, as the record states it.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -144,6 +146,11 @@ pub struct Wants<'a> {
     /// sandbox the engine inherits the whole environment, so a compromised one
     /// reads every secret on the machine. Here it reads the ones that were
     /// named, and a placeholder for anything else resolves to nothing.
+    ///
+    /// Full variable names, `H5I_SECRET_` prefix included. The caller
+    /// normalizes, because the prefix is not decoration: it is the namespace
+    /// the engine substitutes from, and it has to survive all the way to the
+    /// variable the child actually reads. See [`profile_for`].
     pub secrets: &'a [String],
     /// The wall-clock bound, in seconds, or `0` for none.
     ///
@@ -278,6 +285,28 @@ fn profile_for(wants: &Wants<'_>, fonts: &[PathBuf]) -> Profile {
     p.max_procs = Some(64);
 
     p.secrets = wants.secrets.to_vec();
+    // ...and the grants that deliver them, which is a separate field and was
+    // the bug: a profile that declares `secrets` and no `secret_grants` names a
+    // credential nothing fills, and `h5i browser env` answered "no credentials"
+    // for a session started with `--secret`.
+    //
+    // A box gets both from `merge_secret_grants` when its `env.toml` is loaded.
+    // A session has no `env.toml` — it has no repository at all — so the grants
+    // are assembled here, from the same list, and the broker resolves them at
+    // spawn time like any other run's.
+    //
+    // The grant's **name is the variable the child will see**, so it keeps the
+    // `H5I_SECRET_` prefix: `inject = env` injects `(name, value)`, and the
+    // engine substitutes from exactly that namespace. A grant named `ACME_PASS`
+    // would arrive as `ACME_PASS` and `$H5I_SECRET_ACME_PASS` would resolve to
+    // nothing — the failure this exists to end.
+    //
+    // `inject` is left at its default of `env`, which is the only one reachable
+    // here: `broker` refuses `inject = file` off the workspace tier, and a
+    // session is process tier. That refusal is load-bearing rather than
+    // incidental — a file-injected secret is unlinked when the `Brokered` guard
+    // drops, and `h5i browser open` returns while the session keeps running.
+    p.secret_grants = grants_for(wants.secrets);
 
     // A page can allocate. The budgets in the engine bound what one navigation
     // fetches and decodes; this bounds what the process can do with it when a
@@ -289,6 +318,25 @@ fn profile_for(wants: &Wants<'_>, fonts: &[PathBuf]) -> Profile {
     // completion needs a real one. See `Wants::wall_secs`.
     p.wall_secs = wants.wall_secs;
     p
+}
+
+/// The grants a list of `H5I_SECRET_*` names resolves to.
+///
+/// One formula, two readers: [`profile_for`] declares these on the profile, and
+/// the caller brokers them at spawn time. A session that runs unconfined has no
+/// profile to read them off — the host could not confine, or the caller said
+/// not to — and deriving them a second way there is how the two would come to
+/// disagree about which credential a session was promised.
+pub fn grants_for(names: &[String]) -> Vec<SecretGrant> {
+    names
+        .iter()
+        .map(|name| SecretGrant {
+            name: name.clone(),
+            source: Some(format!("env:{name}")),
+            inject: None,
+            ttl: None,
+        })
+        .collect()
 }
 
 /// The resolver's configuration, when it does not live where it appears to.
@@ -421,6 +469,17 @@ mod tests {
             &[],
         );
         assert_eq!(p.secrets, named);
+
+        // The name list is what a reader sees; the grants are what deliver.
+        // Declaring the first without the second is a session that reports the
+        // credential as granted and hands the engine nothing.
+        assert_eq!(p.secret_grants.len(), 1);
+        assert_eq!(p.secret_grants[0].name, "H5I_SECRET_ACME");
+        assert_eq!(p.secret_grants[0].source_or_default(), "env:H5I_SECRET_ACME");
+        // `env`, and it has to be: the engine reads variables, and `file` is
+        // refused off the workspace tier anyway.
+        assert_eq!(p.secret_grants[0].inject_or_default(), "env");
+        assert!(profile_for(&wants(tmp.path()), &[]).secret_grants.is_empty());
     }
 
     /// The sandbox contains the consequences, not the connection. If this ever

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -607,8 +607,13 @@ route to the network is to ask something else, which writes a receipt first.</p>
 <p><strong>What this buys, exactly:</strong></p>
 <ul>
 <li>Credentials named with <code>--secret</code> are in the broker's environment and not in
-  the renderer's. A page-bound <code>type</code> resolves through the broker, so the
-  renderer receives the value for the field it was told to fill and no other.</li>
+  the renderer's. A page-bound <code>type</code> resolves through the broker, so an intact
+  renderer receives the value for the field it was told to fill and no other.
+  A compromised one can ask the broker to resolve any credential <strong>this session
+  was granted</strong>, which is the narrowing the split actually buys: it cannot
+  reach one the session was not granted, and unconfined that would have been
+  every <code>H5I_SECRET_*</code> on the machine. Narrowing it further needs the control
+  channel to move to the broker, which is not built.</li>
 <li>The receipts path, the egress proxy and the allowlist are likewise absent
   from the renderer.</li>
 <li>The cookie jar is not in the renderer's memory. Script sees the non-<code>HttpOnly</code>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -155,6 +155,7 @@
 <a class="t3" href="#what-is-true-by-default">What is true by default</a>
 <a class="t3" href="#read-one-page-no-session">read: one page, no session</a>
 <a class="t3" href="#the-default-sandbox">The default sandbox</a>
+<a class="t3" href="#two-processes-the-broker-and-the-renderer">Two processes: the broker and the renderer</a>
 <a class="t3" href="#--in-box-the-same-session-inside-a-box">--in &lt;box&gt;: the same session, inside a box</a>
 <a class="t3" href="#opening-a-session-from-inside-a-box">Opening a session from inside a box</a>
 <a class="t3" href="#reading-and-acting-beyond-snapshot-and-click">Reading and acting, beyond snapshot and click</a>
@@ -571,6 +572,43 @@ a session runs unconfined.</p>
 the session runs unconfined <strong>and says which</strong>, on the placement line and in the
 record. A sandbox nobody can see is indistinguishable from one that was never
 applied.</p>
+<h3 id="two-processes-the-broker-and-the-renderer">Two processes: the broker and the renderer</h3>
+<p>A session is two processes, and neither is a command you type. The one h5i
+starts is the <strong>broker</strong>: it holds the allowlist, the HTTP client, the receipt
+sink, the cookie jar, the per-page budget and the credentials. It starts the
+<strong>renderer</strong>, which parses the HTML, runs the cascade, decodes the images and
+fonts, runs the page's script and draws the frame. The renderer holds none of
+the things in that first list. It asks; the broker decides and records.</p>
+<pre><code>$ ps -o pid,ppid,args
+  55509  36242  h5i __engine serve https://example.com ...
+  55511  55509  h5i __engine --brokered serve https://example.com ...
+</code></pre>
+<p>The reason is that a browser's parsers are where a stranger's bytes are read. A
+bug in Blitz, Stylo, an image decoder or Boa used to be a bug in the process
+that also held the policy, the jar and every <code>H5I_SECRET_*</code> in the environment.
+Now it is a bug in a process whose environment has none of them, and whose only
+route to the network is to ask something else, which writes a receipt first.</p>
+<p><strong>What this buys, exactly:</strong></p>
+<ul>
+<li>Credentials named with <code>--secret</code> are in the broker's environment and not in
+  the renderer's. A page-bound <code>type</code> resolves through the broker, so the
+  renderer receives the value for the field it was told to fill and no other.</li>
+<li>The receipts path, the egress proxy and the allowlist are likewise absent
+  from the renderer.</li>
+<li>The cookie jar is not in the renderer's memory. Script sees the non-<code>HttpOnly</code>
+  subset because it asks for it, which is the same answer it always got, from a
+  place a parser bug cannot reach past.</li>
+<li>When the renderer dies the broker knows, with a status. When the broker dies
+  the renderer stops, because a renderer that cannot receipt is not a browser.</li>
+</ul>
+<p><strong>What it does not buy yet.</strong> The renderer is in the broker's network namespace,
+so it can still open a socket of its own. The split moved what a compromised
+parser can reach <em>in memory</em>. The request log becomes evidence against a
+compromised parser only when the renderer's own profile denies the network,
+which is ROADMAP §B18.7 step 3 and is not built.</p>
+<p><code>H5I_BROWSER_NO_SPLIT=1</code> runs the engine as one process, the way it ran before.
+It is there for comparing the two shapes, and for a host where spawning is the
+problem. A spawn that fails falls back to one process on its own, and says so.</p>
 <h3 id="--in-box-the-same-session-inside-a-box"><code>--in &lt;box&gt;</code>: the same session, inside a box</h3>
 <pre><code class="language-bash">h5i box --profile browser --engine h5i --name web
 h5i browser open https://example.com --in web

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -548,9 +548,25 @@ log. Containing the network, and earning <code>host-observed</code>, needs a bou
 outside the engine: <code>--in</code>, below.</p>
 <p>Two consequences worth knowing before they surprise you:</p>
 <ul>
-<li><strong>Secrets are not inherited.</strong> Unconfined, the engine reads the whole
+<li>
+<p><strong>Secrets are not inherited.</strong> Unconfined, the engine reads the whole
   environment, so a compromised one reads every <code>H5I_SECRET_*</code> on the machine.
-  Confined it reads none unless named: <code>h5i browser open &lt;url&gt; --secret ACME_PASS</code>.</li>
+  Confined it reads none unless named:</p>
+<pre><code>H5I_SECRET_ACME_PASS=... h5i browser open https://acme.test --secret ACME_PASS
+h5i browser type @e2 '$H5I_SECRET_ACME_PASS'
+</code></pre>
+<p><code>--secret ACME_PASS</code> and <code>--secret H5I_SECRET_ACME_PASS</code> name the same
+credential. The value is resolved from the environment the command is
+started in, once, and delivered to that session alone. It lands in the
+session's broker process, not in the renderer that parses the page.</p>
+<p>Fail-closed: a credential that cannot be resolved refuses the session,
+rather than starting one that will decline the first <code>type</code> that needs it.
+The same in both shapes, because a host that cannot confine still has to
+answer <code>--secret</code> the same way.</p>
+<p>Not for <code>--in</code>. A session placed in a box gets its credentials from that
+box's policy, declared in <code>.h5i/env.toml</code> under the profile it was created
+with. <code>--secret</code> with <code>--in</code> is refused rather than ignored.</p>
+</li>
 <li>
 <p><strong>Personal fonts are visible, and nothing else under <code>$HOME</code> is.</strong> <code>~/.fonts</code>
   and <code>~/.local/share/fonts</code> are granted read-only, because a font someone

--- a/man/man1/h5i.1
+++ b/man/man1/h5i.1
@@ -1408,6 +1408,10 @@ By default a session on this machine runs in a process\-tier sandbox: it may rea
 Let this session substitute `$H5I_SECRET_<NAME>`. Repeatable.
 
 Nothing is granted by default. Unconfined, the engine inherits the whole environment and a compromised one reads every secret on the machine; inside the sandbox it reads the ones that were named.
+
+The value is resolved from the environment this command runs in and delivered to this session alone. Fail\-closed: a name whose variable is not set refuses the session rather than starting one that cannot use it. `ACME_PASS` and `H5I_SECRET_ACME_PASS` name the same thing.
+
+Not for `\-\-in`: a session in a box takes its credentials from that box\*(Aqs policy, in `.h5i/env.toml`.
 .TP
 \fB\-\-width\fR \fI<WIDTH>\fR [default: 1280]
 Viewport width

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -142,6 +142,14 @@ pub enum BrowserCommands {
         /// Nothing is granted by default. Unconfined, the engine inherits the
         /// whole environment and a compromised one reads every secret on the
         /// machine; inside the sandbox it reads the ones that were named.
+        ///
+        /// The value is resolved from the environment this command runs in and
+        /// delivered to this session alone. Fail-closed: a name whose variable
+        /// is not set refuses the session rather than starting one that cannot
+        /// use it. `ACME_PASS` and `H5I_SECRET_ACME_PASS` name the same thing.
+        ///
+        /// Not for `--in`: a session in a box takes its credentials from that
+        /// box's policy, in `.h5i/env.toml`.
         #[arg(long = "secret", value_name = "NAME")]
         secrets: Vec<String>,
 
@@ -1053,6 +1061,30 @@ fn start(
         );
     }
 
+    if let (Some(target), false) = (&opts.in_box, opts.secrets.is_empty()) {
+        // A box already has a place to say this, and it is checked in: two ways
+        // to declare one grant is how one of them rots. `--secret` reaches the
+        // profile h5i builds for a *host* session, which is the placement with
+        // no repository and therefore no `env.toml` to write it in. A session
+        // placed in a box inherits that box's policy, so the grant belongs
+        // there, where a reviewer can read it beside everything else the box is
+        // allowed to do.
+        //
+        // An error rather than a warning because the flag did nothing at all
+        // here: `spawn_in_box` never read it, so every session started this way
+        // ran without the credential it was told to carry and said nothing.
+        anyhow::bail!(
+            "`--secret` does not apply to a session placed in a box. `{target}` gets its \
+             credentials from its own policy.\n\n  \
+             Declare the grant in `.h5i/env.toml`, under the profile the box was created \
+             with:\n    \
+             [profile.browser]\n    \
+             secrets = [\"H5I_SECRET_ACME_PASS\"]\n\n  \
+             `--secret` is for a session on this host, which has no repository and so no \
+             `env.toml` to declare anything in."
+        );
+    }
+
     let placement = match &opts.in_box {
         None => bs::Placement::Host,
         Some(name) => bs::Placement::Box { name: name.clone() },
@@ -1072,7 +1104,7 @@ fn start(
     let dir = bs::dir(root, &id);
 
     let mut spawned = match &placement {
-        bs::Placement::Host => spawn_on_host(&dir, &opts, enclosing_box.is_some())?,
+        bs::Placement::Host => spawn_on_host(root, &dir, &opts, enclosing_box.is_some())?,
         bs::Placement::Box { name } => spawn_in_box(name, &dir, &opts)?,
     };
     let lane = bs::Session::lane_for(&placement, spawned.boundary_enforced);
@@ -1194,7 +1226,12 @@ struct Spawned {
     stop: Box<dyn FnOnce()>,
 }
 
-fn spawn_on_host(dir: &Path, opts: &StartOptions, in_a_box: bool) -> anyhow::Result<Spawned> {
+fn spawn_on_host(
+    root: &Path,
+    dir: &Path,
+    opts: &StartOptions,
+    in_a_box: bool,
+) -> anyhow::Result<Spawned> {
     // A port on a bare host, a socket inside a box.
     //
     // The port is the simpler channel and the session directory can be
@@ -1244,10 +1281,11 @@ fn spawn_on_host(dir: &Path, opts: &StartOptions, in_a_box: bool) -> anyhow::Res
     // engine is somewhere it may read and not run.
     let engine = engine_binary()?;
     let reads = vec![engine.clone()];
+    let secrets = secret_variables(&opts.secrets)?;
     let wants = h5i_core::browser_sandbox::Wants {
         session_dir: dir,
         reads: &reads,
-        secrets: &opts.secrets,
+        secrets: &secrets,
         // A session is resident and is bounded by `--expires-in`, not a signal.
         wall_secs: 0,
     };
@@ -1256,6 +1294,31 @@ fn spawn_on_host(dir: &Path, opts: &StartOptions, in_a_box: bool) -> anyhow::Res
     } else {
         h5i_core::browser_sandbox::resolve_for(&wants)?
     };
+
+    // The credentials this session was told to carry, resolved before anything
+    // is spawned and delivered to this child alone.
+    //
+    // Above the confined/unconfined branch on purpose. A host that cannot
+    // confine still has to answer `--secret` the same way, and the first cut of
+    // this brokered only on the confined path — so on a machine without
+    // Landlock, or under `--no-sandbox`, a credential that did not exist would
+    // have started a session that quietly could not use it. Fail-closed is not
+    // a property of the sandbox; it is a property of the promise.
+    //
+    // The grants come from the same function that put them on the profile, so
+    // the unconfined path cannot promise a different set from the confined one.
+    // Nothing is written to disk: `inject = env` has no file, and `broker`
+    // refuses `inject = file` off the workspace tier, which is what keeps the
+    // guard's unlink-on-drop from mattering to a session that outlives this
+    // command.
+    let brokered = h5i_core::secrets_broker::broker(
+        &h5i_core::browser_sandbox::grants_for(&secrets),
+        &secret_dir(root),
+        false,
+        false,
+        &h5i_core::secrets_broker::fingerprint_key(root)?,
+    )
+    .map_err(unresolved_credential)?;
 
     // Inside the sandbox the environment is cleared, so the engine's own
     // `$HOME`-based font discovery finds nothing. The grant and the search path
@@ -1288,23 +1351,24 @@ fn spawn_on_host(dir: &Path, opts: &StartOptions, in_a_box: bool) -> anyhow::Res
             // `__engine` alone is a subcommand, not a binary.
             let mut confined_argv = vec![engine.display().to_string()];
             confined_argv.extend(argv.iter().cloned());
+            // The environment is cleared and rebuilt from the profile, so
+            // nothing here inherits by accident: `--secret` is a policy
+            // statement rather than a shell habit, and this is where the
+            // statement is made good.
+            let mut injected = brokered.env.clone();
+            // The engine's own single-process switch, which is here because a
+            // debugging hatch that silently does nothing in the default
+            // arrangement is worse than no hatch: it is documented as running
+            // the engine as one process, and inside the sandbox the variable
+            // would otherwise never arrive. It grants nothing and reveals
+            // nothing.
+            injected.extend(single_process_switch());
+
             let handle = h5i_core::sandbox::spawn_background(
                 &c.policy,
                 dir,
                 &confined_argv,
-                // The environment is cleared and rebuilt from the profile, so
-                // nothing here inherits by accident. The granted secrets are
-                // carried in the profile rather than injected as a pile of
-                // variables, which is what makes `--secret` a policy statement
-                // instead of a shell habit.
-                //
-                // The one exception is the engine's own single-process switch,
-                // and it is here because a debugging hatch that silently does
-                // nothing in the default arrangement is worse than no hatch:
-                // it is documented as running the engine as one process, and
-                // inside the sandbox the variable would otherwise never arrive.
-                // It grants nothing and reveals nothing.
-                &single_process_switch(),
+                &injected,
                 &log_path,
                 "browser-session",
             )?;
@@ -1318,6 +1382,12 @@ fn spawn_on_host(dir: &Path, opts: &StartOptions, in_a_box: bool) -> anyhow::Res
                 .stdin(Stdio::null())
                 .stdout(Stdio::from(log.try_clone()?))
                 .stderr(Stdio::from(log));
+            // Named credentials, set explicitly even though this child inherits
+            // the whole environment anyway. What it buys is not secrecy — there
+            // is none to buy on this path, and the summary line says so — it is
+            // that `--secret` means one thing in both shapes: named, resolved,
+            // and refused if it is not there.
+            command.envs(brokered.env.clone());
             detach(&mut command);
             let child = command
                 .spawn()
@@ -2623,6 +2693,76 @@ fn print_answer(answer: &Value) {
         "{}",
         serde_json::to_string_pretty(body).unwrap_or_else(|_| body.to_string())
     );
+}
+
+/// A credential the session was told to carry and could not be given.
+///
+/// The broker's own sentence already names the grant and the variable, which is
+/// the part someone needs; this adds what to do about it and drops the error
+/// enum's prefix, because "Metadata error" is not what went wrong.
+fn unresolved_credential(error: h5i_core::error::H5iError) -> anyhow::Error {
+    let why = match &error {
+        h5i_core::error::H5iError::Metadata(text) => text.clone(),
+        other => other.to_string(),
+    };
+    anyhow::anyhow!(
+        "{why}\n\n  \
+         `--secret` names a credential h5i resolves from the environment you start the \
+         session in, and a session is not started without one it was told to carry. Set the \
+         variable there, or drop the flag."
+    )
+}
+
+/// The `H5I_SECRET_*` variables `--secret` named, in the one spelling that
+/// works.
+///
+/// Both `--secret ACME_PASS` and `--secret H5I_SECRET_ACME_PASS` mean the same
+/// credential, and the manual has used each. The prefix is not decoration: it
+/// is the namespace the engine substitutes from, so it has to be on the
+/// variable the session's child actually reads, and normalizing here is what
+/// keeps one spelling from silently naming a variable nothing sets.
+///
+/// Refused rather than mangled if it is not a variable name. A grant is
+/// resolved from the host environment by this exact string; a name with a space
+/// or a `$` in it could only ever be a typo, and the fail-closed answer to a
+/// typo is to say so before the session exists.
+fn secret_variables(named: &[String]) -> anyhow::Result<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    for raw in named {
+        let name = raw.trim();
+        let full = if name.starts_with(h5i_browser_light::secrets::PREFIX) {
+            name.to_string()
+        } else {
+            format!("{}{name}", h5i_browser_light::secrets::PREFIX)
+        };
+        let suffix = &full[h5i_browser_light::secrets::PREFIX.len()..];
+        if suffix.is_empty() || !suffix.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            anyhow::bail!(
+                "`--secret {raw}` is not the name of an environment variable. Name the \
+                 credential as `ACME_PASS` or `H5I_SECRET_ACME_PASS`, and set \
+                 `H5I_SECRET_ACME_PASS` in the environment you start the session from."
+            );
+        }
+        if !out.contains(&full) {
+            out.push(full);
+        }
+    }
+    // Sorted, because the list is serialized into the profile and the profile
+    // is digested: two callers naming the same two credentials in a different
+    // order must not produce two policies.
+    out.sort();
+    Ok(out)
+}
+
+/// Where a file-injected secret would go, which is deliberately **not** under
+/// the session directory.
+///
+/// `$WORK` is the one place the engine may write, so a credential written there
+/// would be a credential the confined engine could read back and rewrite. The
+/// path is unreachable today — `broker` refuses `inject = file` off the
+/// workspace tier — and it is chosen as though it were not.
+fn secret_dir(root: &Path) -> PathBuf {
+    root.join("secrets")
 }
 
 /// Forward `H5I_BROWSER_NO_SPLIT` into a confined session, if it is set.

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -1297,7 +1297,14 @@ fn spawn_on_host(dir: &Path, opts: &StartOptions, in_a_box: bool) -> anyhow::Res
                 // carried in the profile rather than injected as a pile of
                 // variables, which is what makes `--secret` a policy statement
                 // instead of a shell habit.
-                &[],
+                //
+                // The one exception is the engine's own single-process switch,
+                // and it is here because a debugging hatch that silently does
+                // nothing in the default arrangement is worse than no hatch:
+                // it is documented as running the engine as one process, and
+                // inside the sandbox the variable would otherwise never arrive.
+                // It grants nothing and reveals nothing.
+                &single_process_switch(),
                 &log_path,
                 "browser-session",
             )?;
@@ -2616,6 +2623,20 @@ fn print_answer(answer: &Value) {
         "{}",
         serde_json::to_string_pretty(body).unwrap_or_else(|_| body.to_string())
     );
+}
+
+/// Forward `H5I_BROWSER_NO_SPLIT` into a confined session, if it is set.
+///
+/// The engine runs as two processes — a broker that decides and records, and a
+/// renderer that parses the page — and this is the switch that runs it as one.
+/// Empty in the ordinary case, which is the case that matters: the sandbox
+/// clears the environment, and everything that is not deliberately passed stays
+/// out.
+fn single_process_switch() -> Vec<(String, String)> {
+    match std::env::var(h5i_browser_light::ipc::NO_SPLIT_VAR) {
+        Ok(value) => vec![(h5i_browser_light::ipc::NO_SPLIT_VAR.to_string(), value)],
+        Err(_) => Vec::new(),
+    }
 }
 
 /// The engine is this binary. There is nothing to find.

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -1311,14 +1311,33 @@ fn spawn_on_host(
     // refuses `inject = file` off the workspace tier, which is what keeps the
     // guard's unlink-on-drop from mattering to a session that outlives this
     // command.
-    let brokered = h5i_core::secrets_broker::broker(
-        &h5i_core::browser_sandbox::grants_for(&secrets),
-        &secret_dir(root),
-        false,
-        false,
-        &h5i_core::secrets_broker::fingerprint_key(root)?,
-    )
-    .map_err(unresolved_credential)?;
+    //
+    // Skipped entirely when nothing was named, which is not the same as
+    // brokering an empty list: `fingerprint_key` mints a key file on first use,
+    // and a session that named no credential should not leave one behind in
+    // everybody's state directory for a comparison it will never make.
+    //
+    // The guard is held for the rest of this function on purpose. It is what
+    // would unlink a file-injected secret, and letting it drop before the child
+    // is spawned would be the bug that shape of grant is refused here to avoid.
+    let brokered = if secrets.is_empty() {
+        None
+    } else {
+        Some(
+            h5i_core::secrets_broker::broker(
+                &h5i_core::browser_sandbox::grants_for(&secrets),
+                &secret_dir(root),
+                false,
+                false,
+                &h5i_core::secrets_broker::fingerprint_key(root)?,
+            )
+            .map_err(unresolved_credential)?,
+        )
+    };
+    let granted: Vec<(String, String)> = brokered
+        .as_ref()
+        .map(|b| b.env.clone())
+        .unwrap_or_default();
 
     // Inside the sandbox the environment is cleared, so the engine's own
     // `$HOME`-based font discovery finds nothing. The grant and the search path
@@ -1355,7 +1374,7 @@ fn spawn_on_host(
             // nothing here inherits by accident: `--secret` is a policy
             // statement rather than a shell habit, and this is where the
             // statement is made good.
-            let mut injected = brokered.env.clone();
+            let mut injected = granted.clone();
             // The engine's own single-process switch, which is here because a
             // debugging hatch that silently does nothing in the default
             // arrangement is worse than no hatch: it is documented as running
@@ -1387,7 +1406,7 @@ fn spawn_on_host(
             // is none to buy on this path, and the summary line says so — it is
             // that `--secret` means one thing in both shapes: named, resolved,
             // and refused if it is not there.
-            command.envs(brokered.env.clone());
+            command.envs(granted.clone());
             detach(&mut command);
             let child = command
                 .spawn()

--- a/tests/browser_session_cli.rs
+++ b/tests/browser_session_cli.rs
@@ -76,6 +76,10 @@ impl Site {
             "/third-party" => "<html><body><h1>third party</h1>\
                   <img src=\"https://cdn.example.invalid/x.png\"><p>body</p></body></html>"
                 .to_string(),
+            // Something to type a credential into.
+            "/login" => "<html><body><form action=\"/in\" method=\"post\">\
+                  <input name=\"pass\" type=\"password\"></form></body></html>"
+                .to_string(),
             _ => "<html><head><title>t</title></head><body><h1>hello</h1>\
                   <p>a <a href=\"https://example.com/next\">link</a></p></body></html>"
                 .to_string(),
@@ -104,11 +108,19 @@ impl Fixture {
     }
 
     fn run(&self, args: &[&str]) -> std::process::Output {
-        Command::new(h5i())
-            .args(args)
-            .env("H5I_BROWSER_HOME", self.home.path())
-            .output()
-            .expect("h5i runs")
+        self.run_with(args, &[])
+    }
+
+    /// The same, with variables set in the environment the command is started
+    /// from. That environment is where `--secret` resolves a credential, so a
+    /// test of the credential path has to control it rather than inherit it.
+    fn run_with(&self, args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
+        let mut command = Command::new(h5i());
+        command.args(args).env("H5I_BROWSER_HOME", self.home.path());
+        for (name, value) in env {
+            command.env(name, value);
+        }
+        command.output().expect("h5i runs")
     }
 
     /// The session's allowlist has to name the test server, because the engine
@@ -717,4 +729,102 @@ fn page_text_reaches_the_terminal_without_its_escape_sequences() {
     let text = String::from_utf8_lossy(&snapshot.stdout);
     assert!(!text.contains('\u{1b}'), "an escape reached the terminal");
     let _ = fx.run(&["browser", "close"]);
+}
+
+/// A credential named with `--secret` reaches the session, and its value does
+/// not reach anything the agent reads.
+///
+/// The whole point of the flag, and it was doing none of it: the profile named
+/// the credential and nothing delivered it, so a confined session answered "no
+/// credentials" for one it had been told to carry. Driven through the binary
+/// because the failure lived in the seam between the CLI, the profile and the
+/// spawn, which is exactly the part a library test does not cross.
+#[test]
+fn a_named_credential_reaches_a_confined_session_and_never_a_reply() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let url = format!("{}/login", fx.site.base);
+    let opened = fx.run_with(
+        &[
+            "browser", "open", &url, "--allow", "127.0.0.1", "--secret", "ACME_PASS", "--json",
+        ],
+        &[("H5I_SECRET_ACME_PASS", "hunter2-from-the-test")],
+    );
+    assert!(
+        opened.status.success(),
+        "open failed: {}",
+        String::from_utf8_lossy(&opened.stderr)
+    );
+
+    // The name, from the session's own answer. Never the value: there is no
+    // verb in this engine that returns one. `--json` because the human form
+    // prints the count and the advice, and the names are the field.
+    let listed = fx.run(&["browser", "env", "--json"]);
+    let text = String::from_utf8_lossy(&listed.stdout);
+    assert!(text.contains("H5I_SECRET_ACME_PASS"), "{text}");
+    assert!(!text.contains("hunter2-from-the-test"), "a value was printed: {text}");
+
+    // And it substitutes on the way into the field, reported by placeholder.
+    // The snapshot first, because a ref is something the session served rather
+    // than something a caller may invent.
+    assert!(fx.run(&["browser", "snapshot"]).status.success());
+    let typed = fx.run(&["browser", "type", "@e1", "$H5I_SECRET_ACME_PASS"]);
+    let reply = String::from_utf8_lossy(&typed.stdout);
+    assert!(typed.status.success(), "{}", String::from_utf8_lossy(&typed.stderr));
+    assert!(reply.contains("H5I_SECRET_ACME_PASS"), "{reply}");
+    assert!(!reply.contains("hunter2-from-the-test"), "the value came back: {reply}");
+
+    let _ = fx.run(&["browser", "close"]);
+}
+
+/// A credential that cannot be resolved stops the session before it exists.
+///
+/// Fail-closed, and the reason it matters here: the alternative is a session
+/// that starts fine and refuses the credential at the moment an agent is
+/// halfway through a login, which is the least recoverable place to learn it.
+#[test]
+fn a_credential_that_is_not_set_refuses_the_session_rather_than_starting_one() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let url = fx.site.base.clone();
+    let out = fx.run(&[
+        "browser", "open", &url, "--allow", "127.0.0.1", "--secret", "NOT_SET_ANYWHERE",
+    ]);
+    assert!(
+        !out.status.success(),
+        "a missing credential started a session\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let why = String::from_utf8_lossy(&out.stderr);
+    assert!(why.contains("H5I_SECRET_NOT_SET_ANYWHERE"), "{why}");
+
+    // And nothing was left behind: `browser status` has no session to report.
+    let after = fx.run(&["browser", "status"]);
+    assert!(
+        !after.status.success()
+            || !String::from_utf8_lossy(&after.stdout).contains("NOT_SET_ANYWHERE"),
+        "a failed start left a session"
+    );
+}
+
+/// `--secret` and `--in` are two ways to say one thing, and a box already has
+/// the better one. Refused rather than ignored: this flag was silently dropped
+/// on the way to a box, so a session ran without the credential it was told to
+/// carry and said nothing about it.
+#[test]
+fn a_secret_flag_on_a_boxed_session_is_refused_and_names_env_toml() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let url = fx.site.base.clone();
+    let out = fx.run(&[
+        "browser", "open", &url, "--in", "web", "--secret", "ACME_PASS",
+    ]);
+    assert!(!out.status.success());
+    let why = String::from_utf8_lossy(&out.stderr);
+    assert!(why.contains("env.toml"), "the refusal names where to put it: {why}");
+    assert!(why.contains("secrets"), "{why}");
 }


### PR DESCRIPTION
ROADMAP §B18 steps 1 and 2. The browser engine ran as one process, so a bug in
Blitz, Stylo, an image decoder or Boa was a bug in the process that also held the
allowlist, the receipt sink, the cookie jar and every `H5I_SECRET_*` in the
environment. It runs as two now.

```
$ ps -o pid,ppid,args
  55509  36242  h5i __engine serve https://example.com ...
  55511  55509  h5i __engine --brokered serve https://example.com ...
```

Nothing user-visible changes. Neither half is a command, there is no new
subcommand, and `h5i browser open` is unchanged.

## The seam

`broker::Broker` is the named set of operations §B18.6 measured;
`net::LocalBroker` is the implementation that does the work in this process. The
three cases the measurement called hard:

* `jar()` returned a live reference at twelve call sites. It is three operations
  now (`document_cookie`, `store_cookie`, `keep_only_origin`), which is where
  the `HttpOnly` split lives.
* `budget()` returned a `&Budget`. It returns an `Allowance`, a reading, because
  across a process boundary there is nothing to borrow.
* WebSocket and server-sent events are not request-and-answer. They became one
  `Channel` trait (`send` / `drain` / `close`), which is exactly the surface
  `dom_api.rs` was already using.

## The transport

`ipc::BrokerClient` speaks that trait over a socket pair the broker hands the
renderer as its **standard input**: an ordinary inherited descriptor, so no
library is needed to pass one and no port exists for anything else on the machine
to connect to. The broker re-execs this binary with a hidden `--brokered` and the
parent's own argv, because two halves that parsed different command lines would
be two engines that could disagree about what was asked for. Calls are
multiplexed rather than serialized: a thirty-second fetch must not stall a
socket drain behind it.

The confinement came for free. The session sandbox already grants read on the
engine's binary, since a confined `execve` needs it, and a Landlock domain is
inherited across `execve` and cannot be relaxed. `browser_sandbox` is unchanged.

The split is a Unix arrangement, since the transport is a socket pair a child
inherits. Everywhere else the engine runs as one process, the way it always did.
The gating is per item rather than on the module, so the protocol, the framing
and the client stay compiled on every target the engine builds for and cannot
rot behind a `cfg` nobody exercises.

## What this does not claim

The renderer is still in the broker's network namespace, so a compromised parser
can open a socket of its own. The split moves what it can reach **in memory**.
The request log becomes evidence against a compromised renderer at step 3, and
step 3 is not the one-line profile change the plan called it: the broker is
already inside the sandbox and `unshare`/`setns` are on this codebase's own
seccomp deny-list, so the renderer's confinement has to be authored outside both
halves. Written up as §B18.8 rather than attempted.

Two claims in the original design text were also too strong, and are corrected
here rather than shipped:

* `substitute` is an operation, so a compromised renderer can resolve every
  credential this session was **granted**, not only the one it was told to type.
  The narrowing is about the set: the renderer's environment holds no
  `H5I_SECRET_*` at all. "The ones actually used" waits on the control channel
  moving to the broker.
* The asker's origin is the renderer's word. Half the policy reasons about who
  is asking, and that argument arrives from the renderer. Not a regression, since
  the same code chose it when it was the same process, and not fixed by the
  split either. Recorded as the fifth case §B18.3 does not settle, with the shape
  of the tightening that would close it.

## A credential a session was told to carry

Measuring the secrets gain turned up that `--secret NAME` had never delivered
anything under the default sandbox: `browser_sandbox` set `profile.secrets`, the
name list, and never `profile.secret_grants`, which is what the broker resolves.
A box gets both from `merge_secret_grants` when its `env.toml` loads; a session
has no `env.toml`, so it never passed through the merge and
`h5i browser env` answered "no credentials" for one it had been told to carry.

The grants are declared beside the names now, from one function so the two cannot
disagree, and brokered through `secrets_broker` at spawn. Fail-closed on **both**
paths: a host that cannot confine still has to answer `--secret` the same way.
`--secret` with `--in` is refused rather than ignored, naming `.h5i/env.toml`,
because a box has a checked-in place to declare a grant and `spawn_in_box` never
read the flag.

## What the review found

Ten passes over the branch, in the last two commits.

* **A call could wait forever.** `ask` checked "is the broker gone" and then
  registered its waiter, so a broker ending between the two put the entry in a
  map nobody would look at again, and a write into a closed socket's buffer still
  succeeds. The check and the registration share a lock now.
* **Two ways to hang the broker, both through one mutex.** `Socket::close` takes
  the same lock a `send` holds, and a send into a peer that stopped reading
  blocks for as long as the peer likes. It was reachable from the shutdown path
  and from `ChannelClose` answered on the reading thread.
* **Redaction cost two copies of every control reply**, to change nothing, for
  the common session that named no credential.
* **A windowed read of the log was not windowed:** the `requests` verb read the
  whole log to hand back a tail, which is what its own `since` cursor exists to
  avoid. `records_since` and `log_summary` are operations now.
* Separate ceilings for a message's header and body, checked before either is
  allocated; one budget reading per capabilities reply rather than three from
  three moments; `--brokered` with a standard input that is not a broker says so
  instead of blocking on the keyboard; a session that named no credential no
  longer mints a fingerprint key it will never use.

## Evidence

* The same page (stylesheet, image, script, and a script's own `fetch`) rendered
  through both shapes produces byte-identical JSON and byte-identical stderr.
  `H5I_BROWSER_NO_SPLIT=1` runs the old single process, which is what makes the
  two comparable.
* Killing a resident session's renderer leaves no broker behind, and the record
  says the engine stopped answering. That is §B18.5's claim and it had not been
  tested.
* Killing the broker takes the renderer with it: a renderer that cannot fetch or
  receipt, whose parent is gone, is not a browser.
* 534 engine + 35 corpus + 26 CLI + 120 core tests green, clippy clean on both
  feature combinations, manual and man page regenerated.

## Follow-ups, in order

1. §B18.7 step 3: author the renderer's own profile with `net.mode = deny`, from
   outside both halves. That is what upgrades the request lane, and it needs the
   third lane value with tests keeping it apart from `host-observed`.
2. Move the control channel and the action log to the broker (the §B18.2 table).
   That is also what makes "the credential being typed" the only one the
   renderer can resolve.
3. `start_service_inner` does not broker secrets: only `run_inner` and `shell`
   do. So a box's `secrets = [..]` is inert for any long-running service, the
   in-box browser session included, and only `env.pass` reaches one. That is why
   the `--in` refusal points at `env.toml` for a story that is still half-built.
