### PR TITLE
browser: a handler that read back as a function and never ran, and a harness that never noticed

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7361,6 +7361,367 @@ is confined exactly as much as the whole engine was, and no more"* — the split
 moved what a compromised parser can **reach in memory**, not yet what it can
 **reach on the network**.
 
+## B19. Obscura, second pass: the instruments, not the verbs, 2026-08-27
+
+§B15 read Obscura and Lightpanda across the *verb line* and settled what to take
+there. This pass reads two things that pass did not have: the engine as it
+stands today, which has grown a native rendering pipeline and an MCP server
+since; and `obscura-benchmark`, the companion repository that holds every
+instrument Obscura measures itself with. `obscura-benchmark` is not mentioned
+anywhere in this file, and it is where the useful material is.
+
+The finding, stated first, because it inverts the shape of §B15:
+
+> **The verb-line comparison is closed. The instrument comparison is not.**
+> Almost everything §B15 queued at the verb line has been built (§B15.13,
+> §B17.6, §B17.7). Nothing has been built against the way Obscura *measures*,
+> and that is now the larger of the two gaps.
+
+### B19.1 The two engines, as of today
+
+| | `h5i-browser-light` | Obscura |
+| --- | --- | --- |
+| Rust | 36,666 lines, one crate | 132,253 lines, nine crates |
+| script shim | 5,795 lines (`prelude.js`), Boa | 14,493 lines (`bootstrap.js`), V8 via `deno_core` |
+| DOM and CSS | Blitz plus Stylo, assembled | `html5ever` plus `selectors` plus its own cascade (`css.rs` 10,350, `style.rs` 10,924) |
+| layout and paint | Blitz plus `vello_cpu` | its own, 66,530 lines: forked `taffy`, forked `cosmic-text`, `tiny-skia` |
+| driver surface | 28 CLI subcommands, 20 session verbs | CDP server, 37 MCP tools, `fetch`/`scrape` CLI, embeddable `obscura` crate |
+| record of what was fetched | receipts, fail-closed, written before the bytes move | CDP `Network.*` events, reconstructed and emitted after navigation (§B15.2) |
+| identity on the wire | one honest UA naming this engine (`net.rs:40`) | `--stealth`: a real Chrome TLS ClientHello, cipher order, and matching `navigator` (§B15.12) |
+| default reach | allowlist; loopback allowed, because loopback is the dev server | deny loopback and RFC1918 by default, `--allow-private-network` to opt in |
+
+The size ratio is worth reading carefully rather than quoting. **We are about a
+quarter of their line count, and most of the difference is the renderer they
+wrote and we borrowed.** Subtract `obscura-render` (66,530) and the two engines
+are within a factor of two on the part both projects wrote by hand. That is the
+honest framing of "lightweight", and it is a different sentence from the one a
+raw line count invites.
+
+The second thing worth naming: **they took the opposite bet on the renderer and
+it is not obviously wrong.** Owning layout and paint bought them a `printToPDF`
+that is real (`obscura-browser/src/pdf.rs`, 1,027 lines), an activity-driven
+screencast, a CDP `Emulation` domain, and geometry that DOM APIs and screenshots
+share instead of disagreeing about. Borrowing Blitz bought us all of that
+cheaply for the parts Blitz has and none of it for the parts it does not. We
+should not re-litigate the choice. We should notice that the *cost* of the
+choice is now visible: it is the list in §B19.7.
+
+### B19.2 Their conformance number, and the one instrument worth taking
+
+Obscura reports WPT three ways, from `crates/triage`:
+
+| tier | subtests | what it is |
+| --- | --- | --- |
+| Core | 318,916 / 382,891 (83.3%) | the DOM/HTML/URL/fetch scraping contract |
+| Relevant | 420,319 / 494,422 (85.0%) | Core plus JS-observable correctness needing no layout |
+| Full | 503,413 / 839,489 (60.0%) | the whole suite, "for transparency" |
+
+**Do not compare these to our 333,690 (§B13.2).** §B13.3 already withdrew one
+such comparison and the reasons it gave apply here unchanged and with more
+force: different harness, different corpus, and in this case a denominator that
+is not even the same order of magnitude (584,707 against 839,489). Any table
+putting the two side by side would be the §B13.3 error committed a second time,
+by the same route, with a different competitor.
+
+What *is* transferable is the shape of the report, and it is precisely the thing
+§B13.3 said we were missing. Their tiers live in
+`crates/triage/src/tiers.list`: 163 lines, one `<tier> <prefix>` rule per line,
+first match wins, with a header stating the rule the file is built on:
+
+> The split is by CAPABILITY, not by outcome: a directory is excluded only when
+> it needs a capability Obscura intentionally does not implement (layout /
+> rendering, a media pipeline, real hardware, or a live network peer), never
+> because its tests happen to fail.
+
+That is a **published, auditable, diffable declaration of scope**, and it is the
+answer to the problem §B13.3 diagnosed and then solved with a paragraph of
+prose. Our caveat ("70% of every passing subtest comes from twenty files") is
+true, is correctly stated, and lives only in this document, where it travels
+only as far as somebody reading this document. A tiers file makes it structural:
+the encoding directory becomes one tier among several rather than a footnote,
+and a reader can check the claim by reading a table instead of trusting us.
+
+Two properties of theirs are worth copying exactly, and one is worth refusing:
+
+* **Copy: exclusion is by capability, and the reason is on the line.** A
+  directory is out because we do not implement service workers, not because it
+  scores badly.
+* **Copy: the file is the source of truth for the published number.** A tier is
+  not a query somebody typed once.
+* **Refuse: three tiers where the third is "everything".** "Full 60%" invites
+  exactly the reading their own header warns against. Ours should be scoped
+  tiers plus an explicit *unscoped remainder* count, so the denominator is
+  always visible and never rounded into a percentage.
+
+For us the tiers would not be theirs. Ours split around what an agent reading a
+page actually needs, and §B6's refusals (no iframes, no popups, no workers) are
+already the exclusion list, written down years before the instrument that would
+use them.
+
+### B19.3 The denominator, and the part of WPT we have decided we cannot reach
+
+`wpt/run.py`'s docstring says it plainly: WPT generates a large share of its
+endpoints at serve time, a static server cannot serve them, and the summary
+prints how many were skipped so the denominator is never mistaken for all of
+WPT. That was the right call for the instrument as built, and §B12.1's reason
+for building it that way is still good: nothing was added to the engine to make
+it measurable.
+
+Obscura's runner does not accept that ceiling. `scripts/run-wpt.sh` starts
+**`./wpt serve`**, the real wptserve, on the real `web-platform.test` hostnames,
+after `./wpt manifest` has expanded every generated variant
+(`crates/wpt-runner/src/manifest.rs` walks the manifest's variant arrays and
+skips only the content hash). That is what puts `.any.html`, `.any.worker.html`,
+the `.py` handlers, the HTTPS variants and the cross-origin subdomains inside
+their denominator and outside ours.
+
+The reason to revisit this now is not the score. It is that **three subsystems
+this engine has grown since §B12 are only testable on that server**:
+
+* §B17's same-origin policy and CORS. Every meaningful CORS test needs a second
+  origin, which needs the WPT subdomains, which needs their hosts file.
+* §B16.5's PSL cookies. Cookie scoping tests are about `Domain=` across
+  registrable boundaries, which is again several hostnames.
+* §B17.4's compression. `Content-Encoding` behaviour is served by wptserve's
+  handlers, not by files on disk.
+
+So we currently have three of the engine's most security-relevant subsystems
+tested by our own unit tests and by nothing external, and the external suite
+that would test them is one shell script away. The cost is real and should be
+stated: it needs a WPT checkout that is not pristine (a hosts file entry, and
+`./wpt serve` running), which is exactly what §B12.1's "pristine checkout"
+design chose to avoid. The proposal is not to replace `wpt/serve.py`. It is a
+**second backend** for `wpt/run.py`, off by default, so the static instrument
+stays the one CI can run and the wptserve instrument is what a conformance
+claim is made from.
+
+A second, cheaper borrow from the same runner: it has **two engine backends**,
+one process per test (`fetch`) and a persistent CDP connection with a worker
+pool. Ours is one process per test only, which is why a full sweep is measured
+in hours. We have had a resident session with a control socket since 2026-08-27.
+Pointing `run.py` at one would cost a flag and would be the single largest
+speedup available to that harness.
+
+### B19.4 The four instruments they have and we do not
+
+Their benchmark repo has seven tracks. Two of them we already have and ours is
+better in one respect worth recording. Four we do not have at all.
+
+**We already have, and ours is better:** the head-to-head against Chromium.
+`corpus/compare.py` samples peak RSS across the **whole process tree**, and says
+why: Chromium is a browser, a renderer, a GPU process and a zygote, and
+measuring only the launched process would flatter us by several hundred
+megabytes for no reason. Their `compare/head-to-head.py` reads GNU `time -v`
+Maximum RSS of the launched process. Their reported "Chrome 190 MB" is therefore
+a floor, not a measurement, and their own `compare/scale.py` (which uses
+`psutil`) reports 8.1 GB for eight Chrome workers, which is the same number
+measured properly. Ours is the sounder method and it is not written down
+anywhere but in that file's docstring.
+
+**We do not have, ranked by what they would find here:**
+
+1. **A reliability sweep with a classifier.** `reliability/sweep.py` does a
+   one-level BFS from a seed list to build ~1,500 real URLs, runs the engine
+   over all of them at concurrency, and sorts each outcome into
+   `CRASH` / `PANIC` / `CAP_HIT` / `HANG` / `HANG_HARD` / `THIN` / `OK` from the
+   exit code and stderr. The classes are the point: `CAP_HIT` exists because a
+   cyclic reparent once made `descendants()` loop forever, so the guard against
+   it has a named bucket in the instrument that would show it coming back.
+   This is §B8's own doctrine ("an instrument that cannot name what is missing")
+   applied to *crashing* rather than to *missing features*, and it is the one
+   thing on this list we have no substitute for. `corpus/run.py` reads 35 pages
+   and reports what they asked for; it does not sweep, does not classify, and a
+   panic in it looks like a page that failed.
+2. **An offline capability suite with vendored frameworks.** `obstacle-course/`
+   is 33 self-contained fixtures with React 18, Preact and Vue 3 pinned into
+   `vendor/`, each setting a deterministic value the runner asserts, each timed.
+   It is their authoritative behavioural gate and `AGENTS.md` requires 33/33
+   before any change lands. `tests/corpus.rs` is the same idea and is narrower
+   by construction: its fixtures are hand-written reductions of things the
+   network corpus found, so it can only ever contain regressions of bugs we
+   already had. It cannot answer "does Vue 3 mount", which is a question an
+   agent's user will ask on day one.
+3. **Failure triage that groups.** `crates/triage` deduplicates WPT failures
+   into root causes and prints the top error signatures per spec area. We have
+   the raw material for this and already use it: `run.py`'s `unsupported` map
+   is exactly this instrument in miniature, and §B12.2's "twenty files, four
+   bugs" is what it found. It stops at one directory at a time. Rolling it up
+   across a sweep is a merge, and `wpt/merge.py` already exists.
+4. **Speed as a tracked number.** Every obstacle-course stage is timed, and
+   `AGENTS.md` makes performance a hard constraint with a stated noise floor of
+   plus or minus 10% and a required interleaved A/B methodology. §B15.12a is our
+   equivalent lesson learned the expensive way, three optimisations reasoned
+   from code shape and all three wrong. The lesson it drew was "measure", and no
+   standing measurement was left behind.
+
+**One caution about their repo, and it is a lesson rather than a jab.** Its
+README opens by stating Obscura "has no rendering, layout, or paint pipeline",
+and the results are dated 2026-07-03 against commit `b5039a8`. Obscura's own
+README now headlines native rendering, and `obscura-render` is half the
+codebase. The instrument's *framing* rotted while its numbers stayed
+reproducible. This file has the same exposure at larger scale: §B13.3's
+withdrawn comparison is the shape of it, and the corpus harnesses in §B19.5 are
+the shape of it in code.
+
+### B19.5 Two harnesses in our own tree are pointed at a binary that does not exist
+
+Checked while looking for our answer to their obstacle course. Both fail to
+start, for the same reason, and neither says so anywhere:
+
+* `corpus/run.py:34` defaults to `target/debug/h5i-browser-light`.
+* `corpus/compare.py:28` uses `target/release/h5i-browser-light`.
+
+That binary was removed when the engine became a library reached through
+`h5i __engine` (see `Cargo.toml`'s comment, and `wpt/run.py`'s docstring, which
+records this exact path as "a trap now" and was updated). Both scripts also
+invoke `<bin> open <url> --json`, which is the argv the engine still takes, so
+the fix is the path plus one argument (`h5i __engine open ...`), not a rewrite.
+
+The consequence is worth stating rather than just the bug: **§B8's corpus, the
+instrument this document credits with finding most of the engine's real work,
+has not run since the self-exec change**, and `compare.py`, the source of every
+memory and latency claim about this engine against Chromium, has not run either.
+Any such number in this file predates the broker/renderer split (§B18), which is
+the change most likely to have moved it.
+
+### B19.6 `--restore` copies a file nothing writes
+
+`h5i browser open --restore <id>` documents itself as seeding a new session's
+storage from one that has ended, and `seed_storage` (`src/cli/browser.rs:1903`)
+copies `cookies.json` out of the old session's directory. Nothing in the
+workspace writes `cookies.json`: `cookies.rs:48` says "The jar lives in the
+process and dies with it", and it is accurate. `source.exists()` is therefore
+always false and the flag is a silent no-op.
+
+This is §B15.12's own finding about Obscura ("documented-but-absent
+`localStorage` persistence, where the documentation has to say so") reproduced
+in our tree, at the point where it costs the most: the flag exists to carry a
+login across sessions, and §B15.9 and the LOGIN-mode design both lean on a human
+authenticating once. Today the human authenticates once per session, forever.
+
+Two ways out, and they are not the same feature:
+
+* **Make the flag honest now.** Either refuse `--restore` with "this session
+  never wrote a jar" or delete it. Small, and it stops the promise.
+* **Write the jar, receipted.** A cookie file is credential material, so it is
+  not a `--storage-dir` in our design; it is a host-owned artifact with the same
+  treatment secrets already get (§B15.9's indirection). The shape that fits: the
+  jar is written on session end into the session's own directory, `--restore`
+  names one definite ended session as it already does, and the inheritance is
+  written into the new session's record, which the current help text says
+  happens and which is the part of the design that is already right.
+
+Obscura's `--storage-dir` is the wrong model for us and their own
+`browser_storage_state` / `browser_set_storage_state` pair is the interesting
+one: it is Playwright-shaped, which means a session's authenticated state is a
+value an agent can hold, name and hand back. That is compatible with receipts in
+a way a shared directory on disk is not.
+
+### B19.7 The verb line, re-counted
+
+§B15.2 counted 8 session verbs here against 36 in Obscura and called the gap the
+difference between an agent that finishes and one that stalls. It is now 20
+session verbs and 28 CLI subcommands against 37 MCP tools, and the remaining
+difference is no longer padding either. What they have that we do not, with what
+each is actually for:
+
+| theirs | what it buys | our position |
+| --- | --- | --- |
+| `browser_screenshot` | the agent sees the page it is acting on | **the real gap.** `--screenshot` is on `open` only (`cli.rs:104`); a resident session can only emit JPEG frames to the human's live view (`stream.rs:296`). An agent driving a session cannot capture it. |
+| `back` / `forward` / `reload` | undo a wrong click without re-navigating from scratch | we have no history at all. `reload` is the cheap half and is worth having on its own. |
+| tabs (`tab_new`/`list`/`switch`/`close`) | one session, several pages | the ROADMAP's own table says tab is agent-facing "when there is more than one page in a session". There is never more than one. |
+| `get_cookies` / `set_cookie` / `clear_cookies` | inspect and seed auth | deliberately absent, and it should stay deliberate: handing an agent the cookie is exactly what LOGIN mode exists to avoid. `--dump cookies` including HttpOnly is the version to refuse loudly rather than to have and not document. |
+| `console_messages` | see what the page's script complained about | we surface console output in `open --json` and in snapshot notes, not as a verb on a live session. |
+| `evaluate` | arbitrary JS | refused, correctly. A verb that runs arbitrary script is a verb whose receipt says nothing. |
+| `pdf` | a page as a document | needs print layout, which Blitz does not give us. §B11.5 and §B11.6 already queue it. Cost is now known to be large: theirs is 1,562 lines across two files on top of a renderer they own. |
+
+Only the first three are worth building. The screenshot verb is the one to build
+first and it is nearly free: `Page::screenshot_png` exists, the session holds the
+page, and the verb table (§B15.3) is where it goes.
+
+### B19.8 Import maps: the page names the destination, so the engine does not have to
+
+`script/modules.rs` refuses bare specifiers, and the reason is one of the better
+paragraphs in this codebase: a loader that rewrites `import "lodash"` to a CDN
+turns one line of page script into an unrequested request to a third party
+chosen by the engine. That is right and should not change.
+
+`<script type="importmap">` is the standard's answer to exactly this, and it
+does not have the property the refusal is aimed at: **the page declares the
+mapping, so the engine is not choosing anything.** Obscura implements it in
+`obscura-js/src/import_map.rs`, 455 lines. Every resolved URL still goes through
+our broker, still gets policy-checked, still gets a receipt, and the receipt is
+strictly more informative than today's outcome, which is a refusal that records
+nothing about where the page wanted to go.
+
+This is the rare item that increases both capability and auditability, and the
+refusal it modifies stays intact for its actual target: a bare specifier with no
+import map is still an error naming what would have to exist.
+
+### B19.9 What not to copy, second pass
+
+§B15.12 refused the stealth stack in full and that refusal is unchanged and
+correct. Three additions, since this pass read further:
+
+* **`--proxy` as a scraping feature.** Obscura's is a per-invocation flag
+  pointed at residential proxy pools, and their `AGENTS.md` carries affiliate
+  codes for four providers. Ours is `H5I_EGRESS_PROXY`, set by h5i, and it is an
+  *enforcement point*, not a route. A CLI flag that lets the caller choose the
+  proxy is a CLI flag that lets the caller step around the allowlist that proxy
+  enforces, which `net.rs:250` already says in as many words. Keep it as an
+  environment variable set by the thing doing the enforcing. SOCKS5 support
+  (their `reqwest` has `socks`, ours does not) is the same question and gets the
+  same answer.
+* **`--user-agent` as a free-text override.** `net.rs:40` shares one honest UA
+  between the wire and `navigator`, and the comment gives the reason: a page
+  that branches on it server-side and again in script must see the same answer
+  both times. An override that changes one and not the other is a bug factory,
+  and an override that changes both is the stealth argument wearing a smaller
+  hat. If a site gates on UA and an agent legitimately needs past it, the honest
+  form is a *named* profile whose value is in the receipt, not a string flag.
+* **`--obey-robots` as a boolean.** Their cache answers allow/deny and the
+  request either happens or does not. §B15.6's rule applies: a denial an agent
+  cannot branch on is a denial an agent cannot recover from, and that section
+  already names robots.txt denials as one of the variants that needs a name. If
+  we take robots at all it is as a *receipt annotation* first: record that the
+  origin asked us not to, on the record, and let policy decide. "The page said
+  not to and we did anyway, and here is the line that says so" is a thing only a
+  receipts engine can offer.
+
+### B19.10 The queue
+
+Ordered by what each buys divided by what it costs. The first two are repairs to
+instruments this document already relies on, which is why they are first.
+
+1. **Fix `corpus/run.py` and `corpus/compare.py`** (§B19.5). Two paths and one
+   argument. Until this lands, §B8's corpus is not an instrument, it is a
+   description of one.
+2. **Make `--restore` honest** (§B19.6). Refuse it or implement it; do not ship
+   a flag that copies a file nothing writes.
+3. **A `screenshot` verb on the session** (§B19.7). The page exists, the encoder
+   exists, the verb table is where it goes.
+4. **A reliability sweep with named outcome classes** (§B19.4). The one
+   instrument on the list with no substitute here, and the one whose findings
+   are not reachable any other way: a crash on the 900th real page is not a
+   thing 35 corpus pages or a WPT directory will ever show.
+5. **A tiers file for the WPT report** (§B19.2). Turns §B13.3's caveat from a
+   paragraph a reader has to trust into a table a reader can check.
+6. **A wptserve backend for `wpt/run.py`, off by default** (§B19.3). This is
+   what puts CORS, PSL cookies and compression under external test. Pair it with
+   the resident-session backend, which is the same file and pays for the sweep
+   time.
+7. **An offline capability suite with vendored frameworks** (§B19.4). Ours
+   should be smaller than 33 stages and should test what §B6 says we support,
+   which makes it a companion to the tiers file rather than a second corpus.
+8. **Import maps** (§B19.8).
+9. **`reload`, then history** (§B19.7).
+
+Not queued, decided: no `--proxy` flag, no `--user-agent` flag, no cookie
+read/write verbs, no stealth layer (§B19.9). CDP and MCP stay where §B15.11 put
+them, and nothing in this pass moves either: what changed is that the verb table
+§B15.3 asked for now exists, so the cost estimate in §B15.11 is if anything
+lower than it was.
+
 ---
 
 # Formal verification: a Lean model beside the Rust

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -661,7 +661,12 @@ impl Page {
         // the handler, so the page loaded, sat there, and reported itself
         // settled with `timers_run: 0` — which reads as "nothing to do" rather
         // than "nothing was run".
-        let has_inline_handler = {
+        // Asked only when the answer can change the outcome. Every page with a
+        // script element already builds the realm, and running a
+        // thirty-five-selector query over its whole tree to reach a value that
+        // is then discarded is the shortcut paying for the case it exists to
+        // avoid.
+        let has_inline_handler = || {
             let doc = self.doc.borrow();
             doc.query_selector_all(INLINE_HANDLER_SELECTOR)
                 .map(|ids| !ids.is_empty())
@@ -672,7 +677,7 @@ impl Page {
         // 15ms — the prelude is 113 KiB of JavaScript, parsed and evaluated from
         // scratch — and a page with no script elements was paying all of it for
         // a realm that would never be asked a question.
-        if sources.is_empty() && !has_inline_handler {
+        if sources.is_empty() && !has_inline_handler() {
             self.ran_scripts = true;
             // Trivially settled, and said so rather than left null: a page with
             // no script has finished by definition, and "we do not know" is a

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -221,21 +221,6 @@ pub struct Page {
     notes: Vec<String>,
 }
 
-/// The event-handler content attributes, as a selector.
-///
-/// Enumerated rather than discovered because it has to be a selector: CSS can
-/// match an attribute's *value* by prefix but not its *name*, so "any element
-/// with an `on*` attribute" is not something a selector can ask for. The list
-/// mirrors the one `prelude.js` compiles from, and the two are meant to agree
-/// — this one decides whether the realm is built, that one decides what the
-/// realm compiles once it is.
-const INLINE_HANDLER_SELECTOR: &str = "[onload],[onclick],[onerror],[onchange],[oninput],\
-    [onsubmit],[onfocus],[onblur],[onkeydown],[onkeyup],[onkeypress],[onmousedown],\
-    [onmouseup],[onmouseover],[onmouseout],[onmousemove],[ondblclick],[onscroll],\
-    [onselect],[onreset],[oncontextmenu],[onwheel],[ontoggle],[onpageshow],\
-    [onpagehide],[onhashchange],[onpopstate],[onresize],[onmessage],[onunload],\
-    [onbeforeunload],[onanimationend],[ontransitionend],[onpointerdown],[onpointerup]";
-
 impl Page {
     /// Fetch a URL and load it.
     ///
@@ -653,26 +638,11 @@ impl Page {
                 .unwrap_or_default()
         };
 
-        // A handler attribute is script, and the shortcut below could not see it.
-        //
-        // `<body onload="init()">` is a document whose only code lives in an
-        // attribute. Skipping the realm for it did not skip 15ms of waste, it
-        // skipped the page: the realm being skipped is the thing that compiles
-        // the handler, so the page loaded, sat there, and reported itself
-        // settled with `timers_run: 0` — which reads as "nothing to do" rather
-        // than "nothing was run".
-        let has_inline_handler = {
-            let doc = self.doc.borrow();
-            doc.query_selector_all(INLINE_HANDLER_SELECTOR)
-                .map(|ids| !ids.is_empty())
-                .unwrap_or(false)
-        };
-
         // Nothing to run means nothing to build. Starting the realm costs about
         // 15ms — the prelude is 113 KiB of JavaScript, parsed and evaluated from
         // scratch — and a page with no script elements was paying all of it for
         // a realm that would never be asked a question.
-        if sources.is_empty() && !has_inline_handler {
+        if sources.is_empty() {
             self.ran_scripts = true;
             // Trivially settled, and said so rather than left null: a page with
             // no script has finished by definition, and "we do not know" is a

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -221,6 +221,21 @@ pub struct Page {
     notes: Vec<String>,
 }
 
+/// The event-handler content attributes, as a selector.
+///
+/// Enumerated rather than discovered because it has to be a selector: CSS can
+/// match an attribute's *value* by prefix but not its *name*, so "any element
+/// with an `on*` attribute" is not something a selector can ask for. The list
+/// mirrors the one `prelude.js` compiles from, and the two are meant to agree
+/// — this one decides whether the realm is built, that one decides what the
+/// realm compiles once it is.
+const INLINE_HANDLER_SELECTOR: &str = "[onload],[onclick],[onerror],[onchange],[oninput],\
+    [onsubmit],[onfocus],[onblur],[onkeydown],[onkeyup],[onkeypress],[onmousedown],\
+    [onmouseup],[onmouseover],[onmouseout],[onmousemove],[ondblclick],[onscroll],\
+    [onselect],[onreset],[oncontextmenu],[onwheel],[ontoggle],[onpageshow],\
+    [onpagehide],[onhashchange],[onpopstate],[onresize],[onmessage],[onunload],\
+    [onbeforeunload],[onanimationend],[ontransitionend],[onpointerdown],[onpointerup]";
+
 impl Page {
     /// Fetch a URL and load it.
     ///
@@ -638,11 +653,26 @@ impl Page {
                 .unwrap_or_default()
         };
 
+        // A handler attribute is script, and the shortcut below could not see it.
+        //
+        // `<body onload="init()">` is a document whose only code lives in an
+        // attribute. Skipping the realm for it did not skip 15ms of waste, it
+        // skipped the page: the realm being skipped is the thing that compiles
+        // the handler, so the page loaded, sat there, and reported itself
+        // settled with `timers_run: 0` — which reads as "nothing to do" rather
+        // than "nothing was run".
+        let has_inline_handler = {
+            let doc = self.doc.borrow();
+            doc.query_selector_all(INLINE_HANDLER_SELECTOR)
+                .map(|ids| !ids.is_empty())
+                .unwrap_or(false)
+        };
+
         // Nothing to run means nothing to build. Starting the realm costs about
         // 15ms — the prelude is 113 KiB of JavaScript, parsed and evaluated from
         // scratch — and a page with no script elements was paying all of it for
         // a realm that would never be asked a question.
-        if sources.is_empty() {
+        if sources.is_empty() && !has_inline_handler {
             self.ran_scripts = true;
             // Trivially settled, and said so rather than left null: a page with
             // no script has finished by definition, and "we do not know" is a

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -917,14 +917,6 @@
       const watched = observers.length > 0 || isCustom(this);
       const previous = watched ? api.getAttr(this._id, String(name)) : null;
       api.setAttr(this._id, String(name), String(value));
-      // `el.setAttribute("onclick", ...)` is the same handler the parser would
-      // have compiled, arriving by another road.
-      if (HANDLER_ATTR_SET.has(String(name).toLowerCase())) {
-        const lowered = String(name).toLowerCase();
-        const installed = this.__h5iInline ?? (this.__h5iInline = {});
-        installed[lowered] = String(value);
-        installInlineHandler(this, lowered, String(value));
-      }
       if (watched) {
         const lowered = String(name).toLowerCase();
         recordAttribute(this, lowered, previous);
@@ -1184,12 +1176,7 @@
     // Real serialisation. Returning textContent here silently stripped every
     // tag, so `el.innerHTML = el.innerHTML` destroyed the subtree.
     get innerHTML() { return api.innerHtml(this._id); }
-    set innerHTML(html) {
-      api.setInnerHtml(this._id, String(html));
-      // Markup written after load carries handlers too, and the lifecycle
-      // sweep has already been and gone by the time a page does this.
-      globalThis.__h5iInstallInlineHandlers(this);
-    }
+    set innerHTML(html) { api.setInnerHtml(this._id, String(html)); }
 
     /// `innerHTML`, plus the one thing `innerHTML` is specified *not* to do:
     /// turn `<template shadowrootmode>` into a real shadow root.
@@ -1205,7 +1192,6 @@
     setHTMLUnsafe(html) {
       api.setInnerHtml(this._id, String(html));
       adoptDeclarativeShadowRoots(this);
-      globalThis.__h5iInstallInlineHandlers(this);
     }
     get outerHTML() { return api.outerHtml(this._id); }
     set outerHTML(html) {
@@ -2493,121 +2479,6 @@
       },
     });
   }
-
-  /// The window's own `on*` properties.
-  ///
-  /// `window.onload = fn` stored the function and never called it. The
-  /// accessors above are installed on `Element.prototype`, and the window is
-  /// not an element, so the assignment landed on an ordinary expando: it read
-  /// back correctly, which is why nothing looked wrong, and it never ran.
-  ///
-  /// These delegate to the window's own `addEventListener`, so a page that
-  /// mixes the two forms gets one handler per assignment and no double-fire.
-  const WINDOW_HANDLER_EVENTS = [
-    "load", "unload", "beforeunload", "error", "message", "messageerror",
-    "hashchange", "popstate", "pagehide", "pageshow", "resize", "scroll",
-    "storage", "offline", "online", "languagechange", "rejectionhandled",
-    "unhandledrejection", "afterprint", "beforeprint",
-  ];
-  for (const type of WINDOW_HANDLER_EVENTS) {
-    const slot = `__on_window_${type}`;
-    Object.defineProperty(globalThis, `on${type}`, {
-      configurable: true,
-      get() { return globalThis[slot] ?? null; },
-      set(handler) {
-        if (globalThis[slot]) removeEventListener(type, globalThis[slot]);
-        globalThis[slot] = typeof handler === "function" ? handler : null;
-        if (globalThis[slot]) addEventListener(type, globalThis[slot]);
-      },
-    });
-  }
-
-  /// Event-handler *content attributes*: `<body onload="run()">`.
-  ///
-  /// These never ran either, and for a different reason than the window
-  /// properties: the `on*` accessors are IDL attributes, reached when *script*
-  /// assigns them, and markup does not go through script. Nothing was
-  /// compiling an attribute into a handler at all, so a page whose entire
-  /// behaviour hangs off `<body onload>` loaded, did nothing, and looked idle
-  /// — which is exactly how it was scored.
-  ///
-  /// The compiled function is the spec's shape: the attribute value is a
-  /// function *body* rather than an expression, it takes `event`, and it is
-  /// called with the element as `this`.
-  ///
-  /// The attribute names are enumerated rather than discovered because they
-  /// have to become a selector. CSS can match an attribute's value by prefix
-  /// but not its *name*, so "every element with some `on*` attribute" is not a
-  /// selector — and the alternative, walking every element and asking for its
-  /// attribute names, is a call into the tree per element on documents that
-  /// run to tens of thousands of them.
-  const HANDLER_ATTRS = [
-    ...HANDLER_EVENTS, ...WINDOW_HANDLER_EVENTS,
-    "beforeinput", "select", "reset", "invalid", "toggle", "cancel", "close",
-    "copy", "cut", "paste", "drag", "dragend", "dragenter", "dragleave",
-    "dragover", "dragstart", "drop", "animationstart", "animationiteration",
-    "transitionrun", "transitionstart", "transitioncancel", "pointermove",
-    "pointerover", "pointerout", "pointerenter", "pointerleave", "pointercancel",
-    "mouseenter", "mouseleave", "focusin", "focusout", "readystatechange",
-  ];
-  const HANDLER_ATTR_SET = new Set(HANDLER_ATTRS.map((type) => `on${type}`));
-  const HANDLER_ATTR_SELECTOR = HANDLER_ATTRS.map((type) => `[on${type}]`).join(",");
-
-  /// The handlers `<body>` and `<frameset>` do not keep for themselves.
-  ///
-  /// The spec forwards this set to the window, and the difference is not
-  /// cosmetic: `load` is fired *at* the window, so a `<body onload>` installed
-  /// on the body element would sit through the one event it exists for.
-  const BODY_FORWARDED = new Set([
-    "blur", "error", "focus", "load", "resize", "scroll", "afterprint",
-    "beforeprint", "beforeunload", "hashchange", "languagechange", "message",
-    "messageerror", "offline", "online", "pagehide", "pageshow", "popstate",
-    "rejectionhandled", "storage", "unhandledrejection", "unload",
-  ]);
-
-  function installInlineHandler(element, name, source) {
-    const type = name.slice(2);
-    let compiled;
-    try {
-      compiled = new Function("event", source);
-    } catch (error) {
-      // A handler that does not parse is the page's bug, not this engine's, and
-      // a browser reports it and carries on rather than taking the document
-      // down with it.
-      console.error(`inline ${name} did not compile: ${error}`);
-      return;
-    }
-    const handler = function (event) { return compiled.call(element, event); };
-    const tag = element.tagName;
-    if ((tag === "BODY" || tag === "FRAMESET") && BODY_FORWARDED.has(type)) {
-      globalThis[`on${type}`] = handler;
-      return;
-    }
-    if (`on${type}` in element) element[`on${type}`] = handler;
-    else element.addEventListener(type, handler);
-  }
-
-  /// Compile the inline handlers under `within`, or under the whole document.
-  ///
-  /// Idempotent by remembering the source it last compiled per attribute, so
-  /// the sweep can run again after markup arrives without stacking a second
-  /// copy of every handler on the elements it already saw.
-  globalThis.__h5iInstallInlineHandlers = function (within) {
-    const scope = within && within._id ? within._id : 0;
-    for (const id of api.queryAll(HANDLER_ATTR_SELECTOR, scope)) {
-      const element = wrap(id);
-      if (!element) continue;
-      const installed = element.__h5iInline ?? (element.__h5iInline = {});
-      for (const name of api.attrNames(id) ?? []) {
-        const lowered = String(name).toLowerCase();
-        if (!HANDLER_ATTR_SET.has(lowered)) continue;
-        const source = api.getAttr(id, name);
-        if (source == null || installed[lowered] === source) continue;
-        installed[lowered] = source;
-        installInlineHandler(element, lowered, source);
-      }
-    }
-  };
 
   /// Turn every `<template shadowrootmode>` inside `within` into a shadow root.
   ///
@@ -4686,11 +4557,6 @@
     // Again here: a script that ran during parsing may have added elements
     // with ids, and the handlers about to run will reach for them by name.
     globalThis.__h5iInstallNamedAccess();
-
-    // Before the first event, not after: `<body onload>` is a handler for the
-    // load event dispatched three lines below, so compiling it later would be
-    // compiling it too late.
-    globalThis.__h5iInstallInlineHandlers();
 
     documentReadyState = "interactive";
     at(new Event("readystatechange"));

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -917,6 +917,14 @@
       const watched = observers.length > 0 || isCustom(this);
       const previous = watched ? api.getAttr(this._id, String(name)) : null;
       api.setAttr(this._id, String(name), String(value));
+      // `el.setAttribute("onclick", ...)` is the same handler the parser would
+      // have compiled, arriving by another road.
+      if (HANDLER_ATTR_SET.has(String(name).toLowerCase())) {
+        const lowered = String(name).toLowerCase();
+        const installed = this.__h5iInline ?? (this.__h5iInline = {});
+        installed[lowered] = String(value);
+        installInlineHandler(this, lowered, String(value));
+      }
       if (watched) {
         const lowered = String(name).toLowerCase();
         recordAttribute(this, lowered, previous);
@@ -1176,7 +1184,12 @@
     // Real serialisation. Returning textContent here silently stripped every
     // tag, so `el.innerHTML = el.innerHTML` destroyed the subtree.
     get innerHTML() { return api.innerHtml(this._id); }
-    set innerHTML(html) { api.setInnerHtml(this._id, String(html)); }
+    set innerHTML(html) {
+      api.setInnerHtml(this._id, String(html));
+      // Markup written after load carries handlers too, and the lifecycle
+      // sweep has already been and gone by the time a page does this.
+      globalThis.__h5iInstallInlineHandlers(this);
+    }
 
     /// `innerHTML`, plus the one thing `innerHTML` is specified *not* to do:
     /// turn `<template shadowrootmode>` into a real shadow root.
@@ -1192,6 +1205,7 @@
     setHTMLUnsafe(html) {
       api.setInnerHtml(this._id, String(html));
       adoptDeclarativeShadowRoots(this);
+      globalThis.__h5iInstallInlineHandlers(this);
     }
     get outerHTML() { return api.outerHtml(this._id); }
     set outerHTML(html) {
@@ -2479,6 +2493,121 @@
       },
     });
   }
+
+  /// The window's own `on*` properties.
+  ///
+  /// `window.onload = fn` stored the function and never called it. The
+  /// accessors above are installed on `Element.prototype`, and the window is
+  /// not an element, so the assignment landed on an ordinary expando: it read
+  /// back correctly, which is why nothing looked wrong, and it never ran.
+  ///
+  /// These delegate to the window's own `addEventListener`, so a page that
+  /// mixes the two forms gets one handler per assignment and no double-fire.
+  const WINDOW_HANDLER_EVENTS = [
+    "load", "unload", "beforeunload", "error", "message", "messageerror",
+    "hashchange", "popstate", "pagehide", "pageshow", "resize", "scroll",
+    "storage", "offline", "online", "languagechange", "rejectionhandled",
+    "unhandledrejection", "afterprint", "beforeprint",
+  ];
+  for (const type of WINDOW_HANDLER_EVENTS) {
+    const slot = `__on_window_${type}`;
+    Object.defineProperty(globalThis, `on${type}`, {
+      configurable: true,
+      get() { return globalThis[slot] ?? null; },
+      set(handler) {
+        if (globalThis[slot]) removeEventListener(type, globalThis[slot]);
+        globalThis[slot] = typeof handler === "function" ? handler : null;
+        if (globalThis[slot]) addEventListener(type, globalThis[slot]);
+      },
+    });
+  }
+
+  /// Event-handler *content attributes*: `<body onload="run()">`.
+  ///
+  /// These never ran either, and for a different reason than the window
+  /// properties: the `on*` accessors are IDL attributes, reached when *script*
+  /// assigns them, and markup does not go through script. Nothing was
+  /// compiling an attribute into a handler at all, so a page whose entire
+  /// behaviour hangs off `<body onload>` loaded, did nothing, and looked idle
+  /// — which is exactly how it was scored.
+  ///
+  /// The compiled function is the spec's shape: the attribute value is a
+  /// function *body* rather than an expression, it takes `event`, and it is
+  /// called with the element as `this`.
+  ///
+  /// The attribute names are enumerated rather than discovered because they
+  /// have to become a selector. CSS can match an attribute's value by prefix
+  /// but not its *name*, so "every element with some `on*` attribute" is not a
+  /// selector — and the alternative, walking every element and asking for its
+  /// attribute names, is a call into the tree per element on documents that
+  /// run to tens of thousands of them.
+  const HANDLER_ATTRS = [
+    ...HANDLER_EVENTS, ...WINDOW_HANDLER_EVENTS,
+    "beforeinput", "select", "reset", "invalid", "toggle", "cancel", "close",
+    "copy", "cut", "paste", "drag", "dragend", "dragenter", "dragleave",
+    "dragover", "dragstart", "drop", "animationstart", "animationiteration",
+    "transitionrun", "transitionstart", "transitioncancel", "pointermove",
+    "pointerover", "pointerout", "pointerenter", "pointerleave", "pointercancel",
+    "mouseenter", "mouseleave", "focusin", "focusout", "readystatechange",
+  ];
+  const HANDLER_ATTR_SET = new Set(HANDLER_ATTRS.map((type) => `on${type}`));
+  const HANDLER_ATTR_SELECTOR = HANDLER_ATTRS.map((type) => `[on${type}]`).join(",");
+
+  /// The handlers `<body>` and `<frameset>` do not keep for themselves.
+  ///
+  /// The spec forwards this set to the window, and the difference is not
+  /// cosmetic: `load` is fired *at* the window, so a `<body onload>` installed
+  /// on the body element would sit through the one event it exists for.
+  const BODY_FORWARDED = new Set([
+    "blur", "error", "focus", "load", "resize", "scroll", "afterprint",
+    "beforeprint", "beforeunload", "hashchange", "languagechange", "message",
+    "messageerror", "offline", "online", "pagehide", "pageshow", "popstate",
+    "rejectionhandled", "storage", "unhandledrejection", "unload",
+  ]);
+
+  function installInlineHandler(element, name, source) {
+    const type = name.slice(2);
+    let compiled;
+    try {
+      compiled = new Function("event", source);
+    } catch (error) {
+      // A handler that does not parse is the page's bug, not this engine's, and
+      // a browser reports it and carries on rather than taking the document
+      // down with it.
+      console.error(`inline ${name} did not compile: ${error}`);
+      return;
+    }
+    const handler = function (event) { return compiled.call(element, event); };
+    const tag = element.tagName;
+    if ((tag === "BODY" || tag === "FRAMESET") && BODY_FORWARDED.has(type)) {
+      globalThis[`on${type}`] = handler;
+      return;
+    }
+    if (`on${type}` in element) element[`on${type}`] = handler;
+    else element.addEventListener(type, handler);
+  }
+
+  /// Compile the inline handlers under `within`, or under the whole document.
+  ///
+  /// Idempotent by remembering the source it last compiled per attribute, so
+  /// the sweep can run again after markup arrives without stacking a second
+  /// copy of every handler on the elements it already saw.
+  globalThis.__h5iInstallInlineHandlers = function (within) {
+    const scope = within && within._id ? within._id : 0;
+    for (const id of api.queryAll(HANDLER_ATTR_SELECTOR, scope)) {
+      const element = wrap(id);
+      if (!element) continue;
+      const installed = element.__h5iInline ?? (element.__h5iInline = {});
+      for (const name of api.attrNames(id) ?? []) {
+        const lowered = String(name).toLowerCase();
+        if (!HANDLER_ATTR_SET.has(lowered)) continue;
+        const source = api.getAttr(id, name);
+        if (source == null || installed[lowered] === source) continue;
+        installed[lowered] = source;
+        installInlineHandler(element, lowered, source);
+      }
+    }
+  };
 
   /// Turn every `<template shadowrootmode>` inside `within` into a shadow root.
   ///
@@ -4557,6 +4686,11 @@
     // Again here: a script that ran during parsing may have added elements
     // with ids, and the handlers about to run will reach for them by name.
     globalThis.__h5iInstallNamedAccess();
+
+    // Before the first event, not after: `<body onload>` is a handler for the
+    // load event dispatched three lines below, so compiling it later would be
+    // compiling it too late.
+    globalThis.__h5iInstallInlineHandlers();
 
     documentReadyState = "interactive";
     at(new Event("readystatechange"));

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -2659,7 +2659,7 @@
   /// thing a diagnostic can do. Naming it as unsupported also files it through
   /// `api.unsupported`, so it appears in the counted gaps beside every other
   /// feature this engine does not have rather than hiding inside a parse error.
-  const UNSUPPORTED_SELECTOR = /(^|[^\\w-])::?has\s*\(/i;
+  const UNSUPPORTED_SELECTOR = /:has\s*\(/i;
 
   function checkSelector(selector) {
     const text = String(selector);

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -1482,24 +1482,28 @@
   // its setter — which is the bug this table was written to end: in a module,
   // which is strict, assigning to a getter-only property *throws*, and a
   // classic-script test cannot see it because sloppy mode swallows it.
+  /// The content attributes every element reflects, because they are global.
+  ///
+  /// It used to hold twelve more, and they were not global: `htmlFor`, `rel`,
+  /// `target`, `charset`, `crossOrigin` and the rest belong to particular
+  /// interfaces, and defining them here put them on *every* element. A page
+  /// asking `"htmlFor" in element` — which is how the platform is feature
+  /// detected, and what WPT's reflection helper gates on — was told yes for
+  /// `<div>`, `<button>`, and everything else.
+  ///
+  /// That is not a cosmetic wrong answer. The helper takes it as licence to
+  /// test a property the element should not have, so one file went from 209
+  /// subtests passing to 330 failing: the engine had claimed a surface it does
+  /// not implement, and was then measured against it.
+  ///
+  /// The interface table below is the right owner for the rest, and already
+  /// declared all but three of them. `dir`, `slot` and `accessKey` stay because
+  /// they really do belong to every element.
   const REFLECTED_ATTRIBUTES = {
     dir: "dir",
-    rel: "rel",
     slot: "slot",
-    crossOrigin: "crossorigin",
-    integrity: "integrity",
-    referrerPolicy: "referrerpolicy",
     accessKey: "accesskey",
-    placeholder: "placeholder",
-    htmlFor: "for",
-    target: "target",
-    media: "media",
-    charset: "charset",
-    loading: "loading",
-    decoding: "decoding",
-    autocomplete: "autocomplete",
-  };
-  for (const [property, attribute] of Object.entries(REFLECTED_ATTRIBUTES)) {
+  };  for (const [property, attribute] of Object.entries(REFLECTED_ATTRIBUTES)) {
     Object.defineProperty(Element.prototype, property, {
       configurable: true,
       get() { return api.getAttr(this._id, attribute) || ""; },
@@ -1761,7 +1765,7 @@
     area: ["HTMLAreaElement", [
       ["coords", "coords"], ["download", "download"], ["ping", "ping"],
       ["rel", "rel"], ["shape", "shape"], ["target", "target"],
-      ["noHref", "nohref", "bool"],
+      ["noHref", "nohref", "bool"], ["referrerPolicy", "referrerpolicy"],
     ]],
     img: ["HTMLImageElement", [
       ["srcset", "srcset"], ["sizes", "sizes"], ["useMap", "usemap"],
@@ -1770,6 +1774,7 @@
       ["width", "width", "ulong"], ["height", "height", "ulong"],
       ["hspace", "hspace", "ulong"], ["vspace", "vspace", "ulong"],
       ["decoding", "decoding"], ["loading", "loading"],
+      ["crossOrigin", "crossorigin"], ["referrerPolicy", "referrerpolicy"],
     ]],
     embed: ["HTMLEmbedElement", [
       ["width", "width"], ["height", "height"], ["align", "align"],
@@ -1787,13 +1792,14 @@
       ["poster", "poster", "url"], ["preload", "preload"],
       ["autoplay", "autoplay", "bool"], ["loop", "loop", "bool"],
       ["controls", "controls", "bool"], ["defaultMuted", "muted", "bool"],
+      ["crossOrigin", "crossorigin"],
       ["playsInline", "playsinline", "bool"],
       ["width", "width", "ulong"], ["height", "height", "ulong"],
     ]],
     audio: ["HTMLAudioElement", [
       ["preload", "preload"], ["autoplay", "autoplay", "bool"],
       ["loop", "loop", "bool"], ["controls", "controls", "bool"],
-      ["defaultMuted", "muted", "bool"],
+      ["defaultMuted", "muted", "bool"], ["crossOrigin", "crossorigin"],
     ]],
     source: ["HTMLSourceElement", [
       ["srcset", "srcset"], ["sizes", "sizes"], ["media", "media"],
@@ -1891,6 +1897,7 @@
       ["noModule", "nomodule", "bool"], ["async", "async", "bool"],
       ["defer", "defer", "bool"], ["integrity", "integrity"],
       ["charset", "charset"], ["event", "event"], ["htmlFor", "for"],
+      ["crossOrigin", "crossorigin"], ["referrerPolicy", "referrerpolicy"],
     ]],
     marquee: ["HTMLMarqueeElement", [
       ["behavior", "behavior"], ["bgColor", "bgcolor"],
@@ -2637,9 +2644,34 @@
   /// `querySelector("!!!")` throws `SyntaxError` in a browser and returned
   /// `null` here — the same answer as "no such element", so a page with a typo
   /// took its not-found branch and never learned why.
+  /// The selectors this engine cannot parse but which are not the page's fault.
+  ///
+  /// `:has()` is the whole list today. Stylo's servo selector parser answers
+  /// `parse_has() -> false` and it is hardcoded, not a preference, so `:has()`
+  /// has never parsed here — in a stylesheet or in `querySelector`. That is a
+  /// missing feature, and the throw below is right either way: an unsupported
+  /// pseudo-class makes a selector invalid, and a browser without `:has()`
+  /// throws too.
+  ///
+  /// What was wrong was the sentence. "`.x:has(.y)` is not a valid selector"
+  /// is false — it is a valid selector, and it is 2026. Someone reading that
+  /// goes looking for a typo they will not find, which is the most expensive
+  /// thing a diagnostic can do. Naming it as unsupported also files it through
+  /// `api.unsupported`, so it appears in the counted gaps beside every other
+  /// feature this engine does not have rather than hiding inside a parse error.
+  const UNSUPPORTED_SELECTOR = /(^|[^\\w-])::?has\s*\(/i;
+
   function checkSelector(selector) {
     const text = String(selector);
     if (!api.validSelector(text)) {
+      if (UNSUPPORTED_SELECTOR.test(text)) {
+        api.unsupported("selector :has()");
+        throw new DOMException(
+          `${text} uses :has(), which this engine does not support yet. ` +
+            "It is a valid selector; the engine is the limitation.",
+          "SyntaxError",
+        );
+      }
       throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
     }
     return text;

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -320,6 +320,21 @@ fn an_unsupported_selector_is_not_reported_as_an_invalid_one() {
         "and does not call a valid selector invalid: {message}"
     );
 
+    // Every shape of what precedes `:has`, because the first version of this
+    // guard excluded word characters before the colon — which is exactly what a
+    // tag or class name is. `.row:has(.y)` was told it was malformed.
+    for selector in [".w:has(.y)", "div:has(.y)", ".row:has(.y)", "a:has(img)"] {
+        let asked = format!(
+            "(() => {{ try {{ document.querySelector('{selector}'); return 'accepted' }} \
+             catch (e) {{ return e.message }} }})()"
+        );
+        let said = script.eval_value(&asked).unwrap();
+        assert!(
+            said.contains("does not support"),
+            "{selector} names the missing feature: {said}"
+        );
+    }
+
     // A selector that really is malformed still gets the plain answer.
     let broken = script
         .eval_value(

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -265,6 +265,75 @@ fn the_document_lifecycle_fires() {
 }
 
 #[test]
+fn a_reflected_property_belongs_to_its_interface_and_not_to_every_element() {
+    // `"htmlFor" in element` is how the platform is feature detected, and it
+    // was answering yes for every element: the reflection table was applied to
+    // `Element.prototype` rather than to the interfaces that own each
+    // attribute. WPT's reflection helper gates on exactly this expression, took
+    // the yes as licence to test a property `<button>` does not have, and one
+    // file went from 209 subtests passing to 330 failing — the engine claimed a
+    // surface it does not implement and was measured against it.
+    let (_page, mut script) = page_and_script("<html><body><p>x</p></body></html>");
+    for (tag, property, expected) in [
+        ("label", "htmlFor", "true"),
+        ("output", "htmlFor", "true"),
+        ("button", "htmlFor", "false"),
+        ("div", "htmlFor", "false"),
+        ("a", "rel", "true"),
+        ("div", "rel", "false"),
+        ("img", "crossOrigin", "true"),
+        ("div", "crossOrigin", "false"),
+        ("div", "dir", "true"),
+    ] {
+        let asked = format!("String('{property}' in document.createElement('{tag}'))");
+        assert_eq!(
+            script.eval_value(&asked).unwrap(),
+            expected,
+            "'{property}' in <{tag}>"
+        );
+    }
+}
+
+#[test]
+fn an_unsupported_selector_is_not_reported_as_an_invalid_one() {
+    // `:has()` does not parse here — stylo's servo selector parser answers
+    // `parse_has() -> false` and it is hardcoded — and throwing is right: an
+    // unsupported pseudo-class makes a selector invalid, and a browser without
+    // `:has()` throws too.
+    //
+    // The sentence was the wrong part. "`.x:has(.y)` is not a valid selector"
+    // is false, and it sends whoever reads it looking for a typo that is not
+    // there. A selector this engine merely lacks says so.
+    let (_page, mut script) = page_and_script("<html><body><p>x</p></body></html>");
+    let message = script
+        .eval_value(
+            "(() => { try { document.querySelector('.x:has(.y)'); return 'accepted' } \
+             catch (e) { return e.message } })()",
+        )
+        .unwrap();
+    assert!(
+        message.contains(":has()") && message.contains("does not support"),
+        "names the missing feature: {message}"
+    );
+    assert!(
+        !message.contains("is not a valid selector"),
+        "and does not call a valid selector invalid: {message}"
+    );
+
+    // A selector that really is malformed still gets the plain answer.
+    let broken = script
+        .eval_value(
+            "(() => { try { document.querySelector('!!!'); return 'accepted' } \
+             catch (e) { return e.message } })()",
+        )
+        .unwrap();
+    assert!(
+        broken.contains("is not a valid selector"),
+        "a typo is still a typo: {broken}"
+    );
+}
+
+#[test]
 fn the_window_runs_the_handler_assigned_to_its_onload_property() {
     // `window.onload = fn` read back as a function and never ran. The `on*`
     // accessors were installed on `Element.prototype`, and the window is not an

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -265,6 +265,116 @@ fn the_document_lifecycle_fires() {
 }
 
 #[test]
+fn the_window_runs_the_handler_assigned_to_its_onload_property() {
+    // `window.onload = fn` read back as a function and never ran. The `on*`
+    // accessors were installed on `Element.prototype`, and the window is not an
+    // element, so the assignment landed on an ordinary expando — correct on
+    // inspection, inert in practice, which is the reason it survived four
+    // corpora and 7,684 timing-out WPT files.
+    let (page, _broker) = run_page(
+        "<html><body><div id='out'></div><script>\
+         window.onload = () => { document.getElementById('out').textContent = 'window.onload ran' };\
+         </script></body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(
+        rendered.contains("window.onload ran"),
+        "the property handler fired on load:\n{rendered}"
+    );
+}
+
+#[test]
+fn assigning_the_same_window_handler_twice_leaves_one_handler() {
+    // What separates an `on*` property from `addEventListener`: the second
+    // assignment replaces the first rather than joining it.
+    let (page, _broker) = run_page(
+        "<html><body><div id='out'></div><script>\
+         globalThis.hits = 0;\
+         window.onload = () => { hits++ };\
+         window.onload = () => { hits++; document.getElementById('out').textContent = 'hits=' + hits };\
+         </script></body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(rendered.contains("hits=1"), "one handler, not two:\n{rendered}");
+}
+
+#[test]
+fn body_onload_is_the_windows_load_handler() {
+    // `<body onload>` is forwarded to the window by the spec, and the
+    // difference is not cosmetic: `load` is fired *at* the window, so a handler
+    // left on the body element sits through the one event it exists for.
+    //
+    // This is the shape most of WPT's timeout bucket had — a file whose entire
+    // test is `<body onload="run()">` loaded, registered nothing, and was
+    // scored as an engine that ran it and found nothing to say.
+    let (page, _broker) = run_page(
+        "<html><body onload=\"document.getElementById('out').textContent = 'body onload ran'\">\
+         <div id='out'></div></body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(
+        rendered.contains("body onload ran"),
+        "the content attribute was compiled and fired:\n{rendered}"
+    );
+}
+
+#[test]
+fn an_inline_handler_attribute_runs_with_the_element_as_this() {
+    // The attribute value is a function *body* taking `event`, not an
+    // expression, and it runs with the element as `this`. Both halves are load
+    // bearing: `this.id` is how half of these handlers find what they act on.
+    let (page, _broker) = run_page(
+        "<html><body><button id='b' onclick=\"this.textContent = 'clicked ' + this.id + ' ' + event.type\">b</button>\
+         <script>addEventListener('load', () => document.getElementById('b').click());</script>\
+         </body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(
+        rendered.contains("clicked b click"),
+        "`this` is the element and `event` is in scope:\n{rendered}"
+    );
+}
+
+#[test]
+fn an_inline_handler_arriving_after_load_is_compiled_too() {
+    // The lifecycle sweep has been and gone by the time a page writes markup,
+    // so `innerHTML` and `setAttribute` have to compile what they introduce or
+    // handlers work only when they were in the original document.
+    let (page, _broker) = run_page(
+        "<html><body><div id='host'></div><div id='out'></div><script>\
+         addEventListener('load', () => {\
+           document.getElementById('host').innerHTML =\
+             '<button id=\\'late\\' onclick=\\'document.getElementById(\\\"out\\\").textContent = \\\"late ran\\\"\\'>x</button>';\
+           document.getElementById('late').click();\
+         });</script></body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(
+        rendered.contains("late ran"),
+        "markup written after load carries live handlers:\n{rendered}"
+    );
+}
+
+#[test]
+fn a_handler_attribute_that_does_not_compile_is_reported_not_fatal() {
+    // A syntax error in one handler is the page's bug. A browser reports it and
+    // carries on; taking the document down over it would be this engine
+    // inventing a failure the page does not have.
+    let (page, _broker) = run_page(
+        "<html><body><button id='b' onclick='(((' >b</button>\
+         <div id='out'></div>\
+         <script>addEventListener('load', () => {\
+           document.getElementById('out').textContent = 'document still ran';\
+         });</script></body></html>",
+    );
+    let rendered = page.snapshot().render();
+    assert!(
+        rendered.contains("document still ran"),
+        "the rest of the page is unaffected:\n{rendered}"
+    );
+}
+
+#[test]
 fn an_element_id_becomes_a_global_without_shadowing_one() {
     // "target is not defined" was the single largest cause of files that could
     // report nothing at all: a ReferenceError on line one ends a file before it

--- a/crates/h5i-browser-light/src/stream.rs
+++ b/crates/h5i-browser-light/src/stream.rs
@@ -4098,6 +4098,20 @@ mod tests {
                     p.textContent = 'late'; document.querySelector('#host').appendChild(p); \
                     }, 1000);</script></body></html>";
 
+        // The same page with its timer already resolved, as a control. What the
+        // wait costs has to be compared against what building a session costs
+        // on *this* machine, because an absolute budget measures the runner:
+        // this assertion read `real < 900ms`, passed locally with the whole
+        // test finishing in 200ms, and failed CI at 934ms on a loaded shared
+        // runner. A number that turns red when the machine is busy is not
+        // testing the virtual clock.
+        let without_timer =
+            "<html><body><div id='host'><p>late</p></div><script>var n = 1;</script></body></html>";
+        let control_started = std::time::Instant::now();
+        let mut control = scripted_session_with(without_timer);
+        let _ = control_verb(&mut control, &json!({"verb": "wait_for", "text": "late"}));
+        let control_real = control_started.elapsed();
+
         let started = std::time::Instant::now();
         let mut first = scripted_session_with(page);
         let (a, _) = control_verb(&mut first, &json!({"verb": "wait_for", "text": "late"}));
@@ -4106,9 +4120,20 @@ mod tests {
         assert_eq!(a["ok"], true, "{a:?}");
         assert_eq!(a["met"], true, "the timer fired and the node landed: {a:?}");
         assert_eq!(a["end"], "met");
+
+        // The exact claim, with no clock in it at all: the wait did not wait.
+        // The settle had already run the page's timer to quiescence before the
+        // verb was served, so `wait_for` answered rather than slept. This is
+        // the deterministic half of the property, and it cannot be made to fail
+        // by a busy machine.
+        assert_eq!(
+            a["waited_ms"], 0,
+            "the page's second was spent before the verb was served: {a:?}"
+        );
         assert!(
-            real < std::time::Duration::from_millis(900),
-            "a page's own second of delay costs the agent nothing: {real:?}"
+            real < control_real + std::time::Duration::from_millis(500),
+            "a page's own second of delay costs the agent nothing: {real:?}, \
+             against {control_real:?} for the same page with nothing to wait for"
         );
 
         // And the answer does not depend on how the machine was feeling.

--- a/crates/h5i-browser-light/wpt/baseline.json
+++ b/crates/h5i-browser-light/wpt/baseline.json
@@ -1,11 +1,11 @@
 {
  "note": "Committed floor for the WPT gate. Raise with wpt/check.py --write.",
- "total": 56870,
+ "total": 273796,
  "per_dir": {
-  "css_cssom": 2073,
-  "dom": 1944,
-  "domparsing": 171,
-  "encoding": 8982,
-  "html_dom": 43700
+  "css_cssom": 2100,
+  "dom": 1995,
+  "domparsing": 172,
+  "encoding": 225785,
+  "html_dom": 43744
  }
 }

--- a/crates/h5i-browser-light/wpt/gate.sh
+++ b/crates/h5i-browser-light/wpt/gate.sh
@@ -17,8 +17,8 @@ JOBS="${JOBS:-4}"
 TIMEOUT="${TIMEOUT:-30}"
 OUT="${OUT:-wpt/gate-results}"
 
-if [ ! -x "../../target/release/h5i-browser-light" ]; then
-  echo "no release binary; cargo build --release -p h5i-browser-light" >&2
+if [ ! -x "../../target/release/h5i" ]; then
+  echo "no release binary; cargo build --release -p h5i" >&2
   exit 1
 fi
 

--- a/crates/h5i-browser-light/wpt/run.py
+++ b/crates/h5i-browser-light/wpt/run.py
@@ -54,7 +54,16 @@ import serve  # noqa: E402
 HERE = Path(__file__).resolve().parent
 CRATE = HERE.parent
 REPO = CRATE.parent.parent
-BINARY = REPO / "target" / "release" / "h5i-browser-light"
+# The engine, as the shipping binary reaches it.
+#
+# It used to be `target/release/h5i-browser-light`, and that path is a trap now:
+# the crate became a library when the engine moved inside `h5i __engine`, so
+# nothing rebuilds that file — but a stale copy from the last release that did
+# build it stays on disk, executable, and happily answers every request. The
+# harness went on scoring it for eight days without a word, because "the binary
+# is there" was the only question anyone asked.
+BINARY = REPO / "target" / "release" / "h5i"
+ENGINE_ARGS = ["__engine"]
 
 # Directories that hold machinery rather than tests. Running them produces
 # noise that looks like failure and is not.
@@ -191,7 +200,7 @@ def run_one(args):
     try:
         proc = subprocess.run(
             capped(
-                [str(BINARY), "open", "--script", "--json", "--max-snapshot-lines", "1", url],
+                [str(BINARY), *ENGINE_ARGS, "open", "--script", "--json", "--max-snapshot-lines", "1", url],
                 mem_mb,
             ),
             capture_output=True, timeout=timeout,
@@ -277,7 +286,7 @@ def main():
     opts = parser.parse_args()
 
     if not BINARY.exists():
-        sys.exit(f"no binary at {BINARY}; cargo build --release -p h5i-browser-light")
+        sys.exit(f"no binary at {BINARY}; cargo build --release -p h5i")
 
     root = Path(opts.wpt).expanduser()
     serve.WPT_ROOT = str(root)


### PR DESCRIPTION
Two instruments said the engine was fine. Both were wrong, and one was hiding
the other.

## The harness was scoring a binary nothing had rebuilt in eight days

`h5i-browser-light` became a library when the engine moved inside
`h5i __engine`, so `target/release/h5i-browser-light` stopped being a build
target. The file did not stop existing — the last release that produced one
left it on disk, executable, answering every request the harness made.
`run.py` still pointed at it and `gate.sh` guarded on `-x`, so "the binary is
there" was the only question either asked.

A full sweep run today scored the engine **as it stood on 19 August** and
reported it as current, missing B16, B17 and B18 entirely. It came back at
+565 subtests over the 10 August baseline, which read as "two and a half weeks
of work moved nothing" rather than as a broken instrument. That is the
dangerous direction for a measurement to be wrong in.

Fixed by pointing at `h5i` and passing `__engine`. The stale file is deleted so
the trap cannot spring again.

## Three event-handler defects, in one family

Once the harness was measuring the right engine, the timeout bucket turned out
to be the largest thing wrong with it: 7,684 files (31% of measured) where
testharness gave up. They were not hangs — the median such file finished in
0.17s, and 1,887 of `css`'s 2,221 reported **zero subtests**. The harness ran
and never registered a single test.

| form | before | after |
| --- | --- | --- |
| `window.addEventListener("load", fn)` | fires | fires |
| `el.onclick = fn` | fires | fires |
| `window.onload = fn` | **never ran** | fires |
| `<body onload="...">` | **never ran** | fires |
| `<button onclick="...">` | **never ran** | fires |

1. **`window.onload = fn` stored the function and never called it.** The `on*`
   accessors were installed on `Element.prototype`, and the window is not an
   element, so the assignment landed on an ordinary expando. `typeof
   window.onload` returned `"function"` — which is why this survived four
   corpora and a WPT sweep. Nothing about it looked wrong from outside.

2. **Event-handler content attributes were never compiled at all.** `<body
   onload>` is set by markup, and markup does not go through the IDL setter the
   accessors hook. A page whose behaviour hangs off one of them loaded, did
   nothing, and looked idle.

3. **The realm was only built when the document had a `<script>` element**, so
   a page whose only code lives in an attribute never ran it. That shortcut was
   not skipping 15ms of waste, it was skipping the page — and then reporting
   itself settled with `timers_run: 0`, which reads as "nothing to do" rather
   than "nothing was run". Found by a test written for the second bug and
   failing for this one instead.

Window handlers delegate to the window's own `addEventListener`, so mixing the
two forms leaves one handler per assignment. Inline attributes compile to the
spec's shape — the value is a function *body* taking `event`, called with the
element as `this` — and `<body>` forwards the window's set, which matters
because `load` is fired at the window: a handler left on the body element would
sit through the one event it exists for. Compiled at lifecycle time before the
first dispatch, and again from `setAttribute` and `innerHTML`, because markup
written after load carries handlers too.

## What it is worth, measured rather than estimated

Same binary, same corpus, the fix as the only difference:

| dir | without | with | delta | files timing out |
| --- | --- | --- | --- | --- |
| css | 38,656 | 40,314 | **+1,658** | 2,135 → 1,457 |
| user-timing | 55 | 600 | **+545** | 8 → 3 |
| html | 56,589 | 57,084 | **+495** | 1,792 → 1,493 |
| content-security-policy | 108 | 150 | +42 | 427 → 414 |
| encoding-detection | 0 | 18 | +18 | 75 → 31 |
| dom | 1,962 | 1,965 | +3 | 145 → 131 |
| navigation-api | 0 | 0 | 0 | 240 → 182 |
| pointerevents | 11 | 11 | 0 | 107 → 100 |
| **total** | **104,110** | **106,872** | **+2,762** | **5,071 → 3,951** |

**+2,762 subtests, and 1,120 files that stop timing out.**

Across the whole corpus against 10 August: **337,524 passing, up 3,834**, with
`harness_timeout` down 1,323 and `ok` up 1,305 — a near-exact trade, which is
the point. The fix is about 72% of that gain; B16–B18 is the rest.

`navigation-api` and `pointerevents` are the honest half of the table: 58 and 7
files stop timing out and score nothing. Running and failing is a better answer
than silence, but it is not a point.

## Read the pass rate before quoting it

Pass rate went **down**, 57.07% → 56.23%, while passes went up by 3,834. The
engine reached 15,506 more subtests and converted 3,834 of them, so the
denominator grew faster than the numerator. `check.py` already argues this is
why the gate counts passes rather than a percentage; this is the first run to
demonstrate it. `FAIL` rising by 11,182 is those files reporting real failures
instead of nothing.

## Not fixed here

- **`:has()` is entirely unsupported and now throws.** `selectors-0.39.0`'s
  `Parser::parse_has()` defaults to `false` and `stylo-0.19.0` never overrides
  it, so it has never parsed — in stylesheets or in `querySelector`. Since the
  strict-selector check, `document.querySelector(".x:has(.y)")` raises
  `SyntaxError` where it used to return nothing. For an agent-driving browser
  that is the sharp edge: a locator that throws takes out the caller.
- **`shadow-dom` is down 203 subtests** against 10 August, on both the old and
  new engine. A real regression, not yet diagnosed.
- **`wpt/baseline.json` needs re-recording.** Its `encoding` floor says 8,982
  against a real 225,785 and has been defending nothing for two weeks.

## Notes for the reviewer

- `ROADMAP.md` §B19 (Obscura's instruments) rides along in `3b39c9229`; it is
  not part of the engine change.
- `3b39c9229` also captured `engine.rs` and `prelude.js` mid-A/B, with the fix
  checked out to its pre-fix state, which reverted it and left the seven tests
  failing. `02ad3e346` restores those two files verbatim. Net effect on the
  branch is nil, but the pair looks odd in isolation.
- `clippy --workspace --all-targets` clean under `-D warnings`; 540 crate tests
  pass.


## Also in this branch

Four smaller things, found while measuring the above.

**A reflected property belongs to its interface.** `"htmlFor" in element` was
true for `<div>` and `<button>`: twelve interface-specific attributes were
installed on `Element.prototype`. `in` is how the platform is feature detected,
and WPT's reflection helper gates on exactly that expression.

This **costs 380 subtests in `shadow-dom`** (794 -> 414) and the direction is
correct. About 120 were passing on combinations a real browser skips —
`button.htmlFor` is not a thing — and about 70 are new honest failures, created
by putting `crossOrigin` on `<img>` where the engine is now asked questions it
fails. Withdrawn false passes, and §B12.6's rule applied to a number moving the
unwelcome way. Flagged rather than buried, since it is a visible regression.

**`:has()` says what is actually wrong.** It threw "is not a valid selector",
which is false: it is a valid selector, and `stylo-0.19.0`'s servo parser simply
answers `parse_has() -> false`, hardcoded rather than behind a preference.
Throwing stays right — an unsupported pseudo-class does invalidate a selector —
but the gap now files through `api.unsupported` and is counted beside every
other missing feature. The feature itself is **not** built: a wrapper could
enable parsing for `querySelector`, but stylesheets go through stylo
internally, and a DOM that accepts a selector the cascade ignores is worse than
a clean gap.

**A timing test that measured the runner.** `real < 900ms` over building a
session failed CI at 934ms while finishing locally in 200ms. Replaced with two
assertions containing no absolute number: `waited_ms == 0`, which is the claim
stated exactly, and a wall-clock comparison against the same page with nothing
to wait for, timed on the same machine.

**The gate floor, re-recorded: 56,870 -> 273,796.** It said `encoding: 8982`
against a real 225,785, so the largest column in the corpus had been defending
nothing since 10 August. Worse than absent: it printed "no regression" while a
total collapse there would have passed silently.

## Known and not addressed

- **`shadow-dom` is down 203 subtests against 10 August**, separately from the
  reflection change above. `property-reflection-idl-setters.html` throws
  `cannot convert 'null' or 'undefined' to object` inside the helper's setter
  path. It is under `tentative/` — a proposed reference-target spec this engine
  does not implement — so it was left after diagnosis rather than chased.
- `:has()` remains unimplemented, as above.
- `3b39c9229` and `02ad3e346` are a revert and its restoration: the first
  captured `engine.rs` and `prelude.js` while they were checked out to their
  pre-fix state for the A/B measurement. Net effect nil; the pair reads oddly in
  isolation.
