### PR TITLE
browser: a text node that was the document, and the fixed cost of reading a page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "h5i-error",
  "httpdate",
  "image",
+ "libc",
  "parley",
  "portable-atomic",
  "psl",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4548,8 +4548,123 @@ Not bindings, and the reason four pages read as empty:
 
 ### B8.9 What it costs, measured
 
-`cargo run --release --example perf`. Two rounds, and the second is mostly the
-Boa upgrade paying for itself:
+`cargo run --release --example perf`. Numbers from one WSL2 laptop, and it
+drifts by 10% between runs, so read the ratios rather than the digits.
+
+**First, a correction to what this section used to say.** Its `script` column
+counted the realm twice. A script-enabled factory runs the page's scripts inside
+`from_html`, through `finish_page`, and the benchmark then called `run_scripts`
+again — which does not no-op, it builds a second realm and runs every script a
+second time. At 15.9 ms a realm the error looked like noise; at 58 ms it was
+most of the number, which is how it was finally caught. Only the benchmark was
+affected: `finish_page` is the sole caller in the product.
+
+```
+reading a page                no script     script     outline
+10 sections  (~90 nodes)          2.0ms      72ms       60 lines
+100 sections (~900 nodes)        13.0ms      86ms      500 lines
+500 sections (~4500 nodes)       66.0ms     185ms      500 lines
+
+starting the script realm          63ms per page
+the floor under a scripted page    66ms      (one section: almost all fixed cost)
+
+a DOM property read
+  plain object                      68 ns
+  watched node, known property     198 ns
+  watched node, read from tree     740 ns
+  watched node, remembered         300 ns    (a tag cannot change; it is asked once)
+
+one native call
+  a number back (nodeKind)         136 ns
+  a string back (tagName)          190 ns
+  a string each way (getAttr)      270 ns
+
+queries, 200 calls each
+  document.querySelectorAll        405 µs
+  section.querySelectorAll          20 µs
+  iterating a 400-node result      213 µs
+```
+
+**The realm is still most of a small page**, at 93% of the ten-section row when
+this pass began and about 87% now. Inside it, parse and compile are two thirds:
+33 ms and 9 ms of the 63, against 272 KiB of *code*. Boa parses eagerly, so
+every page pays for every line whether or not it runs one.
+
+Code, not bytes: blanking all 164 KiB of comments in a 448 KiB prelude changed
+parse time by **nothing measurable**. The documentation is free; only what the
+parser tokenises is not. `the_eagerly_parsed_prelude_stays_within_its_budget`
+holds the line at 275 KiB, because the file grew 4,692 lines in two commits
+during a coverage push and took the realm from 15.9 ms to 82.8 ms with nothing
+saying so — every test passed, since a slower engine is not a wrong one.
+
+#### What came out, and what each was worth
+
+1. **The WebIDL member decoration is a tier.** `idlharness` checks that every
+   interface member is enumerable and that an accessor reached on a prototype
+   throws; no page asks either. Rebuilding every descriptor of every interface
+   prototype cost **15 ms of 83**, on every page, and it now lives in a source
+   Boa is handed only under `--webidl-conformance`, which `wpt/run.py` passes.
+2. **The gap reporting moved to the end of the prototype chain.** It was a
+   `Proxy` in front of every wrapper, so it fired on reads that found what they
+   asked for: **799 ns of the 882 ns** a known property cost, against 82 ns for
+   a plain object. A read that misses already walks the whole chain, so the
+   sentinel sits where only a miss arrives. Known reads went to ~200 ns, and a
+   compromise went with it — the proxy passed the raw target as receiver to
+   avoid double-trapping, which made a miss inside a page's own getter
+   invisible.
+3. **The engine stopped paying a trap to ask itself a question.** `get tagName()`
+   reads `this._nsuri` to learn whether the element came from `createElementNS`,
+   and for everything the parser made it never did — so the most-read accessor
+   in the engine walked its whole prototype chain into a proxy, 1415 ns against
+   the 196 ns its native call costs. `declareInternals` answers at the first
+   hop, and `an_internal_read_never_reaches_the_sentinel` is the guard for the
+   next such field.
+4. **Every settle stopped waiting on a sleeping thread.** The deadline watchdog
+   polled a flag every 20 ms and was *joined*, so a settle that finished in
+   50 µs sat in `join` until the thread woke. A 20 ms tax on every settle and
+   every agent `wait`, spent asleep, and intermittent — a race between the body
+   finishing and the watchdog reaching its first sleep, so half the runs looked
+   fine. A condition variable, and the deadline is unchanged.
+
+Three tiers exist so far (`conformance`, `sockets`, `has`, 12 KiB together) and
+the mechanism is cheap to extend, but its ceiling is low: 272 of the 284 KiB of
+code is DOM core that every page uses. The one tier still worth building is the
+form-control extras, ~48 KiB and ~7 ms, which needs the free-variable analysis
+that splitting a shared closure demands.
+
+#### Measured and rejected, so nobody tries again
+
+* **Precomputing the known property names**, so the old proxy trap did a hash
+  lookup instead of walking the prototype chain: no change. The cost was Boa
+  dispatching into a JavaScript trap at all, which is why the answer in the end
+  was to stop standing in front of the object.
+* **Raising the loop bound from 5 to 50 million**: turned a site that returned
+  in three minutes into one that had not returned in four.
+* **Interning the uppercased tag names**, and building the attribute answer
+  without its two intermediate `String`s: no change either. A native call costs
+  ~136 ns of dispatch before it does anything at all, so shaving the work at the
+  far end of it is shaving the small half. The allocations went anyway; the
+  cache did not, because it was state for nothing. What worked was not making
+  the call: `tagName` is remembered on the wrapper, 740 ns to 300 ns.
+* **Stripping comments before handing the source to Boa**: no change, per the
+  measurement above. Worth recording because the idea is obvious and the file is
+  a third comments by volume.
+* **Reusing the compiled prelude across pages**, which would remove the 42 ms of
+  parse and compile and is the only 3x-class win left. A `CodeBlock` owns its
+  `InlineCache` entries, and those hold live shape-to-slot mappings, so reusing
+  one carries the last page's object shapes into the next page's lookups. That
+  is a sharper reason than the interner one this section used to give, and it
+  names the upstream change that would unblock it: reset the caches on reuse, or
+  hang them off the realm rather than the code block.
+
+Reusing the *realm* across navigations is refused on other grounds and still is:
+a page could leave state for whatever loads next, which is the same reason the
+cookie jar is cleared across origins.
+
+#### The history this replaces
+
+The Boa revision bump, measured before and after, and still the strongest
+argument for pinning a revision over a five-month-old release:
 
 ```
 a DOM property read              on 0.19      on main
@@ -4558,51 +4673,19 @@ a DOM property read              on 0.19      on main
   watched node, read from tree     6173 ns     1534 ns
 ```
 
-Four times faster for nothing but a dependency bump, which is the single
-strongest argument for pinning a revision over a five-month-old release.
+Three earlier changes, each of which still holds:
 
-Three things then changed on our side, each measured before and after:
-
-1. **A page with no script no longer builds a realm.** That costs ~15 ms, 114
-   KiB of prelude parsed and evaluated, and a page with nothing to run was
-   paying all of it for a realm never asked a question. It is also reported
-   correctly now: "had none to run" is a different fact from "script is off",
-   and a page with no script is *settled* rather than unknown.
+1. **A page with no script no longer builds a realm.** A page with nothing to
+   run was paying the whole fixed cost for a realm never asked a question. It is
+   also reported correctly: "had none to run" is a different fact from "script
+   is off", and a page with no script is *settled* rather than unknown.
 2. **Collections are no longer watched.** Wrapping a query result in the
-   reporting proxy cost **3.9x on iteration**, 674 µs against 174 µs for a
-   400-node result, because every index read goes through a trap and
-   `for (const el of query)` is the hottest line in DOM code. An array already
-   answers everything a `NodeList` does except `item` and `namedItem`, which are
-   implemented, so the naming it bought was small and the price was not.
-3. **`matches()` is a direct predicate.** It had been asking the *parent* for
-   all matching descendants and checking membership, which made `closest()`
-   walk a subtree per ancestor: quadratic on any page whose framework calls it
-   in a render loop, and worth minutes on a real site.
-
-```
-reading a page                no script     script     outline
-10 sections  (~90 nodes)          1.5ms     37.4ms      60 lines
-100 sections (~900 nodes)        12.7ms     54.1ms     500 lines
-500 sections (~4500 nodes)       69.8ms    166.2ms     500 lines
-
-starting the script realm        15.9ms per page
-queries, 200 calls each
-  document.querySelectorAll        361 µs
-  section.querySelectorAll           6 µs
-  iterating a 400-node result      169 µs
-```
-
-The remaining fixed cost is the realm: 114 KiB of JavaScript parsed per page.
-Reusing one across navigations would remove it, and is *not* safe: a page could
-leave state for whatever loads next, which is the same reason the cookie jar is
-cleared across origins.
-
-**Measured and rejected**, twice, and both are recorded so nobody tries again:
-precomputing the set of known property names so the reporting trap does a hash
-lookup instead of walking the prototype chain changed nothing (the cost is Boa
-dispatching into a JavaScript trap at all); and raising the loop bound from 5 to
-50 million turned a site that returned in three minutes into one that had not
-returned in four.
+   reporting proxy cost **3.9x on iteration**, because every index read went
+   through a trap and `for (const el of query)` is the hottest line in DOM code.
+3. **`matches()` is a direct predicate.** It had been asking the *parent* for all
+   matching descendants and checking membership, which made `closest()` walk a
+   subtree per ancestor: quadratic on any page whose framework calls it in a
+   render loop.
 
 ### B8.10 Source positions, and what they found
 
@@ -6250,10 +6333,14 @@ say so.
 ### B15.12a The performance items, measured: all three answers are no
 
 §B11.5.13 and §B11.5.14 list two performance items — reuse the realm across
-navigations (~20ms a page, §B8.9), and cache the prelude's bytecode (three
-thousand lines of JavaScript parsed per realm). Both were attempted. Neither
+navigations, and cache the prelude's bytecode. Both were attempted. Neither
 should be built, and a third optimisation that looked obvious was measured and
 reverted. Recorded together because the pattern is the point.
+
+The prices have moved since this was written and the answers have not. The realm
+was ~20 ms a page then and is ~63 ms now; the prelude was three thousand lines
+and is ten thousand. §B8.9 carries the current numbers, and a better reason for
+the second refusal than the one below.
 
 **Realm reuse: refused, on grounds §B11.5 did not weigh.** A realm carries
 everything the previous document's script put in it — globals, patched
@@ -6270,6 +6357,16 @@ reason rather than a hard one. `boa_engine::Script::parse` interns identifiers
 into *the context's own* interner (`context.interner_mut()`) and binds the
 result to that context's realm; every page builds a fresh `Context`. A parsed
 script is not a portable artifact, so there is nothing to cache across pages.
+
+Re-examined on Boa 0.22, where the decisive reason turns out to be a different
+and sharper one: a `CodeBlock` owns its `InlineCache` entries, and those hold
+live shape-to-slot mappings filled in as the code runs. Reusing one across
+realms would carry the last page's object shapes into the next page's property
+lookups, which is the same cross-page contamination the realm refusal above
+exists to prevent, arriving through the cache instead of through the globals.
+The upstream change that would unblock it is small and namable: reset the caches
+on reuse, or hang them off the realm rather than the code block. Worth 42 ms of
+the 63, and worth an upstream issue rather than a fork.
 Revisit if Boa grows a shared interner or a serialisable code block. The note
 lives at the prelude's eval site.
 

--- a/crates/h5i-browser-light/Cargo.toml
+++ b/crates/h5i-browser-light/Cargo.toml
@@ -186,3 +186,10 @@ brotli = { version = "8.0.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 tempfile = "3.8"
+
+# `_exit`, for one call: the renderer's "my broker is gone" stop. See
+# `BrokerClient::over` in `ipc.rs` for why `std::process::exit` is not enough
+# there. Unix only, because the renderer is only ever spawned over a socket
+# pair, which is a unix path already.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.186"

--- a/crates/h5i-browser-light/examples/perf.rs
+++ b/crates/h5i-browser-light/examples/perf.rs
@@ -169,10 +169,34 @@ fn main() {
                 .expect("realm");
         });
         println!("\nstarting the script realm: {start:.1?} per page");
+        // Code, not bytes. Blanking every comment in the prelude — 164 KiB of
+        // 448, a third of the file — changed parse time by nothing at all, so
+        // the number that predicts this cost is what the parser has to
+        // tokenise, and the documentation is free.
+        let code = |source: &str| -> usize {
+            source
+                .lines()
+                .filter(|line| !line.trim_start().starts_with("//"))
+                .map(|line| line.len() + 1)
+                .sum()
+        };
+        let core = include_str!("../src/script/prelude.js");
+        let tiers = [
+            ("conformance", include_str!("../src/script/prelude/conformance.js")),
+            ("sockets", include_str!("../src/script/prelude/sockets.js")),
+            ("has", include_str!("../src/script/prelude/has.js")),
+        ];
         println!(
-            "  prelude is {} lines / {} KiB of JavaScript, parsed and evaluated each time",
-            include_str!("../src/script/prelude.js").lines().count(),
-            include_str!("../src/script/prelude.js").len() / 1024,
+            "  the core prelude is {} KiB of code ({} KiB with its comments), parsed every time",
+            code(core) / 1024,
+            core.len() / 1024
+        );
+        let deferred: usize = tiers.iter().map(|(_, source)| code(source)).sum();
+        println!(
+            "  {} KiB more sits in {} tiers ({}), parsed only when a page asks",
+            deferred / 1024,
+            tiers.len(),
+            tiers.iter().map(|(name, _)| *name).collect::<Vec<_>>().join(", ")
         );
     }
 
@@ -214,11 +238,14 @@ fn main() {
             iterate.as_nanos() as f64 / 200.0 / 1000.0);
     }
 
-    // ── the reporting proxy ─────────────────────────────────────────────────
+    // ── where a DOM property read goes ──────────────────────────────────────
     //
-    // Every DOM property read goes through a `get` trap so that an unknown name
-    // can report itself. That is a real cost on the hottest path in the engine,
-    // and it had never been measured.
+    // This section is why the reporting moved. Every DOM property read used to
+    // go through a `get` trap on a proxy in front of every wrapper, so that an
+    // unknown name could report itself — 799 ns of the 882 ns a *known*
+    // property cost, against 82 ns for a plain object. The reporting now sits
+    // at the end of the prototype chain instead, where only a read that missed
+    // arrives, and a known read never meets it.
     println!();
     let url = url::Url::parse("https://bench.example/").unwrap();
     let (scripted, broker) = factory(true);
@@ -250,14 +277,22 @@ fn main() {
         "(() => { let n = 0; const el = document.querySelector('h2'); \
            for (let i = 0; i < 20000; i++) n += el.cloneNode ? 1 : 0; return n })()",
     );
+    // A property that genuinely goes to the tree on every read. It used to be
+    // `tagName`, which stopped being one: a tag cannot change, so the wrapper
+    // remembers it and the second read never leaves JavaScript. That is the
+    // point of the fourth line below, and the reason this one had to move.
     let native = bench(
-        "(() => { let n = 0; const el = document.querySelector('h2'); \
+        "(() => { let n = 0; const el = document.querySelector('section'); \
+           for (let i = 0; i < 20000; i++) n += el.className.length; return n })()",
+    );
+    let remembered = bench(
+        "(() => { let n = 0; const el = document.querySelector('section'); \
            for (let i = 0; i < 20000; i++) n += el.tagName.length; return n })()",
     );
 
     let per = |d: Duration| d.as_nanos() as f64 / reads as f64;
     println!("where a DOM property read goes, over {reads} reads:");
-    println!("  plain object, no proxy        {plain:>10.1?}  ({:.0} ns each)", per(plain));
+    println!("  plain object                  {plain:>10.1?}  ({:.0} ns each)", per(plain));
     println!(
         "  watched node, known property  {trapped:>10.1?}  ({:.0} ns each)",
         per(trapped)
@@ -267,7 +302,11 @@ fn main() {
         per(native)
     );
     println!(
-        "\n  the proxy trap itself         {:>10.1?}  ({:.0} ns each)",
+        "  watched node, remembered      {remembered:>10.1?}  ({:.0} ns each)",
+        per(remembered)
+    );
+    println!(
+        "\n  the object model itself       {:>10.1?}  ({:.0} ns each)",
         trapped.saturating_sub(plain),
         per(trapped.saturating_sub(plain))
     );
@@ -277,13 +316,43 @@ fn main() {
         per(native.saturating_sub(trapped))
     );
 
+    // ── inside one native call ──────────────────────────────────────────────
+    //
+    // "Reaching into the tree" is four things at once, and which of them
+    // dominates decides what is worth fixing: Boa dispatching to a native
+    // function, converting the arguments, finding the host and the node, and
+    // building the answer. Three primitives with the same shape and different
+    // amounts of work at the end separate them.
+    let kind = bench(
+        "(() => { let n = 0; const id = document.querySelector('h2')._id; \
+           for (let i = 0; i < 20000; i++) n += __h5i.nodeKind(id); return n })()",
+    );
+    let tag = bench(
+        "(() => { let n = 0; const id = document.querySelector('h2')._id; \
+           for (let i = 0; i < 20000; i++) n += __h5i.tagName(id).length; return n })()",
+    );
+    let attr = bench(
+        "(() => { let n = 0; const id = document.querySelector('h2')._id; \
+           for (let i = 0; i < 20000; i++) n += String(__h5i.getAttr(id, 'class')).length; \
+           return n })()",
+    );
+    println!("\nwhere a native call goes, over {reads} calls:");
+    println!("  nodeKind: a number back        {kind:>10.1?}  ({:.0} ns each)", per(kind));
+    println!("  tagName: a string back         {tag:>10.1?}  ({:.0} ns each)", per(tag));
+    println!("  getAttr: a string each way     {attr:>10.1?}  ({:.0} ns each)", per(attr));
+
     println!(
-        "\nThe trap is the price of naming what a page asked for and we lack; the tree read is\n\
-         the price of there being one real DOM rather than a JavaScript copy of one. Neither is\n\
-         free, and the second is the larger.\n\n\
-         Measured and rejected: precomputing the set of known property names, so the trap does a\n\
-         hash lookup instead of walking the prototype chain, changed nothing. The cost is Boa\n\
-         dispatching into a JavaScript trap at all, not the test inside it — so the only way to\n\
-         remove it is to stop watching, which would cost the naming that makes a gap reportable."
+        "\nThe object model is the price of a node being an object rather than a number; the tree\n\
+         read is the price of there being one real DOM rather than a JavaScript copy of one. A\n\
+         read the wrapper can answer from what it already knows pays neither, which is what the\n\
+         fourth line is: a tag cannot change, so it is asked for once.\n\n\
+         Measured and rejected, so nobody tries again. **Precomputing the known property names**,\n\
+         so the old proxy trap did a hash lookup instead of walking the prototype chain: no\n\
+         change — the cost was Boa dispatching into a JavaScript trap at all, which is why the\n\
+         fix in the end was to stop being in front of the object. **Interning the uppercased tag\n\
+         names**, and building the attribute answer without its two intermediate `String`s: no\n\
+         change either, and the line above says why — a native call costs ~150 ns before it does\n\
+         anything at all, so shaving the work at the far end of it is shaving the small half.\n\
+         The allocations went anyway; the cache did not, because it was state for nothing."
     );
 }

--- a/crates/h5i-browser-light/examples/perf.rs
+++ b/crates/h5i-browser-light/examples/perf.rs
@@ -205,6 +205,29 @@ fn main() {
         );
     }
 
+    // ── what a scripted page costs before it has any content ────────────────
+    //
+    // One section, so the number is almost entirely fixed cost: build the realm,
+    // run one trivial script, fire the load lifecycle, settle. It is the floor
+    // under every scripted page, and the place a fixed cost that is nobody's
+    // feature shows up as itself.
+    //
+    // It found one. The deadline watchdog polled a flag every 20 ms and was
+    // *joined*, so a settle that finished in 50 us then waited for a sleeping
+    // thread to notice — up to 20 ms on every settle, and on every agent `wait`
+    // besides. It read as script time in a phase profile, and it was
+    // intermittent, because whether the watchdog had reached its first sleep was
+    // a race with the body finishing.
+    {
+        let url = url::Url::parse("https://bench.example/").unwrap();
+        let (scripted, _) = factory(true);
+        let minimal = document_with_script(1);
+        let floor = time(9, || {
+            let _ = scripted.from_html(&minimal, &url);
+        });
+        println!("\nthe floor under a scripted page (1 section): {floor:.1?}");
+    }
+
     // ── queries and collections ─────────────────────────────────────────────
     {
         let url = url::Url::parse("https://bench.example/").unwrap();

--- a/crates/h5i-browser-light/examples/perf.rs
+++ b/crates/h5i-browser-light/examples/perf.rs
@@ -110,11 +110,16 @@ fn main() {
             let _ = page.snapshot();
         });
 
-        let (scripted, broker) = factory(true);
+        let (scripted, _) = factory(true);
         let scripted_html = document_with_script(rows);
+        // No `run_scripts` here: a script-enabled factory has already run them
+        // inside `from_html`, through `finish_page`. Calling it again does not
+        // no-op — it builds a *second* realm and runs the page's scripts again
+        // — so this column counted the realm twice for as long as it has
+        // existed. At 15.9 ms a realm that was a third of the number; at 58 ms
+        // it was most of it, which is how it was finally noticed.
         let with_script = time(5, || {
             let mut page = scripted.from_html(&scripted_html, &url);
-            page.run_scripts(broker.clone()).expect("realm");
             page.refresh();
             let _ = page.snapshot();
         });
@@ -204,8 +209,9 @@ fn main() {
     {
         let url = url::Url::parse("https://bench.example/").unwrap();
         let (factory, broker) = factory(true);
-        let mut page = factory.from_html(&document(200), &url);
-        page.run_scripts(broker.clone()).expect("realm");
+        // Same as below: this document carries no script, so the only realm is
+        // the one built here, which is the one the queries run in.
+        let page = factory.from_html(&document(200), &url);
         let mut script =
             h5i_browser_light::script::Script::new(page.dom(), broker, &url).expect("realm");
 
@@ -249,13 +255,11 @@ fn main() {
     println!();
     let url = url::Url::parse("https://bench.example/").unwrap();
     let (scripted, broker) = factory(true);
-    let mut page = scripted.from_html(&document(20), &url);
-    page.run_scripts(broker).expect("realm");
-    let mut script =
-        h5i_browser_light::script::Script::new(page.dom(), {
-            let (_, broker) = factory(true);
-            broker
-        }, &url)
+    // The document has no script of its own, so `from_html` builds no realm for
+    // it (§B8.9: a page with nothing to run stopped paying for a realm). The
+    // one below is the only one, and it is the one being measured through.
+    let page = scripted.from_html(&document(20), &url);
+    let mut script = h5i_browser_light::script::Script::new(page.dom(), broker, &url)
         .expect("realm");
 
     let reads = 20_000;

--- a/crates/h5i-browser-light/src/budget.rs
+++ b/crates/h5i-browser-light/src/budget.rs
@@ -271,9 +271,105 @@ impl Deadline {
     }
 }
 
+/// The stop of last resort, for the half of this engine no deadline reaches.
+///
+/// Every other ceiling here guards the **script realm**: `--script-seconds`
+/// bounds the script phase, the loop-iteration limit bounds one `for`, the job
+/// deadline bounds the queue. All three work by asking Boa to stop between
+/// pieces of work it is doing. None of them can do anything about a *layout*
+/// that never returns, because no script is running while layout walks the tree
+/// — and layout is native code with no interruption point in it at all.
+///
+/// That gap was not theoretical. A cyclic tree — reachable, at the time, from
+/// `document.body.appendChild(new Text("x"))` — sent blitz walking for ever at
+/// 100% of a core, straight through a 45-second navigation budget and a
+/// 60-second script budget, for **seven hours**. The tree cannot go cyclic any
+/// more, but "no ceiling at all covers half the engine" is the condition that
+/// turned one bug into seven hours, and it is worth closing on its own.
+///
+/// A separate thread, because the wedged thread cannot help; `_exit`, because
+/// `std::process::exit` waits on the atexit handlers and stdio locks that the
+/// wedged thread may be holding (see `stop_now`). Armed for a *navigation*
+/// rather than for the process, so a long-lived `serve` session is bounded per
+/// page rather than in total.
+///
+/// The margin is wide on purpose. This is not a tighter version of the
+/// navigation budget — that one reports a page as unfinished and hands back
+/// what rendered, which is a useful answer. Reaching *this* one ends the
+/// process, so it must be somewhere no page that is merely slow can arrive.
+pub struct HardStop {
+    done: std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+}
+
+/// How far past its budget a navigation may go before the process stops.
+const HARD_STOP_MARGIN: Duration = Duration::from_secs(60);
+
+impl HardStop {
+    pub fn arm(budget: Duration) -> Self {
+        let done = std::sync::Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
+        let watching = done.clone();
+        let ceiling = budget + HARD_STOP_MARGIN;
+        let _ = std::thread::Builder::new()
+            .name("h5i-navigation-stop".to_string())
+            .spawn(move || {
+                let (lock, wake) = &*watching;
+                let mut finished = lock.lock().unwrap_or_else(|e| e.into_inner());
+                let deadline = Instant::now() + ceiling;
+                while !*finished {
+                    let Some(left) = deadline.checked_duration_since(Instant::now()) else {
+                        break;
+                    };
+                    let (guard, _) = wake
+                        .wait_timeout(finished, left)
+                        .unwrap_or_else(|e| e.into_inner());
+                    finished = guard;
+                }
+                if *finished {
+                    return;
+                }
+                eprintln!(
+                    "h5i-browser-light: this page has been loading for {ceiling:?} without \
+                     finishing, which is past anything a slow page does. The engine is stopping \
+                     rather than holding a core indefinitely. This is a bug in the engine: a \
+                     page that takes too long is supposed to be reported as unfinished, not to \
+                     become one that never returns."
+                );
+                crate::ipc::stop_now(71);
+            });
+        Self { done }
+    }
+}
+
+impl Drop for HardStop {
+    /// The navigation finished, however it finished.
+    fn drop(&mut self) {
+        let (lock, wake) = &*self.done;
+        *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
+        wake.notify_all();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_navigation_that_finishes_disarms_its_hard_stop() {
+        // The half of `HardStop` that can be tested in process. The other half
+        // ends the process, so it is verified by running one: a navigation held
+        // open past its ceiling exits 71 and says why.
+        //
+        // What this pins is the part that would be catastrophic to get wrong in
+        // the opposite direction — a guard that fired on a page which had
+        // already finished would take down a working engine, and it would do it
+        // rarely enough to be blamed on anything else.
+        for _ in 0..64 {
+            drop(HardStop::arm(Duration::from_millis(1)));
+        }
+        // The margin is what makes the above safe: an armed stop that outlived
+        // its navigation by 1 ms would have fired sixty-four times by now.
+        std::thread::sleep(Duration::from_millis(50));
+    }
 
     fn tight() -> Budget {
         Budget::new(Limits {

--- a/crates/h5i-browser-light/src/cli.rs
+++ b/crates/h5i-browser-light/src/cli.rs
@@ -829,6 +829,18 @@ struct ViewArgs {
     #[arg(long, default_value_t = 0, value_name = "SECONDS")]
     script_seconds: u64,
 
+    /// Install the WebIDL member decoration: enumerable interface members, and
+    /// the brand check that makes an accessor reached on a prototype throw.
+    ///
+    /// **For instruments.** `idlharness` checks both on every member of every
+    /// interface; a page reads `el.href` and never asks whether the descriptor
+    /// is enumerable. Installing it rebuilds every descriptor of every interface
+    /// prototype, which measured 15 ms of the 83 ms a script realm cost, on
+    /// every page, for something one harness looks at. `wpt/run.py` passes
+    /// this; nothing else needs to.
+    #[arg(long)]
+    webidl_conformance: bool,
+
     #[arg(long, default_value_t = 1280)]
     width: u32,
 
@@ -1147,6 +1159,7 @@ fn factory_for(half: &Half, net: &NetArgs, view: &ViewArgs) -> Result<PageFactor
             script: view.script,
             script_budget: (view.script_seconds > 0)
                 .then(|| std::time::Duration::from_secs(view.script_seconds)),
+            webidl_conformance: view.webidl_conformance,
             navigation_budget: std::time::Duration::from_secs(view.navigation_seconds),
         },
     );

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -72,6 +72,13 @@ pub struct PageOptions {
     /// doing, and it changes nothing for anyone who does not pass it. The
     /// navigation deadline still bounds the whole load either way.
     pub script_budget: Option<std::time::Duration>,
+
+    /// Install the WebIDL member decoration in the script realm.
+    ///
+    /// **For instruments**, and off by default: see
+    /// [`crate::script::RealmOptions::webidl_conformance`] for what it costs
+    /// and who observes it.
+    pub webidl_conformance: bool,
 }
 
 impl Default for PageOptions {
@@ -83,6 +90,7 @@ impl Default for PageOptions {
             max_snapshot_lines: 500,
             script: false,
             script_budget: None,
+            webidl_conformance: false,
             // Above what a slow real page takes and far below what a stuck one
             // would, which is the shape every ceiling in this engine has.
             navigation_budget: std::time::Duration::from_secs(45),
@@ -956,8 +964,15 @@ impl Page {
             return Ok(());
         }
 
-        let mut script = crate::script::Script::new(self.dom(), broker.clone(), &self.url)
-            .map_err(H5iError::Metadata)?;
+        let mut script = crate::script::Script::with_options(
+            self.dom(),
+            broker.clone(),
+            &self.url,
+            crate::script::RealmOptions {
+                webidl_conformance: self.options.webidl_conformance,
+            },
+        )
+        .map_err(H5iError::Metadata)?;
         script.set_encoding(self.encoding);
 
         // The map, before anything can import. First one wins and the rest are

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -2095,7 +2095,7 @@ impl PageFactory {
     /// Load whatever a form asked for, through the same broker as everything
     /// else. A refused submission is an error the agent reads, not a blank page.
     pub fn open_submission(&self, submission: &Submission) -> Result<Page, H5iError> {
-        self.begin_navigation();
+        let _navigating = self.begin_navigation();
         let outcome = self.broker.send_from(
             &submission.url,
             Initiator::Navigation,
@@ -2205,12 +2205,16 @@ impl PageFactory {
     /// Before the navigation's own request, deliberately: resetting afterwards
     /// would give the page that just spent its allowance a clean slate for the
     /// subresources it is about to ask for.
-    fn begin_navigation(&self) {
+    fn begin_navigation(&self) -> crate::budget::HardStop {
         self.broker.reset_budget();
+        // Held by the caller until the page is built, which is the span every
+        // deadline in this engine is supposed to cover and the one where none of
+        // them reach layout. See `HardStop`.
+        crate::budget::HardStop::arm(self.options.navigation_budget)
     }
 
     pub fn open(&self, url: &Url) -> Result<Page, H5iError> {
-        self.begin_navigation();
+        let _navigating = self.begin_navigation();
         // Leaving an origin drops its cookies — in `finish`, against the origin
         // actually loaded rather than the one asked for. See
         // `cookies::Jar::retain_origin` for why that bound exists and what it
@@ -2228,7 +2232,7 @@ impl PageFactory {
     /// The same as [`PageFactory::from_html`], but from bytes whose encoding is
     /// not yet known — so the document gets to say what it is written in.
     pub fn from_bytes(&self, bytes: &[u8], content_type: Option<&str>, base_url: &Url) -> Page {
-        self.begin_navigation();
+        let _navigating = self.begin_navigation();
         self.finish_reporting(Page::from_bytes(
             bytes,
             content_type,
@@ -2240,7 +2244,7 @@ impl PageFactory {
     }
 
     pub fn from_html(&self, html: &str, base_url: &Url) -> Page {
-        self.begin_navigation();
+        let _navigating = self.begin_navigation();
         self.finish_reporting(Page::from_html(
             html,
             base_url,

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -275,6 +275,30 @@ pub struct BrokerClient {
     has_secrets: std::sync::OnceLock<bool>,
 }
 
+/// End this process, from a thread that cannot assume the rest of it is well.
+///
+/// `std::process::exit` is the wrong tool here and the difference is not
+/// theoretical. It runs the atexit handlers and flushes stdio on its way out,
+/// and both take locks — so a thread calling it while *another* thread is deep
+/// in allocation gets to wait for that thread, which is precisely the thread we
+/// have given up on. Measured: with the renderer's main thread spinning inside
+/// layout, this path printed "so it is stopping" and then did not stop. Six of
+/// them accumulated on one machine, the oldest running for seven hours, each
+/// holding a core.
+///
+/// `_exit` skips all of it and returns the descriptor to the kernel. Nothing is
+/// lost: there is no result to flush on this path — the broker that would have
+/// received one is gone — and the line above went to stderr, which Rust does
+/// not buffer.
+fn stop_now(code: i32) -> ! {
+    #[cfg(unix)]
+    unsafe {
+        libc::_exit(code)
+    }
+    #[cfg(not(unix))]
+    std::process::exit(code)
+}
+
 impl BrokerClient {
     /// The renderer's broker, on the descriptor it was handed.
     ///
@@ -324,7 +348,7 @@ impl BrokerClient {
                         "h5i-browser-light: the broker process ended; this renderer cannot fetch \
                          or receipt without it, so it is stopping."
                     );
-                    std::process::exit(70);
+                    stop_now(70);
                 }
             });
 

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -290,7 +290,7 @@ pub struct BrokerClient {
 /// lost: there is no result to flush on this path — the broker that would have
 /// received one is gone — and the line above went to stderr, which Rust does
 /// not buffer.
-fn stop_now(code: i32) -> ! {
+pub(crate) fn stop_now(code: i32) -> ! {
     #[cfg(unix)]
     unsafe {
         libc::_exit(code)

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -35,8 +35,65 @@ fn arg_string(args: &[JsValue], index: usize, context: &mut Context) -> JsResult
         .to_std_string_escaped())
 }
 
-fn arg_id(args: &[JsValue], index: usize, context: &mut Context) -> JsResult<usize> {
-    Ok(args.get_or_undefined(index).to_number(context)? as usize)
+/// The node the prelude has no id for.
+///
+/// `document` is an object literal on the JavaScript side, not a wrapper, and it
+/// deliberately carries no `_id`: every reflected accessor uses
+/// `this._id === undefined` as its WebIDL brand check, so giving the document
+/// one would make it pass for an element. Every path that hands `document._id`
+/// to a primitive therefore hands over `undefined`, and every one of them means
+/// this node.
+const DOCUMENT_NODE_ID: usize = 0;
+
+/// A node id argument, or an error naming what turned up instead.
+///
+/// This used to be `to_number(...)? as usize`, and that cast is why a text node
+/// could be the document. Rust's float-to-integer cast saturates: `NaN as usize`
+/// is **0**, and so is every negative number — and node 0 is the document. So
+/// any argument that was not a number at all became a valid id for the most
+/// consequential node in the tree, silently.
+///
+/// `new Text("x")` produced exactly that (see the prelude's `FROM_ID`), and
+/// appending the result made the document its own descendant, which hung layout
+/// for as long as anyone let it. That particular door is shut on both sides now;
+/// this is the rule underneath it, so the next bad id is an error rather than a
+/// different node.
+///
+/// The one non-numeric argument that is *not* a mistake is `undefined`, which is
+/// what `document._id` reads as. It means the document, it has always meant the
+/// document, and it says so here rather than arriving through a NaN.
+/// What a primitive says when it is handed something that is not an id.
+///
+/// Named as ours rather than as the page's: nothing a page writes reaches here
+/// directly, so an id that is not a number is this engine having lost track of
+/// one of its own nodes.
+fn bad_node_id(saw: &str) -> JsError {
+    JsError::from_opaque(
+        js_string!(format!(
+            "a node id has to be a whole number, and this one is `{saw}`. That is \
+             a bug in this engine, not in the page."
+        ))
+        .into(),
+    )
+}
+
+fn arg_id(args: &[JsValue], index: usize, _context: &mut Context) -> JsResult<usize> {
+    let value = args.get_or_undefined(index);
+    if value.is_undefined() || value.is_null() {
+        return Ok(DOCUMENT_NODE_ID);
+    }
+    // A *number*, not something a number can be made of. JavaScript's coercion
+    // is happy to turn `[]` and `""` into 0, and 0 is the document — so a rule
+    // written in terms of `to_number` would leave the same hole in a narrower
+    // shape. Every id this side ever sees came from `this._id`, which is a
+    // number or it is nothing.
+    let Some(number) = value.as_number() else {
+        return Err(bad_node_id(value.type_of()));
+    };
+    if !number.is_finite() || number.is_sign_negative() || number.fract() != 0.0 {
+        return Err(bad_node_id(&number.to_string()));
+    }
+    Ok(number as usize)
 }
 
 /// Read a JS array of `[name, value]` pairs.

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -587,10 +587,50 @@ fn set_scroll_top(_this: &JsValue, args: &[JsValue], context: &mut Context) -> J
     Ok(JsValue::undefined())
 }
 
+/// Would putting `child` inside `parent` make the tree cyclic?
+///
+/// DOM §4.2.3 forbids it — a node cannot contain itself or its own ancestor —
+/// and the prelude checks it for the nodes it can see. This is the same check
+/// where nothing can get past it, because the consequence is not a wrong answer
+/// but a **hang**: blitz walks the tree for layout, and a cycle means it walks
+/// for ever, at 100% of a core, past every deadline this engine has. Those
+/// deadlines guard the script realm; there is no script running while layout
+/// walks, so none of them fire.
+///
+/// Reachable from ordinary page code, which is what makes it this file's
+/// problem rather than the prelude's: `new Text("x")` used to hand back a
+/// wrapper whose id was the string `"x"`, and the conversion below turns
+/// anything non-numeric into 0 — the document itself. Appending *that* to a
+/// div spliced the whole document under one of its own descendants. One line in
+/// a WPT file left six engines spinning on this machine for seven hours.
+fn would_cycle(doc: &blitz_dom::BaseDocument, parent: usize, child: usize) -> bool {
+    let mut at = Some(parent);
+    while let Some(id) = at {
+        if id == child {
+            return true;
+        }
+        at = doc.get_node(id).and_then(|node| node.parent);
+    }
+    false
+}
+
+/// The error a refused insertion reports, in the spec's own terms.
+fn hierarchy_request(what: &str) -> JsError {
+    JsError::from_opaque(
+        js_string!(format!(
+            "HierarchyRequestError: {what} would make a node contain itself"
+        ))
+        .into(),
+    )
+}
+
 fn append(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let parent_id = arg_id(args, 0, context)?;
     let child_id = arg_id(args, 1, context)?;
     let host = host(context)?;
+    if would_cycle(&host.dom.borrow(), parent_id, child_id) {
+        return Err(hierarchy_request("appending a node"));
+    }
     guard_mutation(&host, "appending a node", || {
         let mut doc = host.dom.borrow_mut();
         let mut mutator = doc.mutate();
@@ -613,6 +653,13 @@ fn insert_before(_this: &JsValue, args: &[JsValue], context: &mut Context) -> Js
         // only in the prelude because a panic is not a DOM error: it takes the
         // page, the snapshot and the receipts with it, and WPT reaches this
         // path on purpose (`ChildNode-after`, `-before`, `-replaceWith`).
+        // The same cycle rule `append` carries, at the other door into the tree:
+        // the new node must not already contain the anchor it is going before.
+        if let Some(parent) = doc.get_node(anchor).and_then(|node| node.parent)
+            && would_cycle(&doc, parent, new_id)
+        {
+            return Err(hierarchy_request("inserting a node"));
+        }
         if doc.get_node(anchor).map(|node| node.parent.is_none()).unwrap_or(true) {
             return Err(boa_engine::JsNativeError::error()
                 .with_message(

--- a/crates/h5i-browser-light/src/script/dom_api.rs
+++ b/crates/h5i-browser-light/src/script/dom_api.rs
@@ -314,15 +314,22 @@ fn get_text(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
 /// stored `viewbox` and rendered nothing. Both are fixed here, in one place,
 /// because `guard_mutation` records what happens when a defect like this is
 /// fixed three times at three call sites instead.
-fn attr_name_for(doc: &blitz_dom::BaseDocument, id: usize, name: &str) -> String {
+/// Borrowed rather than owned: an attribute name arrives lowercase from nearly
+/// every caller, and lowercasing a string that is already lowercase to compare
+/// it against one more was an allocation per attribute read.
+fn attr_name_for<'a>(
+    doc: &blitz_dom::BaseDocument,
+    id: usize,
+    name: &'a str,
+) -> std::borrow::Cow<'a, str> {
     let html_element = doc
         .get_node(id)
         .and_then(|node| node.element_data())
         .is_some_and(|el| el.name.ns == blitz_dom::ns!(html));
-    if html_element {
-        name.to_ascii_lowercase()
+    if html_element && name.bytes().any(|b| b.is_ascii_uppercase()) {
+        std::borrow::Cow::Owned(name.to_ascii_lowercase())
     } else {
-        name.to_string()
+        std::borrow::Cow::Borrowed(name)
     }
 }
 
@@ -332,16 +339,19 @@ fn get_attr(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
     let host = host(context)?;
     let doc = host.dom.borrow();
     let name = attr_name_for(&doc, id, &name);
+    // Straight to a `JsString` from the borrowed value: the intermediate
+    // `String` this used to build was the third allocation in a read that only
+    // ever needed one.
     let found = doc.get_node(id).and_then(|node| {
         node.attrs().and_then(|attrs| {
             attrs
                 .iter()
-                .find(|a| a.name.local.as_ref() == name)
-                .map(|a| a.value.to_string())
+                .find(|a| a.name.local.as_ref() == name.as_ref())
+                .map(|a| js_string!(a.value.as_str()))
         })
     });
     Ok(match found {
-        Some(value) => js_string!(value).into(),
+        Some(value) => value.into(),
         None => JsValue::null(),
     })
 }
@@ -735,7 +745,7 @@ fn set_attr(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResul
         let qual = blitz_dom::QualName::new(
             None,
             blitz_dom::ns!(),
-            blitz_dom::LocalName::from(name.as_str()),
+            blitz_dom::LocalName::from(&*name),
         );
         let mut mutator = doc.mutate();
         mutator.set_attribute(id, qual, &value);
@@ -756,7 +766,7 @@ fn remove_attr(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRe
         let qual = blitz_dom::QualName::new(
             None,
             blitz_dom::ns!(),
-            blitz_dom::LocalName::from(name.as_str()),
+            blitz_dom::LocalName::from(&*name),
         );
         let mut mutator = doc.mutate();
         mutator.clear_attribute(id, qual);

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -42,6 +42,64 @@ use host::{ConsoleLine, Host, HostHandle};
 /// Boa's own prelude is the language; this is the browser.
 const PRELUDE: &str = include_str!("prelude.js");
 
+/// The pieces of the prelude a page has to *ask* for.
+///
+/// Two of the three costs of the prelude are a straight function of the *code*
+/// handed to Boa: parse and compile are 33 ms and 9 ms of the ~59 ms a realm
+/// takes, and Boa parses eagerly — there is no lazy compilation to hide behind,
+/// so every page pays for every line whether or not it runs one.
+///
+/// Code, not bytes: blanking all 164 KiB of comments in a 448 KiB prelude
+/// changed parse time by nothing measurable, so the documentation is free and
+/// only what the parser tokenises is not. The only way not to pay for a line is
+/// not to hand it over. So a surface most pages never touch lives in its own
+/// file, is never given to the parser, and arrives when something reads the
+/// name it defines — see `lazyGlobals` in the core prelude, which installs the
+/// getter that calls back into [`load_tier`].
+///
+/// The bar for moving something here is that a page which *does* use it pays
+/// slightly more (one extra parse of a small file) and a page which does not
+/// pays nothing. That trade only holds while the tier is genuinely optional:
+/// anything the first paint of an ordinary page touches belongs in the core.
+const TIERS: &[(&str, &str)] = &[
+    ("conformance", include_str!("prelude/conformance.js")),
+    ("sockets", include_str!("prelude/sockets.js")),
+    ("has", include_str!("prelude/has.js")),
+];
+
+/// Evaluate one tier into this realm, by name.
+///
+/// Reached from JavaScript as `__h5iTier("name")`. Evaluating into the same
+/// realm rather than a fresh one is the whole point: a tier finishes building
+/// the object model the core started, so it needs the core's interfaces, and it
+/// reaches them through `__h5iInternals` rather than through a shared closure —
+/// a separately parsed source has no way into the core's scope.
+fn load_tier(
+    _this: &boa_engine::JsValue,
+    args: &[boa_engine::JsValue],
+    context: &mut Context,
+) -> boa_engine::JsResult<boa_engine::JsValue> {
+    use boa_engine::JsArgs;
+    let name = args
+        .get_or_undefined(0)
+        .to_string(context)?
+        .to_std_string_escaped();
+    let Some((_, source)) = TIERS.iter().find(|(known, _)| *known == name) else {
+        return Err(boa_engine::JsError::from_opaque(
+            js_string!(format!("no such prelude tier: {name}")).into(),
+        ));
+    };
+    // Named like the core prelude's own frames, and for the same reason: a
+    // stack frame from here is a bug report against this engine, not against
+    // the page.
+    let path = format!("<h5i browser prelude: {name}>");
+    context.eval(Source::from_reader(
+        source.as_bytes(),
+        Some(std::path::Path::new(&path)),
+    ))?;
+    Ok(boa_engine::JsValue::undefined())
+}
+
 /// What a stack frame inside this engine's own prelude is called.
 ///
 /// The prelude was the one source evaluated without a path, so any frame in it
@@ -337,6 +395,37 @@ impl Settled {
     }
 }
 
+/// What a realm is built with, beyond the document it is bound to.
+///
+/// A struct rather than more parameters on [`Script::new`], because every one
+/// of these is a switch an *instrument* throws and nothing else does, and a
+/// caller that wants none of them should not have to say so.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RealmOptions {
+    /// Install the WebIDL member decoration: enumerable interface members, and
+    /// the brand check that makes an accessor reached on the prototype object
+    /// itself throw rather than run against nothing.
+    ///
+    /// **For instruments.** `idlharness` checks both on every member of every
+    /// interface, and nothing else does: a page reads `el.href`, it does not
+    /// ask whether the descriptor is enumerable. Installing it walks every own
+    /// property of every interface prototype and rebuilds each descriptor with
+    /// two closures, which measured **15 ms of the 83 ms** a realm cost — paid
+    /// by every page, observed by one harness.
+    ///
+    /// Not the `get x`/`set x` accessor naming, which reads as the third thing
+    /// this does and is not: Boa names class accessors correctly on its own and
+    /// the reflection tables name theirs, so that part is already true without
+    /// this. `the_webidl_decoration_arrives_only_when_an_instrument_asks` pins
+    /// all three so the distinction cannot rot.
+    ///
+    /// So it is off unless asked for, `wpt/run.py` asks for it, and the
+    /// conformance number is unchanged. Same shape as `--script-seconds`: an
+    /// instrument says what it is doing, and it changes nothing for anyone who
+    /// does not pass it.
+    pub webidl_conformance: bool,
+}
+
 /// A JavaScript realm bound to one document.
 pub struct Script {
     context: Context,
@@ -369,6 +458,16 @@ impl Script {
         dom: Dom,
         broker: std::sync::Arc<dyn crate::broker::Broker>,
         base: &url::Url,
+    ) -> Result<Self, String> {
+        Self::with_options(dom, broker, base, RealmOptions::default())
+    }
+
+    /// The same, for a caller that has an instrument's switches to throw.
+    pub fn with_options(
+        dom: Dom,
+        broker: std::sync::Arc<dyn crate::broker::Broker>,
+        base: &url::Url,
+        options: RealmOptions,
     ) -> Result<Self, String> {
         let url = base.to_string();
         let host = Rc::new(Host::new(dom, broker, base.clone()));
@@ -415,6 +514,23 @@ impl Script {
                 boa_engine::property::Attribute::empty(),
             )
             .map_err(|e| e.to_string())?;
+        // Built by hand rather than through `register_global_callable` so it
+        // carries the same attributes `__h5iUrl` does: a page walking its own
+        // globals must not find this engine's machinery among them.
+        let tier_loader = boa_engine::object::FunctionObjectBuilder::new(
+            context.realm(),
+            boa_engine::NativeFunction::from_fn_ptr(load_tier),
+        )
+        .name("__h5iTier")
+        .length(1)
+        .build();
+        context
+            .register_global_property(
+                js_string!("__h5iTier"),
+                tier_loader,
+                boa_engine::property::Attribute::empty(),
+            )
+            .map_err(|e| e.to_string())?;
         // Parsed on every realm, and it cannot be otherwise with this Boa.
         //
         // ROADMAP §B11.5.14 wanted this cached: three thousand lines of
@@ -429,6 +545,16 @@ impl Script {
         //
         // The sibling item, reusing the realm itself across navigations, is
         // refused on other grounds — see `Page::run_scripts`.
+        // Read by the core prelude at the one point the decoration has to
+        // happen: after every prototype is populated and before the interfaces
+        // reach the page.
+        context
+            .register_global_property(
+                js_string!("__h5iConformance"),
+                options.webidl_conformance,
+                boa_engine::property::Attribute::empty(),
+            )
+            .map_err(|e| e.to_string())?;
         context
             .eval(Source::from_reader(
                 PRELUDE.as_bytes(),

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -988,20 +988,41 @@ impl Script {
     /// off rather than left to look merely thin.
     fn with_job_deadline<T>(&mut self, budget: Duration, body: impl FnOnce(&mut Self) -> T) -> (T, bool) {
         let cancel = self.cancel.clone();
-        let finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let watching = finished.clone();
+        // A condition variable rather than a polled flag, because this thread is
+        // *joined*: whatever it is still doing when the body finishes, the page
+        // waits for.
+        //
+        // It used to sleep 20 ms between checks, so a page that settled in 50 µs
+        // — which is most pages, most of the time — then sat in `join` until the
+        // watchdog next woke up. **A 20 ms tax on every settle**, and on every
+        // agent `wait` besides, spent asleep. It read as script time in the
+        // profile and was not: the settle loop ran one round costing 50 µs
+        // inside a phase that measured 20.4 ms. It was intermittent, too, which
+        // is the worst way for a cost to present — a plain race between the body
+        // and the watchdog's first check, so half the runs looked fine.
+        let done = std::sync::Arc::new((
+            std::sync::Mutex::new(false),
+            std::sync::Condvar::new(),
+        ));
+        let watching = done.clone();
         let deadline = std::time::Instant::now() + budget;
 
         let watchdog = std::thread::Builder::new()
             .name("h5i-script-deadline".to_string())
             .spawn(move || {
-                while std::time::Instant::now() < deadline {
-                    if watching.load(std::sync::atomic::Ordering::Relaxed) {
-                        return false;
-                    }
-                    std::thread::sleep(Duration::from_millis(20));
+                let (lock, wake) = &*watching;
+                let mut finished = lock.lock().unwrap_or_else(|e| e.into_inner());
+                while !*finished {
+                    let Some(left) = deadline.checked_duration_since(std::time::Instant::now())
+                    else {
+                        break;
+                    };
+                    let (guard, _) = wake
+                        .wait_timeout(finished, left)
+                        .unwrap_or_else(|e| e.into_inner());
+                    finished = guard;
                 }
-                if watching.load(std::sync::atomic::Ordering::Relaxed) {
+                if *finished {
                     return false;
                 }
                 cancel.store(true, portable_atomic::Ordering::Relaxed);
@@ -1010,7 +1031,14 @@ impl Script {
             .ok();
 
         let out = body(self);
-        finished.store(true, std::sync::atomic::Ordering::Relaxed);
+        {
+            let (lock, wake) = &*done;
+            *lock.lock().unwrap_or_else(|e| e.into_inner()) = true;
+            // Under the lock's release, not before it: a watchdog notified while
+            // the flag was still false would go back to waiting out the budget,
+            // and the join below would wait with it.
+            wake.notify_all();
+        }
         let fired = watchdog.and_then(|w| w.join().ok()).unwrap_or(false);
 
         // Boa clears the flag itself when it acts on it, but a deadline that

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -955,6 +955,22 @@
       // element's constructor runs as `super()` with no arguments — the class
       // never sees the node it is being attached to — so the id arrives out of
       // band, exactly as the construction stack works in a real engine.
+      //
+      // Anything else with no id is a page calling `new Element()`, which DOM
+      // §4.4 and §4.9 say is not a thing: `Node`, `Element` and `CharacterData`
+      // are not constructible, and every engine throws here. Ours did not, and
+      // the result was the same defect `new Text("x")` had — `_id` became
+      // `null`, the primitives read that as node 0, and node 0 is the document.
+      // `new Element().textContent = "x"` wrote through to the document and
+      // took the process down with it.
+      //
+      // `Text` and `Comment` *are* constructible, and reach this with a real id
+      // because their own constructors make a node first.
+      if (typeof id !== "number" && upgrading === null) {
+        throw new TypeError(
+          "Illegal constructor: this interface is not constructible",
+        );
+      }
       this._id = id === undefined ? upgrading : id;
     }
 

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -14,6 +14,59 @@
 
   const api = globalThis.__h5i;
 
+  /// What a lazily parsed part of the prelude can reach.
+  ///
+  /// Most of this file is one closure, which is why it is cheap to write and
+  /// impossible to split: every binding is in scope everywhere and nothing
+  /// declares what it needs. A tier (see `TIERS` in `mod.rs`) is a *separate*
+  /// `eval`, so it has no way in, and this record is the door. Sections put
+  /// what a tier needs on it as they build it, and a tier takes only what it
+  /// names — which makes the dependency visible in both files instead of
+  /// implicit in a shared scope.
+  const internals = {};
+  Object.defineProperty(globalThis, "__h5iInternals", {
+    value: internals, writable: false, enumerable: false, configurable: false,
+  });
+
+  /// Names that stand for a source this realm has not parsed yet.
+  ///
+  /// Reading one loads its tier, which defines the name for real and takes this
+  /// accessor's place. The read is the trigger because reading is what a page
+  /// does first with an interface it wants: `new WebSocket(...)`, and
+  /// `typeof WebSocket === "function"` for the feature detection that comes
+  /// before it. Both arrive here, so both bring the file in.
+  ///
+  /// The property it leaves behind is WebIDL's shape for an interface object —
+  /// `{ writable: true, enumerable: false, configurable: true }` — which is
+  /// also what the enumerability pass at the end of this file would have given
+  /// it, and it has to be set here because that pass has long since run by the
+  /// time a tier loads.
+  function lazyGlobals(tier, names) {
+    const install = (name, value) => {
+      Object.defineProperty(globalThis, name, {
+        value, writable: true, enumerable: false, configurable: true,
+      });
+    };
+    for (const name of names) {
+      Object.defineProperty(globalThis, name, {
+        configurable: true,
+        enumerable: false,
+        get() {
+          __h5iTier(tier);
+          const now = Object.getOwnPropertyDescriptor(globalThis, name);
+          // A tier that loaded without defining what it was asked for would
+          // otherwise return this accessor's own undefined, for ever, and look
+          // exactly like an engine that never had the interface.
+          if (!now || now.get) {
+            throw new Error(`the ${tier} tier did not define ${name}`);
+          }
+          return now.value;
+        },
+        set(value) { install(name, value); },
+      });
+    }
+  }
+
   /// Tag name to the interface that tag gets, filled in once the
   /// interfaces below exist. A Map declared here rather than beside them
   /// because `constructElement` is defined above and would otherwise read
@@ -169,7 +222,11 @@
     if (existing) return existing;
     // Re-entrant construction — a custom element's constructor asking the
     // document for itself — gets a plain wrapper rather than recursing forever.
-    if (constructing.has(id)) return observed(new Element(id), "Element");
+    if (constructing.has(id)) {
+      const partial = new Element(id);
+      partial._kind = 1;
+      return partial;
+    }
 
 
     // The tree decides what a node is. A set of ids on this side only knew
@@ -185,10 +242,12 @@
     // Labelled by what the node actually is. Calling a text node "Element"
     // reported `Element.tagName` as missing when what happened was a page
     // reading `tagName` off a text node, where no engine has one.
+    // Read back by the sentinel at the end of every node's prototype chain,
+    // which is where a missing property is named. `label` above is what it
+    // says; this is how it reaches the trap without a wrapper per node.
     raw._kind = kind;
-    const node = observed(raw, label);
-    wrappers.set(id, node);
-    return node;
+    wrappers.set(id, raw);
+    return raw;
   }
 
   // ── custom elements ──────────────────────────────────────────────────────
@@ -561,8 +620,8 @@
     return out;
   }
 
-  // Wrap an object we own so that reading a property it does not have is
-  // *recorded* rather than silently undefined.
+  // Report a read that found nothing, without taxing the reads that find
+  // something.
   //
   // The corpus found the gap this closes. `missingApi` names globals, so
   // `WebSocket` reports itself — but a page reading `el.scrollIntoView` or
@@ -571,46 +630,68 @@
   // anywhere named the property. The measurement could not see what was left,
   // which is a different thing from nothing being left.
   //
-  // Only genuinely unknown names are recorded. Anything on the prototype chain
-  // is a property we implement, and anything the page itself assigned is an
-  // expando it expects to read back — both take the plain path, so a working
-  // page records nothing at all.
-  function observed(target, label) {
-    return new Proxy(target, {
+  // **This used to be a `Proxy` around every wrapper**, and the reporting was
+  // right while the price was not: a `get` trap in front of an object fires for
+  // every read, including the overwhelming majority that find exactly what they
+  // asked for. Measured at **799 ns of the 882 ns** a known property read cost
+  // against 82 ns for a plain object — a 10x tax on the hottest path in the
+  // engine, to name the reads that miss.
+  //
+  // A missing read already walks the whole prototype chain; a found one stops
+  // where it is found. So the reporting goes at the *end* of the chain instead
+  // of the front of the object, and the two cases separate themselves: a
+  // property we implement is found on a prototype and never reaches here, and
+  // only a genuine miss pays for a trap. Nothing about *what* is reported
+  // changes.
+  //
+  // It also removes a compromise the proxy form had to make. That trap passed
+  // the raw target as the receiver, so a getter the *page* defined on its own
+  // class ran with the proxy stripped and its own missing reads went
+  // unrecorded. A sentinel has no receiver to substitute: `receiver` is the
+  // object the page actually read from, always.
+
+  /// The labels `wrap` gives the three kinds of node it hands out.
+  const KIND_LABELS = { 1: "Element", 3: "Text", 8: "Comment" };
+
+  /// One stand-in per label, because building a fresh proxy per object was the
+  /// other half of the old cost: `el.classList` minted one on every read.
+  const sentinels = new Map();
+
+  /// Objects that *are* sentinels, so a second `observed` on the same target
+  /// stacks nothing.
+  const isSentinel = new Set();
+
+  function gapTrap(naming) {
+    return {
       get(object, property, receiver) {
+        // Found after all: the sentinel stands in for the tail of a real
+        // prototype chain, and `Object.prototype`'s members are still there.
         if (typeof property === "symbol" || property in object) {
-          // The raw target as receiver, not the proxy. A getter invoked with
-          // the proxy as `this` pays another trap for every `this._id` it
-          // reads, so each of our own accessors cost two — `nodeType` was
-          // 2.15 µs for what is a field lookup. Passing the target takes the
-          // hot properties to 0.85 µs.
-          //
-          // What it narrows: a getter *defined by the page* on its own class
-          // runs with the target as `this`, so an unknown property read inside
-          // one is not reported. Methods are unaffected — `el.method()` still
-          // calls with the proxy as `this` — and the reporting that has found
-          // real bugs has always been about properties the page reads *off* a
-          // node, which is unchanged.
-          return Reflect.get(object, property, object);
+          return Reflect.get(object, property, receiver);
         }
         // `then` is probed by the promise machinery on anything it is handed;
         // recording it would report a missing API every time a node passed
         // through an await.
         if (property === "then") return undefined;
 
-        // A gap is only a gap if a real browser would have answered. Reading
-        // `tagName` off a text node gets undefined in every engine there is —
-        // reporting it would send us building something that does not exist,
-        // and the corpus did exactly that until this rule was written.
-        if (label !== "Element" && property in Element.prototype) return undefined;
-
         // Nor is a page's own bookkeeping. No web platform property begins with
         // an underscore or a dollar; frameworks' private fields routinely do.
         // Solid reads `document._$DX_DELEGATE` before it sets it, and the list
         // an agent reads carried that as something this engine was missing.
+        //
+        // First, and not only for tidiness: `naming` below reads `_kind` off
+        // the receiver, and a receiver without one would come back here for
+        // that read. This rule is what makes that terminate.
         const name = String(property);
         const first = name.charCodeAt(0);
-        if (first === 95 || first === 36) return undefined;
+        if (first === 95 || first === 36) {
+          // Ours, and therefore a cost rather than a gap: see
+          // `declareInternals`. Counted only when a test asks, because the
+          // answer to "did one of our own reads walk the whole chain" is
+          // otherwise invisible — it is undefined either way.
+          if (globalThis.__h5iReportInternalMisses) api.unsupported(`internal miss: ${name}`);
+          return undefined;
+        }
 
         // Nor is a generated key. jQuery and Sizzle stamp elements with names
         // like `jQuery360062973586668224961` and `sizzle1786301869537`, read
@@ -620,10 +701,83 @@
         // that long, because it would have to be typed by a person.
         if (/\d{6}/.test(name)) return undefined;
 
-        api.unsupported(`${label}.${String(property)}`);
+        // Something we never handed out. A page's own `class Store extends
+        // EventTarget` reaches no sentinel, but a bare `new Element(id)` this
+        // file made for its own use does, and that is not an object the page
+        // asked us for.
+        const label = naming(receiver);
+        if (label === null || label === undefined) return undefined;
+
+        // A gap is only a gap if a real browser would have answered. Reading
+        // `tagName` off a text node gets undefined in every engine there is —
+        // reporting it would send us building something that does not exist,
+        // and the corpus did exactly that until this rule was written.
+        if (label !== "Element" && property in Element.prototype) return undefined;
+
+        api.unsupported(`${label}.${name}`);
         return undefined;
       },
-    });
+    };
+  }
+
+  /// The stand-in that goes where `proto` was.
+  ///
+  /// Its target is an empty object *over* `proto` rather than `proto` itself,
+  /// which is what keeps `instanceof` honest: a proxy reports its target's
+  /// prototype, so the real chain continues through it instead of ending at it.
+  function gapSentinel(proto, label) {
+    const naming = typeof label === "function" ? label : () => label;
+    const found = sentinels.get(label);
+    if (found !== undefined && Object.getPrototypeOf(found) === proto) return found;
+    const sentinel = new Proxy(Object.create(proto), gapTrap(naming));
+    isSentinel.add(sentinel);
+    if (found === undefined) sentinels.set(label, sentinel);
+    return sentinel;
+  }
+
+  /// Watch one object: for the singletons this file builds as literals, where
+  /// every property it really has is an own property and the sentinel is
+  /// reached only by a read that missed.
+  function observed(target, label) {
+    const proto = Object.getPrototypeOf(target);
+    if (isSentinel.has(proto)) return target;
+    Object.setPrototypeOf(target, gapSentinel(proto, label));
+    return target;
+  }
+
+  /// Declare the fields this file sets only sometimes.
+  ///
+  /// `get tagName()` reads `this._nsuri` to find out whether the element came
+  /// from `createElementNS`, and for everything the parser made it never did.
+  /// That read found nothing on the instance, nothing on any prototype, and
+  /// arrived at the sentinel — so **the engine was paying a trap to ask itself
+  /// a question about its own bookkeeping**, on the hottest accessor there is.
+  /// It measured 1415 ns against the 196 ns the underlying native call costs.
+  ///
+  /// A value of `undefined` on the prototype answers the same question at the
+  /// first hop. Writable, because an instance that *does* have a namespace
+  /// assigns over it, and a non-writable prototype property would make that
+  /// assignment fail. Non-enumerable, because these are machinery and nothing
+  /// that walks an interface should see them.
+  ///
+  /// `an_internal_read_never_reaches_the_sentinel` is the guard: add a field
+  /// like this and forget to declare it, and that test says so.
+  function declareInternals(proto, names) {
+    for (const name of names) {
+      Object.defineProperty(proto, name, {
+        value: undefined, writable: true, enumerable: false, configurable: true,
+      });
+    }
+  }
+
+  /// Watch every instance of a class, once, by putting the sentinel at the end
+  /// of the class's own chain. The per-instance form would sit *above* the
+  /// instance and below the prototype holding its methods, which puts a trap
+  /// back in front of every method call — the cost this rewrite removes.
+  function observedClass(Interface, label) {
+    const proto = Object.getPrototypeOf(Interface.prototype);
+    if (isSentinel.has(proto)) return;
+    Object.setPrototypeOf(Interface.prototype, gapSentinel(proto, label));
   }
 
   // `class` is the famous one, but `rel` is a token list too, and so are
@@ -1482,7 +1636,17 @@
       if (this._nsuri !== undefined && this._nsuri !== "http://www.w3.org/1999/xhtml") {
         return this._prefix ? `${this._prefix}:${this._localName}` : this._localName;
       }
-      return api.tagName(this._id);
+      // Remembered on the wrapper, because a native call costs ~150 ns of
+      // dispatch however little it does at the end of it — and this is the
+      // most-read property in the engine. The prelude alone branches on it a
+      // dozen times (`=== "SCRIPT"`, `=== "TEMPLATE"`, `=== "TEXTAREA"`), each
+      // of those a round trip into Rust for an answer that cannot change: an
+      // element's tag is fixed when the element is made.
+      //
+      // The same bet `_kind` already makes, and it stands or falls with it: a
+      // wrapper is keyed by node id and kept, so both are wrong together if a
+      // freed id is ever handed to a new node.
+      return this._tag ?? (this._tag = api.tagName(this._id));
     }
     get nodeName() { return this.tagName; }
     get children() { return collection(this.childNodes.filter((n) => n.nodeType === 1), "HTMLCollection"); }
@@ -1544,7 +1708,7 @@
       // [SameObject]: the identical list every read — pages compare them.
       if (!this.__h5iClassList) {
         this.__h5iClassList =
-          observed(DOMTokenList._indexed(new DOMTokenList(this, "class")), "DOMTokenList");
+          DOMTokenList._indexed(new DOMTokenList(this, "class"));
       }
       return this.__h5iClassList;
     }
@@ -1552,7 +1716,7 @@
     get relList() {
       if (!this.__h5iRelList) {
         this.__h5iRelList =
-          observed(DOMTokenList._indexed(new DOMTokenList(this, "rel")), "DOMTokenList");
+          DOMTokenList._indexed(new DOMTokenList(this, "rel"));
       }
       return this.__h5iRelList;
     }
@@ -5527,189 +5691,12 @@
   // until a Blitz release depends on stylo >= 0.20 (see ROADMAP §B22.1).
   const HAS_PATTERN = /:has\(/i;
 
-  function rawAddClass(id, cls) {
-    const original = api.getAttr(id, "class");
-    api.setAttr(id, "class", original ? `${original} ${cls}` : cls);
-    return () => {
-      if (original === null) api.removeAttr(id, "class");
-      else api.setAttr(id, "class", original);
-    };
-  }
-
-  function splitTopLevelCommas(text) {
-    const parts = [];
-    let depth = 0;
-    let current = "";
-    for (const ch of text) {
-      if (ch === "(" || ch === "[") depth += 1;
-      else if (ch === ")" || ch === "]") depth -= 1;
-      if (ch === "," && depth === 0) {
-        parts.push(current);
-        current = "";
-      } else current += ch;
-    }
-    parts.push(current);
-    return parts;
-  }
-
-  /// Split one complex selector into `[combinator, compound]` pairs at the
-  /// top level: `"> p b"` becomes `[[">", "p"], [" ", "b"]]`. Brackets and
-  /// parens shield their contents, so `a[title="> x"]` stays one compound.
-  function splitRelativePairs(arg) {
-    const pairs = [];
-    let combinator = " ";
-    let current = "";
-    let depth = 0;
-    const flush = () => {
-      if (current !== "") {
-        pairs.push([combinator, current]);
-        current = "";
-        combinator = " ";
-      }
-    };
-    for (const ch of arg) {
-      if (ch === "(" || ch === "[") depth += 1;
-      else if (ch === ")" || ch === "]") depth -= 1;
-      if (depth === 0 && (ch === ">" || ch === "+" || ch === "~")) {
-        flush();
-        combinator = ch;
-      } else if (depth === 0 && /\s/.test(ch)) {
-        flush();
-      } else {
-        current += ch;
-      }
-    }
-    flush();
-    return pairs;
-  }
-
-  /// Does `el` have a relative match for the pair chain? Evaluated locally —
-  /// children for `>`, the sibling walk for `+`/`~`, a scoped query for the
-  /// descendant hop — so the cost is the neighbourhood actually inspected,
-  /// not a document-wide probe per candidate (which measured 244ms against
-  /// this version's ~1ms on a 2,000-node page).
-  function relativePairsHold(el, pairs, index) {
-    if (index >= pairs.length) return true;
-    const [combinator, compound] = pairs[index];
-    const step = (candidate) =>
-      candidate.matches(compound) && relativePairsHold(candidate, pairs, index + 1);
-    if (combinator === ">") {
-      for (const child of el.children) if (step(child)) return true;
-      return false;
-    }
-    if (combinator === "+") {
-      const next = el.nextElementSibling;
-      return next !== null && step(next);
-    }
-    if (combinator === "~") {
-      for (let n = el.nextElementSibling; n; n = n.nextElementSibling) {
-        if (step(n)) return true;
-      }
-      return false;
-    }
-    for (const found of el.querySelectorAll(compound)) {
-      if (relativePairsHold(found, pairs, index + 1)) return true;
-    }
-    return false;
-  }
-
-  /// Rewrite every `:has(ARG)` in `text` to a marker class, tagging the
-  /// elements that match. Returns the rewritten selector and the cleanup
-  /// that removes every marker.
-  function prepareHasSelector(text) {
-    const cleanups = [];
-    const cleanup = () => {
-      for (const undo of cleanups) undo();
-    };
-    try {
-      let out = "";
-      let i = 0;
-      let group = 0;
-      const lower = text.toLowerCase();
-      while (i < text.length) {
-        const at = lower.indexOf(":has(", i);
-        if (at === -1) {
-          out += text.slice(i);
-          break;
-        }
-        out += text.slice(i, at);
-        let depth = 1;
-        let j = at + 5;
-        while (j < text.length && depth > 0) {
-          if (text[j] === "(") depth += 1;
-          else if (text[j] === ")") depth -= 1;
-          j += 1;
-        }
-        if (depth !== 0) {
-          throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
-        }
-        const argText = text.slice(at + 5, j - 1);
-        if (HAS_PATTERN.test(argText)) {
-          // `:has()` may not nest, per the spec's own grammar.
-          throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
-        }
-        const args = splitTopLevelCommas(argText).map((s) => s.trim()).filter(Boolean);
-        if (args.length === 0) {
-          throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
-        }
-        // Validate each argument once, as the complex selector it is.
-        for (const arg of args) {
-          if (!api.validSelector(arg.replace(/^[>+~]\s*/, ""))) {
-            throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
-          }
-        }
-        const marker = `__h5i_has_${group}__`;
-        group += 1;
-        const tagged = new Set();
-        for (const arg of args) {
-          if (/^[>+~]/.test(arg)) {
-            // A leading combinator is evaluated *from the matches inward*:
-            // one engine query finds every element matching the first
-            // compound, the rest of the chain is verified locally from each,
-            // and the anchor falls out of the combinator — the parent for
-            // `>`, the previous sibling for `+`, every preceding sibling for
-            // `~`. No per-candidate document scan: this is what took the
-            // worst case from 244ms to ~2ms on a 2,000-node page.
-            const pairs = splitRelativePairs(arg);
-            const [combinator, first] = pairs[0];
-            for (const id of api.queryAll(first, 0)) {
-              const m = wrap(id);
-              if (!m || !relativePairsHold(m, pairs, 1)) continue;
-              if (combinator === ">") {
-                const parent = api.parent(id);
-                if (parent !== null && parent !== undefined) tagged.add(parent);
-              } else if (combinator === "+") {
-                const previous = m.previousElementSibling;
-                if (previous) tagged.add(previous._id);
-              } else {
-                for (let n = m.previousElementSibling; n; n = n.previousElementSibling) {
-                  tagged.add(n._id);
-                }
-              }
-            }
-          } else {
-            // The descendant form has a fast path: every strict ancestor of
-            // a match "has" it, because a scoped query only constrains the
-            // subject to the scope's subtree.
-            for (const id of api.queryAll(arg, 0)) {
-              for (let p = api.parent(id); p !== null && p !== undefined; p = api.parent(p)) {
-                tagged.add(p);
-              }
-            }
-          }
-        }
-        for (const id of tagged) {
-          if (api.nodeKind(id) === 1) cleanups.push(rawAddClass(id, marker));
-        }
-        out += `.${marker}`;
-        i = j;
-      }
-      return { rewritten: out, cleanup };
-    } catch (error) {
-      cleanup();
-      throw error;
-    }
-  }
+  // The evaluator itself is in `prelude/has.js`, parsed the first time a
+  // selector actually contains `:has(`. Every selector-taking API already asked
+  // that question to decide whether it needed any of this; now the same
+  // question decides whether the file exists yet.
+  internals.wrap = wrap;
+  internals.HAS_PATTERN = HAS_PATTERN;
 
   /// The wrapper every selector-taking API goes through: plain selectors go
   /// straight to `checkSelector`, `:has()` selectors get their markers for
@@ -5717,7 +5704,8 @@
   function withHasMarkers(selector, run) {
     const text = String(selector);
     if (!HAS_PATTERN.test(text)) return run(checkSelector(text));
-    const { rewritten, cleanup } = prepareHasSelector(text);
+    if (!internals.prepareHasSelector) __h5iTier("has");
+    const { rewritten, cleanup } = internals.prepareHasSelector(text);
     try {
       return run(checkSelector(rewritten));
     } finally {
@@ -7408,8 +7396,38 @@
     toString() { return this._range ? this._range.toString() : ""; }
   }
 
+  // ── what this file hands out is watched, once ────────────────────────────
+  //
+  // Four classes rather than four objects per read. The sentinel goes at the
+  // end of each class's own prototype chain, so a method or accessor the class
+  // really has is found before anything is trapped, and only a read that missed
+  // arrives at the report. See `observedClass`.
+  //
+  // `Node` covers every node, because `Element`, `Text` and `Comment` all
+  // descend from it — and its label comes from the receiver, since one chain
+  // ends three kinds of node and "reading `tagName` off a text node" has to
+  // stay distinguishable from reading it off an element.
+  internals.withStack = withStack;
+  observedClass(Node, (receiver) => KIND_LABELS[receiver._kind] ?? null);
+  declareInternals(Node.prototype, ["_kind"]);
+  declareInternals(Element.prototype, [
+    // Set by `createElementNS`, and by nothing the parser does.
+    "_nsuri", "_prefix", "_localName",
+    // The tag, remembered on first read: see `get tagName`.
+    "_tag",
+    // The token list a `classList` read memoises on its element.
+    "__h5iClassList",
+    // A form control's dirty overlay: present only once something set it.
+    "_checked", "_value", "_selected",
+    // The shadow root an element may have been given, and usually was not.
+    "_shadow",
+  ]);
+  observedClass(DOMTokenList, "DOMTokenList");
+  observedClass(Range, "Range");
+  observedClass(Selection, "Selection");
+
   const selection = new Selection();
-  function getSelection() { return observed(selection, "Selection"); }
+  function getSelection() { return selection; }
 
   /// `document.execCommand`, for the commands this engine can actually carry out.
   ///
@@ -7660,7 +7678,7 @@
     open() { return document; },
     close() {},
 
-    createRange() { return observed(new Range(), "Range"); },
+    createRange() { return new Range(); },
     getSelection() { return getSelection(); },
 
     /// The commands this engine carries out, and no others.
@@ -7977,6 +7995,11 @@
   // Same rule for `document`: a page reading `document.activeElement` or
   // `document.fonts` should produce a named gap, not a silent undefined.
   const document = observed(documentImpl, "document");
+  // The document is passed wherever a node is, and every one of those paths
+  // reads `._id` off it. It does not have one — there is no id that means "the
+  // document" to the primitives — so each of those reads walked its whole chain
+  // into the sentinel. 105 of them in one ordinary page's worth of work.
+  declareInternals(documentImpl, ["_id"]);
 
   const console = {
     log: (...a) => api.log("log", a.map(render).join(" ")),
@@ -8177,216 +8200,22 @@
   // true for a stub cost three sites their entire bundle. This is a working
   // object over a real connection, or the identifier is not defined at all.
   //
+  // **In its own source**, because a page that opens no socket should not parse
+  // it: `prelude/sockets.js`, reached by reading either name. `typeof
+  // WebSocket === "function"` still answers true — reading the name is what
+  // brings the file in — so the rule above is unchanged by the move.
+  //
   // Delivery is at settle-round boundaries rather than the instant a frame
   // lands, because the session has no pump at rest. See `socket_drain` in
   // dom_api.rs.
-  const openSockets = new Map(); // id -> WebSocket
+  lazyGlobals("sockets", ["WebSocket", "EventSource"]);
 
-  class WebSocket extends EventTarget {
-    constructor(url, protocols) {
-      super();
-      if (arguments.length === 0) {
-        throw new TypeError("WebSocket requires a url");
-      }
-      this._url = String(url);
-      this._protocols = protocols;
-      this.readyState = WebSocket.CONNECTING;
-      this.bufferedAmount = 0;
-      this.extensions = "";
-      this.protocol = "";
-      this.binaryType = "blob";
-      this.onopen = null;
-      this.onmessage = null;
-      this.onclose = null;
-      this.onerror = null;
-      // Throws if the policy refused it, which is what a page sees for any
-      // other refused request too.
-      this._id = api.socketOpen(this._url);
-      openSockets.set(this._id, this);
-    }
-
-    get url() {
-      return this._url;
-    }
-
-    send(data) {
-      if (this.readyState === WebSocket.CONNECTING) {
-        throw new DOMException_("still connecting", "InvalidStateError");
-      }
-      if (this.readyState !== WebSocket.OPEN) return;
-      api.socketSend(this._id, typeof data === "string" ? data : String(data));
-    }
-
-    close(code, reason) {
-      if (this.readyState === WebSocket.CLOSED) return;
-      this.readyState = WebSocket.CLOSING;
-      api.socketClose(this._id);
-      openSockets.delete(this._id);
-      this.readyState = WebSocket.CLOSED;
-      const event = new Event("close");
-      event.code = code === undefined ? 1000 : code;
-      event.reason = reason === undefined ? "" : String(reason);
-      event.wasClean = true;
-      this._fire("close", event);
-    }
-
-    _fire(kind, event) {
-      const handler = this["on" + kind];
-      if (typeof handler === "function") {
-        try {
-          handler.call(this, event);
-        } catch (error) {
-          console.error("websocket " + kind + " handler threw: " + withStack(error));
-        }
-      }
-      this.dispatchEvent(event);
-    }
-  }
-  WebSocket.CONNECTING = 0;
-  WebSocket.OPEN = 1;
-  WebSocket.CLOSING = 2;
-  WebSocket.CLOSED = 3;
-
-  // A minimal DOMException stand-in, only where the spec names one.
-  function DOMException_(message, name) {
-    const error = new Error(message);
-    error.name = name;
-    return error;
-  }
-
-  // Collect what arrived and turn it into events. Returns how many were
-  // delivered, so the settle loop knows whether the round did any work: a
-  // socket that is merely *open* must not hold the page busy forever, and one
-  // that delivered a message should get another round.
-  // `EventSource`, over the same delivery mechanism. Real, or absent — the
-  // rule above applies here too.
-  const openStreams = new Map(); // id -> EventSource
-
-  class EventSource extends EventTarget {
-    constructor(url, init) {
-      super();
-      if (arguments.length === 0) {
-        throw new TypeError("EventSource requires a url");
-      }
-      this._url = String(url);
-      this.withCredentials = !!(init && init.withCredentials);
-      this.readyState = EventSource.CONNECTING;
-      this.onopen = null;
-      this.onmessage = null;
-      this.onerror = null;
-      this._id = api.sseOpen(this._url);
-      openStreams.set(this._id, this);
-    }
-
-    get url() {
-      return this._url;
-    }
-
-    close() {
-      if (this.readyState === EventSource.CLOSED) return;
-      api.sseClose(this._id);
-      openStreams.delete(this._id);
-      this.readyState = EventSource.CLOSED;
-    }
-
-    _fire(kind, event) {
-      const handler = this["on" + kind];
-      if (typeof handler === "function") {
-        try {
-          handler.call(this, event);
-        } catch (error) {
-          console.error("eventsource " + kind + " handler threw: " + withStack(error));
-        }
-      }
-      this.dispatchEvent(event);
-    }
-  }
-  EventSource.CONNECTING = 0;
-  EventSource.OPEN = 1;
-  EventSource.CLOSED = 2;
-
-  globalThis.WebSocket = WebSocket;
-  globalThis.EventSource = EventSource;
-
-  globalThis.__h5iDrainSockets = function () {
-    let delivered = 0;
-    for (const socket of Array.from(openSockets.values())) {
-      const events = api.socketDrain(socket._id);
-      for (const entry of events) {
-        const kind = entry[0];
-        const payload = entry[1];
-        delivered++;
-        if (kind === "open") {
-          socket.readyState = WebSocket.OPEN;
-          socket._fire("open", new Event("open"));
-        } else if (kind === "message") {
-          const event = new Event("message");
-          event.data = payload;
-          event.origin = socket._url;
-          socket._fire("message", event);
-        } else if (kind === "close") {
-          socket.readyState = WebSocket.CLOSED;
-          // Tell the engine too, not just this map. Dropping it only here left
-          // the Rust side holding the connection for the life of the page: the
-          // snapshot reported a phantom open socket forever, and every later
-          // `wait_for` polled in real time for the whole network budget
-          // because the engine still believed something might arrive.
-          api.socketClose(socket._id);
-          openSockets.delete(socket._id);
-          const event = new Event("close");
-          event.code = 1006;
-          event.reason = payload;
-          event.wasClean = false;
-          socket._fire("close", event);
-        } else if (kind === "error") {
-          const event = new Event("error");
-          event.message = payload;
-          socket._fire("error", event);
-        }
-      }
-    }
-
-    for (const stream of Array.from(openStreams.values())) {
-      const events = api.sseDrain(stream._id);
-      for (const entry of events) {
-        const kind = entry[0];
-        const payload = entry[1];
-        delivered++;
-        if (kind === "open") {
-          stream.readyState = EventSource.OPEN;
-          stream._fire("open", new Event("open"));
-        } else if (kind === "message") {
-          // The name arrives as its own field. Reading it out of the payload
-          // meant guessing, and a plain `data: one\ndata: two` was read as an
-          // event named `one` carrying `two`, so `onmessage` never fired.
-          const name = entry[2] || "message";
-          const event = new Event(name);
-          event.data = payload;
-          event.origin = stream._url;
-          stream._fire(name === "message" ? "message" : name, event);
-        } else if (kind === "close") {
-          stream.readyState = EventSource.CLOSED;
-          api.sseClose(stream._id);
-          openStreams.delete(stream._id);
-          const event = new Event("error");
-          event.message = payload;
-          stream._fire("error", event);
-        } else if (kind === "error") {
-          const event = new Event("error");
-          event.message = payload;
-          stream._fire("error", event);
-        }
-      }
-    }
-
-    return delivered;
-  };
-
-  /// How many long-lived connections this page has open, for the engine's own
-  /// reporting.
-  globalThis.__h5iOpenSockets = function () {
-    return openSockets.size + openStreams.size;
-  };
+  /// What the settle loop asks every round. A page that never opened a socket
+  /// has no sockets to drain, and answering that without loading the tier is
+  /// the whole point: `prelude/sockets.js` replaces both of these when it
+  /// arrives.
+  globalThis.__h5iDrainSockets = function () { return 0; };
+  globalThis.__h5iOpenSockets = function () { return 0; };
 
   globalThis.__h5iPendingTimers = function () {
     let pending = 0;
@@ -9660,56 +9489,19 @@
       FONT_FACE_RULE: 5, PAGE_RULE: 6, MARGIN_RULE: 9, NAMESPACE_RULE: 10,
       KEYFRAMES_RULE: 7, KEYFRAME_RULE: 8, SUPPORTS_RULE: 12,
     });
-    // ── WebIDL member polish ─────────────────────────────────────────────
+    // ── WebIDL member decoration ──────────────────────────────────────────
     //
-    // Three properties of every interface member that idlharness checks and
-    // class syntax gets wrong: members are enumerable, accessor functions are
-    // named `get x`/`set x`, and an accessor reached on the prototype object
-    // itself throws TypeError instead of running against nothing. The
-    // reflection tables already emit all three; this pass brings the members
-    // written as plain class accessors and methods up to the same contract.
-    // Underscore names are internal machinery and stay out of enumeration.
-    const polish = (Interface) => {
-      const proto = Interface && Interface.prototype;
-      if (!proto) return;
-      for (const key of Object.getOwnPropertyNames(proto)) {
-        if (key === "constructor" || key.startsWith("_")) continue;
-        const desc = Object.getOwnPropertyDescriptor(proto, key);
-        if (!desc.configurable) continue;
-        desc.enumerable = true;
-        if (desc.get) {
-          const inner = desc.get;
-          desc.get = function () {
-            // The WebIDL brand check: the prototype itself and any object
-            // that is not an instance of this interface both get the
-            // TypeError — `desc.get.call({})` is idlharness's own probe.
-            if (this === proto || !(this instanceof Interface)) {
-              throw new TypeError(`Illegal invocation: ${key} needs an instance`);
-            }
-            return inner.call(this);
-          };
-          Object.defineProperty(desc.get, "name", { value: `get ${key}` });
-        }
-        if (desc.set) {
-          const inner = desc.set;
-          desc.set = function (value) {
-            if (this === proto || !(this instanceof Interface)) {
-              throw new TypeError(`Illegal invocation: ${key} needs an instance`);
-            }
-            return inner.call(this, value);
-          };
-          Object.defineProperty(desc.set, "name", { value: `set ${key}` });
-        }
-        Object.defineProperty(proto, key, desc);
-      }
-    };
-    for (const Interface of [
+    // Its own source, parsed only when an instrument asks: see
+    // `prelude/conformance.js`. Called from *here* rather than after the
+    // prelude finishes because the decoration has to see the prototypes in the
+    // state the rest of this file leaves them in, and the interfaces it needs
+    // are closure bindings that a separately parsed source cannot reach.
+    internals.polishTargets = [
       EventTarget, Node, Element, Text, Comment, CharacterData,
       DocumentFragment, Range, Event, XMLHttpRequest, CSSRule,
-      ...new Set(TAG_CLASSES.values()),
-    ]) {
-      polish(Interface);
-    }
+    ];
+    internals.TAG_CLASSES = TAG_CLASSES;
+    if (globalThis.__h5iConformance) __h5iTier("conformance");
 
     defineConstants(DOMException, {
       INDEX_SIZE_ERR: 1, DOMSTRING_SIZE_ERR: 2, HIERARCHY_REQUEST_ERR: 3,

--- a/crates/h5i-browser-light/src/script/prelude.js
+++ b/crates/h5i-browser-light/src/script/prelude.js
@@ -216,6 +216,18 @@
     return knownDocumentNode;
   }
 
+  /// Tells "wrap the node that already has this id" apart from "a page called
+  /// `new Text('hello')`".
+  ///
+  /// `Text` and `Comment` are constructible interfaces — DOM §4.10 and §4.11
+  /// say a page may build one — and this file's own classes take a *node id* as
+  /// their first argument. Without a way to tell the two apart, `new Text("x")`
+  /// built a wrapper whose id was the string `"x"`, which the primitives
+  /// converted to 0, which is the document. The page got the document back
+  /// dressed as a text node, and appending it anywhere put the document inside
+  /// itself. See `would_cycle` in `dom_api.rs` for what that cost.
+  const FROM_ID = Symbol("h5i node id");
+
   function wrap(id) {
     if (id === null || id === undefined) return null;
     let existing = wrappers.get(id);
@@ -235,9 +247,9 @@
     let raw;
     let label;
     const kind = api.nodeKind(id);
-    if (kind === 8) { raw = new Comment(id); label = "Comment"; }
+    if (kind === 8) { raw = new Comment(id, FROM_ID); label = "Comment"; }
     else if (kind === 1) { raw = constructElement(id); label = "Element"; }
-    else { raw = new Text(id); label = "Text"; }
+    else { raw = new Text(id, FROM_ID); label = "Text"; }
 
     // Labelled by what the node actually is. Calling a text node "Element"
     // reported `Element.tagName` as missing when what happened was a page
@@ -1149,7 +1161,28 @@
       }
     }
 
+    /// DOM §4.2.3's first pre-insertion step: a node may not be put inside
+    /// itself or inside anything it already contains.
+    ///
+    /// **Before the detach, which is the whole point.** `dom_api.rs` refuses the
+    /// same thing, but by the time it is asked the node has been unlinked from
+    /// its parent and the ancestor relationship it would have seen is gone — so
+    /// the refusal there catches a raw primitive call and cannot catch this. The
+    /// two are not redundant; they cover different halves of the same rule.
+    _refuseIfAncestor(child) {
+      if (!child || child.nodeType === 11) return;
+      for (let at = this; at; at = at.parentNode) {
+        if (at === child || at._id === child._id) {
+          throw new DOMException(
+            "the new child contains the parent it was being put inside",
+            "HierarchyRequestError",
+          );
+        }
+      }
+    }
+
     appendChild(child) {
+      this._refuseIfAncestor(child);
       // Inserting a fragment inserts its children and leaves the fragment
       // behind, which is the whole reason a fragment exists.
       if (child && child.nodeType === 11) {
@@ -1170,6 +1203,7 @@
     }
     insertBefore(child, anchor) {
       if (!anchor) return this.appendChild(child);
+      this._refuseIfAncestor(child);
       // The spec's pre-insert step, and not a formality: without it the anchor
       // reaches blitz, which inserts relative to the anchor's parent and
       // unwraps it. A caller that passes a node from somewhere else is asking
@@ -1594,6 +1628,13 @@
   }
 
   class Text extends CharacterData {
+    /// `new Text(data)`, which is a page building a node, unless `FROM_ID` says
+    /// this is the file wrapping one it already has.
+    constructor(data, token) {
+      super(token === FROM_ID
+        ? data
+        : api.createText(data === undefined ? "" : String(data)));
+    }
     get wholeText() {
       // Adjacent text nodes read as one run, which is what the property means.
       let text = "";
@@ -1622,6 +1663,12 @@
   // A real comment node, not a text node wearing a hat: a marker that showed up
   // in `textContent` would appear in the outline an agent reads.
   class Comment extends CharacterData {
+    /// Same rule as `Text`: `new Comment(data)` is a page building a node.
+    constructor(data, token) {
+      super(token === FROM_ID
+        ? data
+        : api.createComment(data === undefined ? "" : String(data)));
+    }
     get nodeType() { return 8; }
     get nodeValue() { return api.getText(this._id); }
   }

--- a/crates/h5i-browser-light/src/script/prelude/conformance.js
+++ b/crates/h5i-browser-light/src/script/prelude/conformance.js
@@ -1,0 +1,71 @@
+// The WebIDL member decoration, which only a conformance harness observes.
+//
+// Parsed and evaluated only when `RealmOptions::webidl_conformance` is set,
+// which `wpt/run.py` sets and nothing else does. It lived in the core prelude
+// until it was measured: rebuilding every descriptor of every interface
+// prototype cost **15 ms of the 83 ms** a realm took, on every page, for two
+// properties no page reads. See `TIERS` in `mod.rs` for the rule this file is
+// an instance of.
+//
+// A separate `eval` has no way into the core's closure, so what it needs
+// arrives through `__h5iInternals`: the interfaces that are not reachable by
+// name at the point this runs, and the tag-to-interface map.
+(function () {
+  "use strict";
+
+  const internals = globalThis.__h5iInternals;
+
+  // ── WebIDL member polish ─────────────────────────────────────────────
+  //
+  // Two properties of every interface member that idlharness checks and class
+  // syntax does not give: members are enumerable, and an accessor reached on
+  // the prototype object itself throws TypeError instead of running against
+  // nothing. The reflection tables already emit both; this pass brings the
+  // members written as plain class accessors and methods up to the same
+  // contract. Underscore names are internal machinery and stay out of
+  // enumeration.
+  //
+  // The `get x`/`set x` naming below is *maintenance*, not one of the two:
+  // Boa already names class accessors that way, and rebuilding the descriptor
+  // here would lose the name if it were not put back.
+  const polish = (Interface) => {
+    const proto = Interface && Interface.prototype;
+    if (!proto) return;
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (key === "constructor" || key.startsWith("_")) continue;
+      const desc = Object.getOwnPropertyDescriptor(proto, key);
+      if (!desc.configurable) continue;
+      desc.enumerable = true;
+      if (desc.get) {
+        const inner = desc.get;
+        desc.get = function () {
+          // The WebIDL brand check: the prototype itself and any object
+          // that is not an instance of this interface both get the
+          // TypeError — `desc.get.call({})` is idlharness's own probe.
+          if (this === proto || !(this instanceof Interface)) {
+            throw new TypeError(`Illegal invocation: ${key} needs an instance`);
+          }
+          return inner.call(this);
+        };
+        Object.defineProperty(desc.get, "name", { value: `get ${key}` });
+      }
+      if (desc.set) {
+        const inner = desc.set;
+        desc.set = function (value) {
+          if (this === proto || !(this instanceof Interface)) {
+            throw new TypeError(`Illegal invocation: ${key} needs an instance`);
+          }
+          return inner.call(this, value);
+        };
+        Object.defineProperty(desc.set, "name", { value: `set ${key}` });
+      }
+      Object.defineProperty(proto, key, desc);
+    }
+  };
+  for (const Interface of [
+    ...internals.polishTargets,
+    ...new Set(internals.TAG_CLASSES.values()),
+  ]) {
+    polish(Interface);
+  }
+})();

--- a/crates/h5i-browser-light/src/script/prelude/has.js
+++ b/crates/h5i-browser-light/src/script/prelude/has.js
@@ -1,0 +1,203 @@
+// `:has()`, evaluated here because the engine's selector parser refuses it.
+//
+// Its own source, parsed the first time a selector containing `:has(` reaches
+// `withHasMarkers` — which for most pages is never. The trigger is exact: the
+// core already tests every selector against `HAS_PATTERN` to decide whether any
+// of this is needed, so the test that used to choose between two code paths now
+// chooses whether there is a second path yet.
+//
+// See `TIERS` in `mod.rs` for the rule, and the core's `withHasMarkers` for
+// what calls into this.
+(function () {
+  "use strict";
+
+  const api = globalThis.__h5i;
+  const internals = globalThis.__h5iInternals;
+  const { wrap, HAS_PATTERN } = internals;
+
+  function rawAddClass(id, cls) {
+    const original = api.getAttr(id, "class");
+    api.setAttr(id, "class", original ? `${original} ${cls}` : cls);
+    return () => {
+      if (original === null) api.removeAttr(id, "class");
+      else api.setAttr(id, "class", original);
+    };
+  }
+
+  function splitTopLevelCommas(text) {
+    const parts = [];
+    let depth = 0;
+    let current = "";
+    for (const ch of text) {
+      if (ch === "(" || ch === "[") depth += 1;
+      else if (ch === ")" || ch === "]") depth -= 1;
+      if (ch === "," && depth === 0) {
+        parts.push(current);
+        current = "";
+      } else current += ch;
+    }
+    parts.push(current);
+    return parts;
+  }
+
+  /// Split one complex selector into `[combinator, compound]` pairs at the
+  /// top level: `"> p b"` becomes `[[">", "p"], [" ", "b"]]`. Brackets and
+  /// parens shield their contents, so `a[title="> x"]` stays one compound.
+  function splitRelativePairs(arg) {
+    const pairs = [];
+    let combinator = " ";
+    let current = "";
+    let depth = 0;
+    const flush = () => {
+      if (current !== "") {
+        pairs.push([combinator, current]);
+        current = "";
+        combinator = " ";
+      }
+    };
+    for (const ch of arg) {
+      if (ch === "(" || ch === "[") depth += 1;
+      else if (ch === ")" || ch === "]") depth -= 1;
+      if (depth === 0 && (ch === ">" || ch === "+" || ch === "~")) {
+        flush();
+        combinator = ch;
+      } else if (depth === 0 && /\s/.test(ch)) {
+        flush();
+      } else {
+        current += ch;
+      }
+    }
+    flush();
+    return pairs;
+  }
+
+  /// Does `el` have a relative match for the pair chain? Evaluated locally —
+  /// children for `>`, the sibling walk for `+`/`~`, a scoped query for the
+  /// descendant hop — so the cost is the neighbourhood actually inspected,
+  /// not a document-wide probe per candidate (which measured 244ms against
+  /// this version's ~1ms on a 2,000-node page).
+  function relativePairsHold(el, pairs, index) {
+    if (index >= pairs.length) return true;
+    const [combinator, compound] = pairs[index];
+    const step = (candidate) =>
+      candidate.matches(compound) && relativePairsHold(candidate, pairs, index + 1);
+    if (combinator === ">") {
+      for (const child of el.children) if (step(child)) return true;
+      return false;
+    }
+    if (combinator === "+") {
+      const next = el.nextElementSibling;
+      return next !== null && step(next);
+    }
+    if (combinator === "~") {
+      for (let n = el.nextElementSibling; n; n = n.nextElementSibling) {
+        if (step(n)) return true;
+      }
+      return false;
+    }
+    for (const found of el.querySelectorAll(compound)) {
+      if (relativePairsHold(found, pairs, index + 1)) return true;
+    }
+    return false;
+  }
+
+  /// Rewrite every `:has(ARG)` in `text` to a marker class, tagging the
+  /// elements that match. Returns the rewritten selector and the cleanup
+  /// that removes every marker.
+  function prepareHasSelector(text) {
+    const cleanups = [];
+    const cleanup = () => {
+      for (const undo of cleanups) undo();
+    };
+    try {
+      let out = "";
+      let i = 0;
+      let group = 0;
+      const lower = text.toLowerCase();
+      while (i < text.length) {
+        const at = lower.indexOf(":has(", i);
+        if (at === -1) {
+          out += text.slice(i);
+          break;
+        }
+        out += text.slice(i, at);
+        let depth = 1;
+        let j = at + 5;
+        while (j < text.length && depth > 0) {
+          if (text[j] === "(") depth += 1;
+          else if (text[j] === ")") depth -= 1;
+          j += 1;
+        }
+        if (depth !== 0) {
+          throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
+        }
+        const argText = text.slice(at + 5, j - 1);
+        if (HAS_PATTERN.test(argText)) {
+          // `:has()` may not nest, per the spec's own grammar.
+          throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
+        }
+        const args = splitTopLevelCommas(argText).map((s) => s.trim()).filter(Boolean);
+        if (args.length === 0) {
+          throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
+        }
+        // Validate each argument once, as the complex selector it is.
+        for (const arg of args) {
+          if (!api.validSelector(arg.replace(/^[>+~]\s*/, ""))) {
+            throw new DOMException(`${text} is not a valid selector`, "SyntaxError");
+          }
+        }
+        const marker = `__h5i_has_${group}__`;
+        group += 1;
+        const tagged = new Set();
+        for (const arg of args) {
+          if (/^[>+~]/.test(arg)) {
+            // A leading combinator is evaluated *from the matches inward*:
+            // one engine query finds every element matching the first
+            // compound, the rest of the chain is verified locally from each,
+            // and the anchor falls out of the combinator — the parent for
+            // `>`, the previous sibling for `+`, every preceding sibling for
+            // `~`. No per-candidate document scan: this is what took the
+            // worst case from 244ms to ~2ms on a 2,000-node page.
+            const pairs = splitRelativePairs(arg);
+            const [combinator, first] = pairs[0];
+            for (const id of api.queryAll(first, 0)) {
+              const m = wrap(id);
+              if (!m || !relativePairsHold(m, pairs, 1)) continue;
+              if (combinator === ">") {
+                const parent = api.parent(id);
+                if (parent !== null && parent !== undefined) tagged.add(parent);
+              } else if (combinator === "+") {
+                const previous = m.previousElementSibling;
+                if (previous) tagged.add(previous._id);
+              } else {
+                for (let n = m.previousElementSibling; n; n = n.previousElementSibling) {
+                  tagged.add(n._id);
+                }
+              }
+            }
+          } else {
+            // The descendant form has a fast path: every strict ancestor of
+            // a match "has" it, because a scoped query only constrains the
+            // subject to the scope's subtree.
+            for (const id of api.queryAll(arg, 0)) {
+              for (let p = api.parent(id); p !== null && p !== undefined; p = api.parent(p)) {
+                tagged.add(p);
+              }
+            }
+          }
+        }
+        for (const id of tagged) {
+          if (api.nodeKind(id) === 1) cleanups.push(rawAddClass(id, marker));
+        }
+        out += `.${marker}`;
+        i = j;
+      }
+      return { rewritten: out, cleanup };
+    } catch (error) {
+      cleanup();
+      throw error;
+    }
+  }
+
+  internals.prepareHasSelector = prepareHasSelector;
+})();

--- a/crates/h5i-browser-light/src/script/prelude/sockets.js
+++ b/crates/h5i-browser-light/src/script/prelude/sockets.js
@@ -1,0 +1,234 @@
+// Long-lived connections: `WebSocket` and `EventSource`.
+//
+// Its own source, parsed only when a page reads one of those two names. Most
+// pages read neither, and the ones that do pay a few hundred microseconds to
+// parse this at the moment they ask — see `TIERS` in `mod.rs` for the rule.
+//
+// The drain hooks below *replace* the do-nothing versions the core installs.
+// A page with no sockets has nothing to deliver, and the settle loop asking it
+// every round is how the core can answer without this file being here.
+(function () {
+  "use strict";
+
+  const api = globalThis.__h5i;
+  const { withStack } = globalThis.__h5iInternals;
+  const { Event, EventTarget, console } = globalThis;
+
+  // ── websockets ─────────────────────────────────────────────────────────
+  //
+  // Real, or absent. The rule at the top of the "absent, not stubbed" section
+  // applies here more than anywhere: `typeof WebSocket === "function"` answering
+  // true for a stub cost three sites their entire bundle. This is a working
+  // object over a real connection, or the identifier is not defined at all.
+  //
+  // Delivery is at settle-round boundaries rather than the instant a frame
+  // lands, because the session has no pump at rest. See `socket_drain` in
+  // dom_api.rs.
+  const openSockets = new Map(); // id -> WebSocket
+
+  class WebSocket extends EventTarget {
+    constructor(url, protocols) {
+      super();
+      if (arguments.length === 0) {
+        throw new TypeError("WebSocket requires a url");
+      }
+      this._url = String(url);
+      this._protocols = protocols;
+      this.readyState = WebSocket.CONNECTING;
+      this.bufferedAmount = 0;
+      this.extensions = "";
+      this.protocol = "";
+      this.binaryType = "blob";
+      this.onopen = null;
+      this.onmessage = null;
+      this.onclose = null;
+      this.onerror = null;
+      // Throws if the policy refused it, which is what a page sees for any
+      // other refused request too.
+      this._id = api.socketOpen(this._url);
+      openSockets.set(this._id, this);
+    }
+
+    get url() {
+      return this._url;
+    }
+
+    send(data) {
+      if (this.readyState === WebSocket.CONNECTING) {
+        throw new DOMException_("still connecting", "InvalidStateError");
+      }
+      if (this.readyState !== WebSocket.OPEN) return;
+      api.socketSend(this._id, typeof data === "string" ? data : String(data));
+    }
+
+    close(code, reason) {
+      if (this.readyState === WebSocket.CLOSED) return;
+      this.readyState = WebSocket.CLOSING;
+      api.socketClose(this._id);
+      openSockets.delete(this._id);
+      this.readyState = WebSocket.CLOSED;
+      const event = new Event("close");
+      event.code = code === undefined ? 1000 : code;
+      event.reason = reason === undefined ? "" : String(reason);
+      event.wasClean = true;
+      this._fire("close", event);
+    }
+
+    _fire(kind, event) {
+      const handler = this["on" + kind];
+      if (typeof handler === "function") {
+        try {
+          handler.call(this, event);
+        } catch (error) {
+          console.error("websocket " + kind + " handler threw: " + withStack(error));
+        }
+      }
+      this.dispatchEvent(event);
+    }
+  }
+  WebSocket.CONNECTING = 0;
+  WebSocket.OPEN = 1;
+  WebSocket.CLOSING = 2;
+  WebSocket.CLOSED = 3;
+
+  // A minimal DOMException stand-in, only where the spec names one.
+  function DOMException_(message, name) {
+    const error = new Error(message);
+    error.name = name;
+    return error;
+  }
+
+  // Collect what arrived and turn it into events. Returns how many were
+  // delivered, so the settle loop knows whether the round did any work: a
+  // socket that is merely *open* must not hold the page busy forever, and one
+  // that delivered a message should get another round.
+  // `EventSource`, over the same delivery mechanism. Real, or absent — the
+  // rule above applies here too.
+  const openStreams = new Map(); // id -> EventSource
+
+  class EventSource extends EventTarget {
+    constructor(url, init) {
+      super();
+      if (arguments.length === 0) {
+        throw new TypeError("EventSource requires a url");
+      }
+      this._url = String(url);
+      this.withCredentials = !!(init && init.withCredentials);
+      this.readyState = EventSource.CONNECTING;
+      this.onopen = null;
+      this.onmessage = null;
+      this.onerror = null;
+      this._id = api.sseOpen(this._url);
+      openStreams.set(this._id, this);
+    }
+
+    get url() {
+      return this._url;
+    }
+
+    close() {
+      if (this.readyState === EventSource.CLOSED) return;
+      api.sseClose(this._id);
+      openStreams.delete(this._id);
+      this.readyState = EventSource.CLOSED;
+    }
+
+    _fire(kind, event) {
+      const handler = this["on" + kind];
+      if (typeof handler === "function") {
+        try {
+          handler.call(this, event);
+        } catch (error) {
+          console.error("eventsource " + kind + " handler threw: " + withStack(error));
+        }
+      }
+      this.dispatchEvent(event);
+    }
+  }
+  EventSource.CONNECTING = 0;
+  EventSource.OPEN = 1;
+  EventSource.CLOSED = 2;
+
+  globalThis.WebSocket = WebSocket;
+  globalThis.EventSource = EventSource;
+
+  globalThis.__h5iDrainSockets = function () {
+    let delivered = 0;
+    for (const socket of Array.from(openSockets.values())) {
+      const events = api.socketDrain(socket._id);
+      for (const entry of events) {
+        const kind = entry[0];
+        const payload = entry[1];
+        delivered++;
+        if (kind === "open") {
+          socket.readyState = WebSocket.OPEN;
+          socket._fire("open", new Event("open"));
+        } else if (kind === "message") {
+          const event = new Event("message");
+          event.data = payload;
+          event.origin = socket._url;
+          socket._fire("message", event);
+        } else if (kind === "close") {
+          socket.readyState = WebSocket.CLOSED;
+          // Tell the engine too, not just this map. Dropping it only here left
+          // the Rust side holding the connection for the life of the page: the
+          // snapshot reported a phantom open socket forever, and every later
+          // `wait_for` polled in real time for the whole network budget
+          // because the engine still believed something might arrive.
+          api.socketClose(socket._id);
+          openSockets.delete(socket._id);
+          const event = new Event("close");
+          event.code = 1006;
+          event.reason = payload;
+          event.wasClean = false;
+          socket._fire("close", event);
+        } else if (kind === "error") {
+          const event = new Event("error");
+          event.message = payload;
+          socket._fire("error", event);
+        }
+      }
+    }
+
+    for (const stream of Array.from(openStreams.values())) {
+      const events = api.sseDrain(stream._id);
+      for (const entry of events) {
+        const kind = entry[0];
+        const payload = entry[1];
+        delivered++;
+        if (kind === "open") {
+          stream.readyState = EventSource.OPEN;
+          stream._fire("open", new Event("open"));
+        } else if (kind === "message") {
+          // The name arrives as its own field. Reading it out of the payload
+          // meant guessing, and a plain `data: one\ndata: two` was read as an
+          // event named `one` carrying `two`, so `onmessage` never fired.
+          const name = entry[2] || "message";
+          const event = new Event(name);
+          event.data = payload;
+          event.origin = stream._url;
+          stream._fire(name === "message" ? "message" : name, event);
+        } else if (kind === "close") {
+          stream.readyState = EventSource.CLOSED;
+          api.sseClose(stream._id);
+          openStreams.delete(stream._id);
+          const event = new Event("error");
+          event.message = payload;
+          stream._fire("error", event);
+        } else if (kind === "error") {
+          const event = new Event("error");
+          event.message = payload;
+          stream._fire("error", event);
+        }
+      }
+    }
+
+    return delivered;
+  };
+
+  /// How many long-lived connections this page has open, for the engine's own
+  /// reporting.
+  globalThis.__h5iOpenSockets = function () {
+    return openSockets.size + openStreams.size;
+  };
+})();

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -4096,6 +4096,45 @@ fn a_constructed_text_node_is_a_text_node_and_not_the_document() {
 }
 
 #[test]
+fn a_bad_node_id_is_an_error_rather_than_the_document() {
+    // Rust's float-to-integer cast saturates, so `NaN as usize` is 0 — and node
+    // 0 is the document. Every argument that was not a number at all therefore
+    // named the most consequential node in the tree, and named it silently.
+    // That is how `new Text("x")` came back with `nodeType === 9`.
+    //
+    // The prelude cannot produce these any more, so this reaches past it to the
+    // primitives, which is where the rule has to hold: the next bad id will come
+    // from somewhere nobody has thought of yet.
+    let (_page, mut script) = page_and_script("<html><body><p id='p'>hi</p></body></html>");
+    for bad in ["'x'", "NaN", "-1", "1.5", "Infinity", "{}", "[]", "''", "'1'", "true"] {
+        let answer = script
+            .eval_value(&format!(
+                "(() => {{ try {{ return 'got ' + String(__h5i.nodeKind({bad})) }} \
+                   catch (e) {{ return 'refused' }} }})()"
+            ))
+            .unwrap();
+        assert_eq!(answer, "refused", "__h5i.nodeKind({bad}) was accepted");
+    }
+
+    // `undefined` is the exception, and not an accident: `document` carries no
+    // `_id` — every reflected accessor uses `this._id === undefined` as its
+    // WebIDL brand check, so giving the document one would make it pass for an
+    // element — and every path that hands `document._id` to a primitive means
+    // the document. 9 is DOCUMENT_NODE.
+    assert_eq!(script.eval_value("String(__h5i.nodeKind(undefined))").unwrap(), "9");
+    assert_eq!(script.eval_value("String(__h5i.nodeKind(null))").unwrap(), "9");
+
+    // It is a coercion ban, deliberately. `Number([])` and `Number("")` are both
+    // 0, which is the document, so a rule that let JavaScript coerce first would
+    // leave the same hole in a narrower shape. An id is a number or it is an
+    // error; `"1"` is refused along with the rest.
+    // And the document still answers as itself through the paths that rely on
+    // it, rather than through a NaN that happened to land on the right node.
+    assert_eq!(script.eval_value("document.nodeType").unwrap(), "9");
+    assert_eq!(script.eval_value("document.querySelector('#p').textContent").unwrap(), "hi");
+}
+
+#[test]
 fn a_node_cannot_be_put_inside_itself() {
     // The rule that makes the hang above impossible to reach again, from any
     // direction rather than from the one that was found.

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -3371,6 +3371,185 @@ console: {console:?}"
     );
 }
 
+/// A realm with an instrument's switches thrown, which the default is not.
+fn conformance_script(html: &str) -> (crate::engine::Page, Script) {
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None).expect("broker");
+    let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
+    let factory = PageFactory::new(broker, fonts.sources.clone(), PageOptions::default());
+    let base = url::Url::parse("https://app.example/").unwrap();
+    let page = factory.from_html(html, &base);
+    let script = Script::with_options(
+        page.dom(),
+        factory.broker().clone(),
+        &base,
+        RealmOptions { webidl_conformance: true },
+    )
+    .expect("realm");
+    (page, script)
+}
+
+#[test]
+fn the_webidl_decoration_arrives_only_when_an_instrument_asks() {
+    // The decoration is a whole source that is not parsed by default, so this
+    // checks the tier seam as much as the decoration: a realm built the
+    // ordinary way must not have it, and one built with the flag must — from a
+    // file the first realm never handed to Boa.
+    //
+    // What the pass actually adds, probed on both a plain class accessor and a
+    // reflected one: the member becomes enumerable, and the accessor refuses a
+    // receiver that is not an instance. The `get x` naming is *not* part of it
+    // — Boa names class accessors correctly on its own, and the reflection
+    // tables name theirs — which is worth pinning down, because it is the one
+    // of the three a reader would assume the pass was carrying.
+    let probe = r#"(() => {
+        const out = [];
+        for (const [Iface, key] of [[Node, "textContent"], [Element, "id"]]) {
+          const d = Object.getOwnPropertyDescriptor(Iface.prototype, key);
+          let refused = false;
+          try { d.get.call({}); } catch (e) { refused = String(e).includes("Illegal invocation"); }
+          out.push(d.enumerable + "," + d.get.name + "," + refused);
+        }
+        return out.join("|");
+    })()"#;
+
+    let (_page, mut plain) = page_and_script("<html><body><p id='x'>hi</p></body></html>");
+    assert_eq!(
+        plain.eval_value(probe).unwrap(),
+        "false,get textContent,false|false,get id,false",
+        "an ordinary page paid for the conformance decoration"
+    );
+
+    let (_page, mut decorated) = conformance_script("<html><body><p id='x'>hi</p></body></html>");
+    assert_eq!(
+        decorated.eval_value(probe).unwrap(),
+        "true,get textContent,true|true,get id,true",
+        "the conformance tier did not install"
+    );
+
+    // And the decoration does not cost the page its own reads.
+    assert_eq!(
+        decorated.eval_value("document.querySelector('p').id").unwrap(),
+        "x"
+    );
+}
+
+/// What the parser is handed, which is not the same as how big the file is.
+///
+/// Comments are free: blanking all 164 KiB of them in a 448 KiB prelude changed
+/// parse time by *nothing measurable*, so a budget counted in raw bytes would
+/// tax the documentation this engine is largely made of, and would not predict
+/// the cost. Everything else is a token the parser builds.
+///
+/// The rule is line-based, which is exact here because the prelude has no block
+/// comments and no template literal spans a line — both checked below.
+fn code_bytes(source: &str) -> usize {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .map(|line| line.len() + 1)
+        .sum()
+}
+
+#[test]
+fn the_eagerly_parsed_prelude_stays_within_its_budget() {
+    // **Parse and compile are two thirds of what a script realm costs** — 42 ms
+    // of 59 — and both are a straight function of the code handed to Boa. There
+    // is no lazy compilation to hide behind: every page pays for every line,
+    // whether or not it ever runs one.
+    //
+    // This number is a floor under noticing. The prelude grew by 4,692 lines in
+    // two commits during a coverage push, the realm went from 15.9 ms to 82.8 ms
+    // per page, and nothing said so — the tests all passed, because a slower
+    // engine is not a wrong one. A budget that has to be raised on purpose puts
+    // the price in the diff that pays it.
+    //
+    // Raising it is a normal thing to do, not a failure. The exchange rate is
+    // roughly **150 µs of per-page realm cost per KiB of code**, so a KiB spent
+    // here is a KiB every page pays for whether or not it uses the feature. The
+    // question the number asks is only whether it could be a tier instead: see
+    // `TIERS` in `mod.rs`, and `lazyGlobals` in the prelude.
+    const BUDGET_KIB: usize = 275;
+
+    assert!(
+        !super::PRELUDE.contains("/*"),
+        "the prelude has grown a block comment; `code_bytes` counts by line and \
+         would charge the parser for prose it skips for free"
+    );
+
+    let code = code_bytes(super::PRELUDE) / 1024;
+    assert!(
+        code <= BUDGET_KIB,
+        "the eagerly parsed prelude is {code} KiB of code, over its {BUDGET_KIB} KiB \
+         budget. Every page pays about 150 µs per KiB of this, at realm build, \
+         used or not. Either move the new surface into a tier (`TIERS` in \
+         `mod.rs`) or raise BUDGET_KIB deliberately and say what the page is \
+         getting for it."
+    );
+}
+
+#[test]
+fn a_tier_is_not_parsed_until_the_page_asks_for_it() {
+    // The deferral has to be observable, or it is a claim rather than a fact:
+    // an accessor standing where the interface will be is what "not parsed yet"
+    // looks like from JavaScript, and a data property is what it looks like
+    // afterwards. Both are checked here so that a tier quietly becoming eager
+    // — by something in the core touching the name — shows up as a failure.
+    let (_page, mut script) = page_and_script("<html><body></body></html>");
+    assert_eq!(
+        script
+            .eval_value(
+                "Object.getOwnPropertyDescriptor(globalThis, 'WebSocket').get ? 'deferred' : 'eager'"
+            )
+            .unwrap(),
+        "deferred"
+    );
+    // Reading the name is the trigger, and `typeof` is a read: it is how a page
+    // asks whether the interface exists at all, and it must not answer
+    // "undefined" for something this engine has.
+    assert_eq!(script.eval_value("typeof WebSocket").unwrap(), "function");
+    assert_eq!(
+        script
+            .eval_value(
+                "Object.getOwnPropertyDescriptor(globalThis, 'WebSocket').get ? 'deferred' : 'eager'"
+            )
+            .unwrap(),
+        "eager"
+    );
+    // The other shape of trigger. `:has()` is not reached by name — it arrives
+    // inside a selector string — so its tier is loaded by the test the core
+    // already ran to decide whether it needed the evaluator at all. A plain
+    // selector must not bring it in; a `:has()` one must.
+    let (_page, mut selectors) = page_and_script(
+        "<html><body><div id='a'><i class='flag'></i></div><div id='b'></div></body></html>",
+    );
+    let loaded = "__h5iInternals.prepareHasSelector ? 'loaded' : 'deferred'";
+    assert_eq!(selectors.eval_value(loaded).unwrap(), "deferred");
+    assert_eq!(selectors.eval_value("document.querySelectorAll('div').length").unwrap(), "2");
+    assert_eq!(
+        selectors.eval_value(loaded).unwrap(),
+        "deferred",
+        "an ordinary selector parsed the `:has()` evaluator"
+    );
+    assert_eq!(selectors.eval_value("document.querySelector('div:has(.flag)').id").unwrap(), "a");
+    assert_eq!(selectors.eval_value(loaded).unwrap(), "loaded");
+
+    // One file, both names: reading `WebSocket` above brought `EventSource`
+    // with it, because they share a source and splitting them would mean
+    // parsing the same file twice.
+    //
+    // And it arrives shaped as WebIDL says an interface object is — the pass
+    // that fixes that for the core interfaces ran long before this file did.
+    assert_eq!(
+        script
+            .eval_value(
+                "(() => { const d = Object.getOwnPropertyDescriptor(globalThis, 'EventSource'); \
+                   return [!!d.get, d.enumerable, d.writable, d.configurable].join('|') })()"
+            )
+            .unwrap(),
+        "false|false|true|true"
+    );
+}
+
 #[test]
 fn interface_objects_are_not_enumerable_on_the_global() {
     // WebIDL §3.7: an interface object is `enumerable: false`. Every one of
@@ -3868,6 +4047,128 @@ fn an_api_this_engine_lacks_names_itself_instead_of_throwing_anonymously() {
     assert!(
         reported.iter().any(|n| n == "navigator.clipboard"),
         "a property names its whole path: {reported:?}"
+    );
+}
+
+#[test]
+fn a_gap_is_named_by_the_object_it_was_read_from() {
+    // The reporting contract, pinned where it now lives: at the *end* of a
+    // node's prototype chain rather than in a proxy in front of every wrapper.
+    // Everything below held under the proxy too, except the last assertion,
+    // which the proxy could not make.
+    let (_page, mut script) = page_and_script("<html><body><p id='p'>text</p></body></html>");
+    script
+        .eval(
+            r#"const el = document.getElementById('p');
+               void el.scrollIntoViewIfNeeded;   // a real gap, named
+               void el.firstChild.tagName;       // no engine answers this
+               void el._privateThing;            // a framework's own field
+               void el.$store;
+               void el.jQuery360062973586668224961;
+               el.expando = 1; void el.expando;  // the page's own, read back
+
+               // The chain still ends where it did. A sentinel that reported
+               // its own prototype instead of standing in front of one would
+               // take `instanceof Object` down with it, silently.
+               globalThis.shape = [
+                 el instanceof Object, el instanceof Element, el instanceof Node,
+                 'scrollIntoViewIfNeeded' in el, typeof el.toString,
+               ].join('|');
+
+               // A getter the *page* defines, reading something we lack. The
+               // proxy form passed the raw target as the receiver to avoid
+               // paying a second trap per `this._id`, so a miss inside one of
+               // these was invisible. There is no receiver to substitute now.
+               Object.defineProperty(Element.prototype, 'probe', {
+                 get() { return this.pageDefinedGetterAsked; },
+               });
+               void el.probe;"#,
+        )
+        .expect("runs");
+
+    assert_eq!(
+        script.eval_value("shape").unwrap(),
+        "true|true|true|false|function",
+        "the sentinel changed what a node *is*"
+    );
+
+    let reported: Vec<String> = script.unsupported().into_iter().map(|(n, _)| n).collect();
+    assert!(
+        reported.iter().any(|n| n == "Element.scrollIntoViewIfNeeded"),
+        "a gap names the interface it was read from: {reported:?}"
+    );
+    for quiet in [
+        "tagName",              // reading an element property off a text node
+        "_privateThing",
+        "$store",
+        "jQuery360062973586668224961",
+        "expando",
+    ] {
+        assert!(
+            !reported.iter().any(|n| n.contains(quiet)),
+            "{quiet} is not a gap in this engine: {reported:?}"
+        );
+    }
+    assert!(
+        reported.iter().any(|n| n == "Element.pageDefinedGetterAsked"),
+        "a miss inside a page's own getter is reported now: {reported:?}"
+    );
+}
+
+#[test]
+fn an_internal_read_never_reaches_the_sentinel() {
+    // The sentinel at the end of a node's chain is for names *pages* ask for.
+    // This file's own bookkeeping must not arrive there: a field we set only
+    // sometimes — `_nsuri`, set by `createElementNS` and by nothing the parser
+    // does — is absent on almost every element, so `get tagName()` reading it
+    // walked the whole prototype chain into a proxy trap to learn something
+    // about itself. It cost 1415 ns on an accessor whose native call is 196 ns.
+    //
+    // `declareInternals` puts an `undefined` on the prototype so the read stops
+    // at the first hop. This is the guard for the next such field: a workout
+    // over the surface an ordinary page touches, and nothing of ours may miss.
+    let (_page, mut script) = page_and_script(
+        "<html><body><div id='d' class='a b'><p>one</p><a href='/x'>two</a>\
+         <input type='checkbox'><input type='text' value='v'>\
+         <select><option>o</option></select><ul><li>l</li></ul>\
+         <template><b>t</b></template></div></body></html>",
+    );
+    script
+        .eval(
+            r#"globalThis.__h5iReportInternalMisses = true;
+               for (const el of document.querySelectorAll('*')) {
+                 void el.tagName; void el.nodeName; void el.id; void el.className;
+                 void el.classList; void el.children; void el.childNodes;
+                 void el.parentNode; void el.nextSibling; void el.firstChild;
+                 void el.textContent; void el.innerHTML; void el.attributes;
+                 void el.style; void el.value; void el.checked; void el.type;
+                 void el.nodeType; void el.isConnected; void el.ownerDocument;
+                 void el.dataset; void el.hidden; void el.shadowRoot;
+                 el.setAttribute('data-x', '1'); void el.getAttribute('data-x');
+                 el.addEventListener('click', () => {});
+                 el.dispatchEvent(new Event('click'));
+                 void el.getBoundingClientRect();
+                 void el.matches('div'); void el.closest('div');
+               }
+               const box = document.querySelector('input[type=checkbox]');
+               box.checked = true; void box.checked;
+               const text = document.querySelector('input[type=text]');
+               text.value = 'typed'; void text.value;
+               document.querySelector('#d').innerHTML = '<span>new</span>';
+               document.createElementNS('http://www.w3.org/2000/svg', 'circle').tagName;
+               void document.body.textContent;"#,
+        )
+        .expect("runs");
+
+    let missed: Vec<(String, usize)> = script
+        .unsupported()
+        .into_iter()
+        .filter(|(name, _)| name.starts_with("internal miss: "))
+        .collect();
+    assert!(
+        missed.is_empty(),
+        "these reads of our own fields walked the prototype chain to the \
+         sentinel; declare them with `declareInternals`: {missed:#?}"
     );
 }
 

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -4093,6 +4093,41 @@ fn a_constructed_text_node_is_a_text_node_and_not_the_document() {
         script.eval_value("String(new Text().data) + '|' + new Text().nodeType").unwrap(),
         "|3"
     );
+
+    // And the interfaces that are *not* constructible say so, which is the same
+    // defect wearing the other hat: `new Element()` left `_id` as `null`, the
+    // primitives read that as node 0, and node 0 is the document — so
+    // `new Element().textContent = "x"` wrote through to the document and took
+    // the process down with it. DOM §4.4 and §4.9: these throw in every engine.
+    for name in ["Element", "Node", "CharacterData"] {
+        assert_eq!(
+            script
+                .eval_value(&format!(
+                    "(() => {{ try {{ new {name}(); return 'built' }} \
+                       catch (e) {{ return e.constructor.name }} }})()"
+                ))
+                .unwrap(),
+            "TypeError",
+            "new {name}() did not throw"
+        );
+    }
+
+    // A custom element still upgrades, which is the one path that legitimately
+    // reaches those constructors with no id in hand.
+    let (_page, mut custom) = page_and_script(
+        "<html><body><x-thing id='t'>light</x-thing></body></html>",
+    );
+    assert_eq!(
+        custom
+            .eval_value(
+                "(() => { class Thing extends HTMLElement { \
+                     get probe() { return 'upgraded:' + this.id } } \
+                   customElements.define('x-thing', Thing); \
+                   return document.getElementById('t').probe })()"
+            )
+            .unwrap(),
+        "upgraded:t"
+    );
 }
 
 #[test]

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -4051,6 +4051,102 @@ fn an_api_this_engine_lacks_names_itself_instead_of_throwing_anonymously() {
 }
 
 #[test]
+fn a_constructed_text_node_is_a_text_node_and_not_the_document() {
+    // `new Text("x")` is a page building a node — DOM §4.10 says it may — and
+    // this file's classes take a *node id* as their first argument. Without a
+    // way to tell those apart the page got a wrapper whose id was the string
+    // "x", which the primitives converted to 0, which is the document. So
+    // `new Text("x").nodeType` was **9**, and appending it anywhere put the
+    // document inside one of its own descendants.
+    //
+    // What that cost: `dom/events/Event-dispatch-click.html` does exactly this
+    // (`input.appendChild(new Text("does not matter"))`) and the engine walked
+    // the resulting cycle for ever, at 100% of a core, past every deadline it
+    // has — those guard the script realm, and no script is running while layout
+    // walks. Six of them were found spinning on one machine, the oldest for
+    // seven hours. The file now reports in 0.18 s.
+    let (_page, mut script) = page_and_script("<html><body><div id='d'></div></body></html>");
+    assert_eq!(
+        script
+            .eval_value(
+                "(() => { const t = new Text('hello'); const c = new Comment('note'); \
+                   return [t.nodeType, JSON.stringify(t.data), t.wholeText, \
+                           c.nodeType, JSON.stringify(c.data)].join('|') })()"
+            )
+            .unwrap(),
+        "3|\"hello\"|hello|8|\"note\"",
+        "a constructed Text or Comment is not a real node"
+    );
+    // And it is a node the tree accepts, which is the half that was hanging.
+    assert_eq!(
+        script
+            .eval_value(
+                "(() => { const d = document.getElementById('d'); \
+                   const t = new Text('hi'); d.appendChild(t); \
+                   return d.textContent + '|' + (t.parentNode === d) })()"
+            )
+            .unwrap(),
+        "hi|true"
+    );
+    // No argument is the empty string, not the document.
+    assert_eq!(
+        script.eval_value("String(new Text().data) + '|' + new Text().nodeType").unwrap(),
+        "|3"
+    );
+}
+
+#[test]
+fn a_node_cannot_be_put_inside_itself() {
+    // The rule that makes the hang above impossible to reach again, from any
+    // direction rather than from the one that was found.
+    //
+    // It is checked twice on purpose. Here, *before* the child is unlinked from
+    // its parent, because that is the only moment the ancestor relationship
+    // still exists — the spec orders it that way for exactly this reason. And
+    // again in `dom_api.rs`, which is the last door before blitz and the only
+    // one a raw primitive call goes through. Neither check can replace the
+    // other: this one cannot see a primitive call, and that one cannot see an
+    // ancestry that the detach has already erased.
+    let (_page, mut script) = page_and_script(
+        "<html><body><div id='outer'><div id='inner'></div></div></body></html>",
+    );
+    for attempt in [
+        "document.getElementById('inner').appendChild(document.documentElement)",
+        "document.getElementById('inner').appendChild(document.getElementById('outer'))",
+        "document.getElementById('outer').appendChild(document.getElementById('outer'))",
+        "document.getElementById('inner').insertBefore(document.getElementById('outer'), null)",
+    ] {
+        let refused = script
+            .eval_value(&format!(
+                "(() => {{ try {{ {attempt}; return 'allowed' }} \
+                   catch (e) {{ return e.name }} }})()"
+            ))
+            .unwrap();
+        assert_eq!(refused, "HierarchyRequestError", "{attempt} was not refused");
+    }
+
+    // The primitive underneath refuses it too, which is what stops a cycle that
+    // never passed through the code above.
+    assert!(
+        script
+            .eval_value(
+                "(() => { try { __h5i.append(document.getElementById('inner')._id, \
+                   document.documentElement._id); return 'allowed' } \
+                   catch (e) { return String(e) } })()"
+            )
+            .unwrap()
+            .contains("HierarchyRequestError"),
+        "the primitive allowed a cycle"
+    );
+
+    // Still a working document afterwards, rather than a half-moved tree.
+    assert_eq!(
+        script.eval_value("document.getElementById('inner').parentNode.id").unwrap(),
+        "outer"
+    );
+}
+
+#[test]
 fn a_gap_is_named_by_the_object_it_was_read_from() {
     // The reporting contract, pinned where it now lives: at the *end* of a
     // node's prototype chain rather than in a proxy in front of every wrapper.

--- a/crates/h5i-browser-light/wpt/baseline.json
+++ b/crates/h5i-browser-light/wpt/baseline.json
@@ -1,9 +1,9 @@
 {
  "note": "Committed floor for the WPT gate. Raise with wpt/check.py --write.",
- "total": 293792,
+ "total": 293875,
  "per_dir": {
-  "css_cssom": 2134,
-  "dom": 3306,
+  "css_cssom": 2133,
+  "dom": 3390,
   "domparsing": 384,
   "encoding": 225785,
   "html_dom": 62183

--- a/crates/h5i-browser-light/wpt/run.py
+++ b/crates/h5i-browser-light/wpt/run.py
@@ -241,6 +241,13 @@ def run_one(args):
                  # which is a score that depends on the other processes on the
                  # box. See `--script-seconds`.
                  "--script-seconds", str(int(script_seconds)),
+                 # WebIDL member decoration: enumerable members and the brand
+                 # check that makes an accessor reached on a prototype throw.
+                 # `idlharness` checks both on every member of every interface
+                 # and no page does, so the engine installs it only when asked
+                 # — it cost 15 ms of the 83 ms a script realm took, on every
+                 # page. Asked for here, so this number means what it meant.
+                 "--webidl-conformance",
                  *grants, url],
                 mem_mb,
             ),


### PR DESCRIPTION
This started as a question about whether `script/prelude.js` was still worth
what it cost. The answer was no, and finding out why turned up a page that
could hang the engine for ever.

## Any page could stop this engine

```js
document.body.appendChild(new Text("hi"))
```

`Text` and `Comment` are constructible interfaces a page may call, and this
file's node classes take a *node id* as their first argument. With no way to
tell those apart, `new Text("x")` built a wrapper whose id was the string
`"x"`; `arg_id` converted it with `as usize`, which saturates to 0 for anything
non-numeric; and node 0 is the document. So `new Text("x").nodeType` was **9**,
and appending it put the document inside one of its own descendants.

Blitz then walked the cycle for ever at 100% of a core. Nothing stopped it: the
script budget, the navigation deadline and the loop-iteration limit all guard
the *script realm*, and no script runs while layout walks.

`dom/events/Event-dispatch-click.html` does exactly this, and **six orphaned
renderers were found spinning on the development machine, the oldest for seven
hours forty minutes**, each holding a core and quietly making every measurement
taken that day wrong. That file now reports in 0.18 s.

Fixed in three places, because one is the bug and two are why it cannot recur:
real constructors behind a private brand; the spec's pre-insertion check in the
prelude *before* the child is unlinked, which is the only moment the ancestry
still exists; and the same rule again in `dom_api.rs`, the last door before
blitz. `inner.appendChild(documentElement)` was a process abort before this and
is a `HierarchyRequestError` now.

`new Element()` was the same defect wearing the other hat, and shipping it would
have been shipping the bug this PR is named after. `Node`, `Element` and
`CharacterData` are not constructible — DOM §4.4 and §4.9 — but ours let a page
call them, leaving `_id` as `null`, which the primitives read as node 0, which is
the document. `new Element().textContent = "x"` wrote through to the document
and took the process down. They throw now, and a custom element still upgrades,
which is the one path that legitimately reaches those constructors with no id.

Three more holes closed behind it:

* **An id is a number.** Not something a number can be made of — `Number([])`
  and `Number("")` are also 0, so a rule written in terms of `to_number` would
  leave the same hole in a narrower shape. `undefined` stays as the one
  documented exception, because `document` deliberately carries no `_id`: every
  reflected accessor uses `this._id === undefined` as its WebIDL brand check.
* **Layout has a ceiling.** Every deadline here guards the script realm by
  asking Boa to stop between pieces of work, and none of them can touch native
  code that never returns. `HardStop` is armed per *navigation* rather than per
  process, so a long-lived `serve` session is bounded per page, and it uses
  `_exit` from its own thread because the wedged thread cannot help.

## And the renderers that would not stop

A second, independent defect, found only because the first one produced six of
them. The renderer already exits when its broker dies, and every orphan **had
printed the message saying so**. It then did not exit: `std::process::exit`
runs the atexit handlers and flushes stdio, and both take locks, so a watchdog
thread calling it waits on the very thread it has given up on. `_exit` skips
all of it.

A full WPT gate run used to leave one spinning engine behind every time. It now
leaves none.

## What a page costs

Base and branch, measured back to back on an idle machine with the same
corrected benchmark. Page-level rows are noisy by ±10%; the micro numbers are
stable.

```
                                   before      after
reading a scripted page
  10 sections  (~90 nodes)          113ms       73ms
  100 sections (~900 nodes)         109ms       97ms
  500 sections (~4500 nodes)        192ms      188ms

starting the script realm            91ms       71ms

a DOM property read
  known property                    855ns      196ns     4.4x
  reaching the tree                2238ns      700ns     3.2x
```

Large pages barely move because they are dominated by layout, which this does
not touch: on 4500 nodes `refresh()` alone is 37 ms and the scriptless column
pays it too. Script execution on a small page is under 1.5 ms in total. There
is no "script is slow" problem here; there was a "starting up is slow" problem.

## Where the cost went

1. **The WebIDL member decoration is a tier.** `idlharness` checks that every
   interface member is enumerable and that an accessor reached on a prototype
   throws. No page asks either, and rebuilding every descriptor of every
   interface prototype cost **15 ms of 83** on every page. It now lives in a
   source Boa is handed only under `--webidl-conformance`, which `wpt/run.py`
   passes, so the conformance number is unchanged.
2. **Gap reporting moved to the end of the prototype chain.** It was a `Proxy`
   in front of every wrapper, so it fired on reads that found exactly what they
   asked for: **799 ns of the 882 ns** a known property cost. A read that misses
   already walks the whole chain, so the sentinel sits where only a miss
   arrives. It also removes a documented compromise — the proxy passed the raw
   target as receiver to avoid double-trapping, which made a miss inside a
   page's own getter invisible.
3. **The engine stopped paying a trap to ask itself a question.** `get tagName()`
   reads `this._nsuri` to learn whether the element came from `createElementNS`,
   and for everything the parser made it never did. So the most-read accessor in
   the engine walked its whole prototype chain into a proxy: 1415 ns against the
   196 ns its native call costs.
4. **Every settle stopped waiting on a sleeping thread.** The deadline watchdog
   polled a flag every 20 ms and was *joined*, so a settle that finished in
   50 µs sat in `join` until the thread woke up. A 20 ms tax on every settle and
   every agent `wait`, spent asleep — and intermittent, a race between the body
   finishing and the watchdog reaching its first sleep, so half the runs looked
   fine.

Three tiers exist (`conformance`, `sockets`, `has`) and the mechanism is cheap
to extend, but its ceiling is low: 272 of the 284 KiB of code is DOM core that
every page uses.

## Measured and rejected

Recorded in `examples/perf` and ROADMAP §B8.9 so nobody repeats them.

* **Interning the uppercased tag names**, and removing two intermediate
  `String`s from every attribute read: no change. A native call costs ~136 ns of
  dispatch before it does anything, so shaving the work at the far end is
  shaving the small half. What worked was not making the call — `tagName` is
  remembered on the wrapper, 740 ns to 300 ns.
* **Stripping comments before handing the source to Boa**: no change at all,
  and a third of the file is comments. Parse scales with *code*. This is why
  the new budget test counts code rather than bytes: documentation is free.
* **Reusing the compiled prelude across pages**, which would remove the 42 ms of
  parse and compile and is the only 3x-class win left. A `CodeBlock` owns its
  `InlineCache` entries and those hold live shape-to-slot mappings, so reuse
  would carry one page's object shapes into the next page's lookups — the same
  contamination the realm refusal exists to prevent, arriving through the cache
  instead of the globals. That is a sharper reason than the interner one
  §B15.12a used to give, and it names the small upstream change that would
  unblock it.

## Guards, so this does not quietly come back

The prelude grew 4,692 lines in two commits during a coverage push and took the
realm from 15.9 ms to 82.8 ms with nothing saying so, because every test passed
— a slower engine is not a wrong one.

* `the_eagerly_parsed_prelude_stays_within_its_budget` holds the eager source at
  275 KiB of code, with the exchange rate (~150 µs of per-page cost per KiB) in
  the failure message.
* `an_internal_read_never_reaches_the_sentinel` fails if one of our own fields
  is read without being declared.
* `a_tier_is_not_parsed_until_the_page_asks_for_it` fails if a tier quietly
  becomes eager.
* `the floor under a scripted page` in `examples/perf` is the number that would
  have caught the settle bug; timing stays out of the tests deliberately.

## Verification

* **627 tests**, up from 617.
* **WPT gate: 293,875**, raised from a 293,792 baseline. `dom` +84, and 143 more
  subtests are scored at all because a file that times out reports nothing.
  `css_cssom` -1. Two idle runs agreed to the subtest, and neither left an
  engine behind.
* Clippy clean on both feature configurations. Man page unchanged. Green on CI,
  which includes the full workspace suite, the macOS lane and the
  `x86_64-pc-windows-msvc` cross-check — the last of which is what proves the
  `#[cfg(not(unix))]` arm of the renderer's stop compiles at all.

A caution for anyone re-running the gate: `html/dom` is bimodal on a loaded
machine, 58,313 against 62,183, because `html/dom/idlharness` sits on its script
ceiling and reports nothing when it overruns. Run it idle. I got this wrong once
mid-branch and briefly believed a speedup had recovered 3,870 subtests.

## Not in this PR

The form-control tier (~48 KiB of code, ~7 ms) is the one worthwhile tiering
item left and needs the free-variable analysis that splitting a shared closure
demands. `run.py` still kills only its direct child rather than the process
group, which is now belt-and-braces. The `_exit` fix has no automated test:
proving it needs a wedged renderer, and this PR removes the only one available.
