### PR TITLE
browser: the page a session was opened on, a helper run with no sessi…

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -2662,6 +2662,19 @@ Runtime scoping is not cosmetic: a Claude box must not get Codex's credentials
 or egress to OpenAI, because a prompt-injected agent could otherwise read the
 *other* runtime's token and use it against an allowlisted host.
 
+A note on the one grant nobody would think to write. The built-in read set
+carries the handful of paths `/etc/resolv.conf` is a symlink *to*
+(`/mnt/wsl/resolv.conf` on WSL, the systemd-resolved and resolvconf locations
+under `/run`), one file each. `/etc` alone is not enough, because Landlock
+follows the link to a path the box was never granted, and what that costs does
+not look like a denied file: `getaddrinfo` answers "Temporary failure in name
+resolution" and a `net.mode = "host"` box reads as a machine with no network.
+The entries are the same on every host whether the files exist or not, because
+a grant resolved from the local `/etc` would give one profile a different
+policy digest on every machine. **A custom profile that sets `fs.read`
+replaces that list**, so a box of your own with `mode = "host"` needs the line
+for your host, which `readlink -f /etc/resolv.conf` names.
+
 Custom profiles live in `.h5i/env.toml`:
 
 ```toml

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -474,18 +474,36 @@ lets the engine reach the whole host network corroborates nothing, and such a
 session stays `engine-claimed`. What earns `host-observed` is an egress
 allowlist or a `deny` net mode — enforcement outside the engine.
 
-**What `net.egress` means on a tier that does not enforce it.** h5i hands the
-box's list to the engine either way, so a session there starts with those
-origins granted. On `supervised`, `container` and `microvm` the same list is
-applied at the boundary, and it bounds what anything in the box can reach. On
-`workspace` and `process` the network scope is deny or host and nothing applies
-it per host: the list arrives as a **default** for the engine's own allowlist,
-not as a ceiling, so `--allow` adds to it and so does naming a start URL. An
-agent inside such a box reaches past the list exactly as `curl` in that box
-does. That is not the browser getting around something. It is what a tier with
-no network boundary means, and it is why a session there keeps saying
-`engine-claimed` and why `h5i browser status` is the line to read rather than
-the tier's name.
+**Can `--allow` get around the box's `net.egress`?** No, and the reason is at
+creation rather than in the browser. A profile that declares an egress
+allowlist cannot be created at a tier that cannot enforce one:
+
+```
+$ h5i box create webtest --profile browser --isolation process
+Error: profile 'browser' sets a net.egress domain allowlist, but isolation
+'process' cannot enforce it (process-v1 supports net.mode deny|host only) —
+use a supervisor/container backend or drop net.egress (fail-closed)
+```
+
+So a box whose list reaches the engine is a box with a boundary underneath it.
+h5i does hand that list to the engine, and `--allow` and the start URL add to
+it, but what they add is what the engine will *ask* for. What leaves the box is
+still decided outside it:
+
+```
+$ h5i browser read https://example.com --in webbox   # webbox allows en.wikipedia.org
+  confined : box webbox, policy 2bb35dc2fa6c...
+https://example.com: could not open https://example.com/: denied by policy:
+`example.com` could not be resolved: Temporary failure in name resolution
+```
+
+The engine granted the target it was handed, exactly as `read` always does, and
+the box's pinned DNS refused it anyway.
+
+A box that declares no egress list has nothing to widen: its net mode is host
+or deny, nothing outside the engine is deciding about hosts, and a session
+there keeps saying `engine-claimed`. That line, not the tier's name, is what
+says whether anything corroborated the request log.
 
 Two mechanics are worth knowing, because they explain the shape of the feature:
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -76,7 +76,7 @@ agent and the human can operate on.
 Reading and acting on a page, which needs nothing else:
 
 ```bash
-h5i browser open https://example.com --allow example.com
+h5i browser open https://example.com       # the page grants itself; `--allow` adds more
 h5i browser snapshot                       # the outline, with @ref handles
 h5i browser click @e3
 h5i browser requests                       # what it reached, and what was refused
@@ -232,6 +232,19 @@ status line:
 ```
 requests : engine-claimed (fail-closed, and the engine's own account of what it fetched)
 ```
+
+#### The page grants itself
+
+A session reaches the URL it was opened on, and nothing else remote. Naming a
+URL and then naming its origin again is ceremony that teaches nothing, so
+`open` grants the page it was given exactly as `read` grants its targets.
+`--allow` is for the origins beyond it: an API the page calls, a CDN it pulls
+from. Loopback is reachable by default because it is the dev server, and
+`--no-loopback` takes that back.
+
+The grant is the page and not "and whatever this page pulls in". An off-origin
+subresource is still refused, and still says so in the request log, which is
+the part a wider default would have given away.
 
 ### `read`: one page, no session
 
@@ -447,9 +460,10 @@ h5i browser open https://example.com --in web
 h5i browser snapshot  # identical verb, identical answer
 ```
 
-`--in` changes nothing you type. It changes **who saw the network**. The box
-enforces its egress allowlist at its own boundary, which is outside the thing
-being described, so the session's lane is upgraded:
+`--in` changes nothing you type. It changes **who saw the network**, when the
+box's tier is one that applies its egress allowlist at its own boundary. That
+boundary is outside the thing being described, so the session's lane is
+upgraded:
 
 ```
 requests : host-observed (also seen at the box's boundary, outside the engine)
@@ -459,6 +473,19 @@ Being in a box is not by itself enough to earn that line. A box whose policy
 lets the engine reach the whole host network corroborates nothing, and such a
 session stays `engine-claimed`. What earns `host-observed` is an egress
 allowlist or a `deny` net mode — enforcement outside the engine.
+
+**What `net.egress` means on a tier that does not enforce it.** h5i hands the
+box's list to the engine either way, so a session there starts with those
+origins granted. On `supervised`, `container` and `microvm` the same list is
+applied at the boundary, and it bounds what anything in the box can reach. On
+`workspace` and `process` the network scope is deny or host and nothing applies
+it per host: the list arrives as a **default** for the engine's own allowlist,
+not as a ceiling, so `--allow` adds to it and so does naming a start URL. An
+agent inside such a box reaches past the list exactly as `curl` in that box
+does. That is not the browser getting around something. It is what a tier with
+no network boundary means, and it is why a session there keeps saying
+`engine-claimed` and why `h5i browser status` is the line to read rather than
+the tier's name.
 
 Two mechanics are worth knowing, because they explain the shape of the feature:
 
@@ -608,7 +635,8 @@ Four things are deliberate:
   stays a read that found none. A silent fallback would move a session's traffic
   outside the engine's log without anyone asking, which is the one thing that
   log promises cannot happen.
-- **It runs where the session runs.** A boxed session runs yt-dlp *inside its
+- **It runs where the session runs, and with no session it runs here.** A
+  boxed session runs yt-dlp *inside its
   box*, and a boxed session whose box has no yt-dlp is refused rather than
   served from the host: running it outside would move the session's network to a
   boundary its caller did not choose. Whether that box has an egress boundary at
@@ -645,6 +673,17 @@ if any part of a run failed, so a run that wrote the transcript and then hit a
 rate limit on a second language is a complete answer reported as a failure. h5i
 reports it as an answer, and puts the partial failure in the note beside it,
 because that is what explains a missing title.
+
+**No session is needed when `--url` names the media.** There is no page here to
+render, so the only thing a session was ever contributing to this lane is a
+placement, and a run with none happens on this machine. It says exactly that in
+its `evidence` line, it opens no session and leaves none behind, and it is
+still written down: `h5i browser audit --no-session` lists the runs that belong
+to no session, with the same argv and the same host-observed lane as a row
+inside a session's timeline. They are kept out of that timeline on purpose,
+because a run that was not part of a session must not appear inside one. To put
+the run behind a boundary, open a session with `--in <box>` and it runs in
+there.
 
 A host session's helper is contained by whatever started h5i, and the reply says
 that too rather than implying a boundary that is not there. Automatic captions

--- a/crates/h5i-browser-light/src/cli.rs
+++ b/crates/h5i-browser-light/src/cli.rs
@@ -1927,9 +1927,26 @@ fn control_file_beside(stream_file: &Path) -> PathBuf {
 }
 
 fn build_policy(net: &NetArgs) -> Policy {
-    // Flags first, then whatever h5i granted the box. Both are additive: an
-    // agent cannot widen the box's policy by passing `--allow`, because the
-    // sandbox's own egress enforcement is still the boundary underneath.
+    // Flags first, then whatever h5i granted the box, and the two are a
+    // **union**.
+    //
+    // This used to say that an agent therefore cannot widen the box's policy,
+    // "because the sandbox's own egress enforcement is still the boundary
+    // underneath". That is true only where such a boundary exists: supervised,
+    // container and microvm. On `workspace` and `process` the tier's network
+    // scope is deny-or-host, so nothing polices which hosts are reached and the
+    // union *is* the whole policy — `--allow` widens it, and so does naming a
+    // start URL. On those tiers the box's `net.egress` reaches this engine as a
+    // default rather than as a ceiling, and the engine's allowlist is a
+    // cooperating process's own account of what it will fetch, which is why the
+    // lane it earns stays `engine-claimed`
+    // ([`h5i_core::browser_session::Session::lane_for`]) and why nothing here
+    // calls it containment.
+    //
+    // Left as a union deliberately: an intersection would *read* as enforcement
+    // while being bypassable by the agent that owns the environment this
+    // variable arrives in, which is the same generous-direction claim in a new
+    // costume.
     let from_env: Vec<String> = std::env::var(ALLOW_VAR)
         .unwrap_or_default()
         .split(',')

--- a/crates/h5i-browser-light/src/cli.rs
+++ b/crates/h5i-browser-light/src/cli.rs
@@ -1930,23 +1930,21 @@ fn build_policy(net: &NetArgs) -> Policy {
     // Flags first, then whatever h5i granted the box, and the two are a
     // **union**.
     //
-    // This used to say that an agent therefore cannot widen the box's policy,
-    // "because the sandbox's own egress enforcement is still the boundary
-    // underneath". That is true only where such a boundary exists: supervised,
-    // container and microvm. On `workspace` and `process` the tier's network
-    // scope is deny-or-host, so nothing polices which hosts are reached and the
-    // union *is* the whole policy — `--allow` widens it, and so does naming a
-    // start URL. On those tiers the box's `net.egress` reaches this engine as a
-    // default rather than as a ceiling, and the engine's allowlist is a
-    // cooperating process's own account of what it will fetch, which is why the
-    // lane it earns stays `engine-claimed`
-    // ([`h5i_core::browser_session::Session::lane_for`]) and why nothing here
-    // calls it containment.
+    // A union that still cannot widen a box's *enforced* policy, and the reason
+    // is at creation rather than here: a profile that declares `net.egress`
+    // cannot be created at a tier that cannot enforce one. `h5i box create
+    // --isolation process --profile <one with egress>` is refused, fail-closed
+    // ("process-v1 supports net.mode deny|host only"), so a box whose list
+    // reaches this engine is a box with a boundary underneath it. `--allow`
+    // adds an origin to what this process will *ask* for; what actually leaves
+    // the box is still decided outside it, which is what a `read --in` against
+    // an un-listed origin demonstrates — the engine grants the target it was
+    // handed and the box's pinned DNS refuses to resolve it.
     //
-    // Left as a union deliberately: an intersection would *read* as enforcement
-    // while being bypassable by the agent that owns the environment this
-    // variable arrives in, which is the same generous-direction claim in a new
-    // costume.
+    // A box that declares no list is a box with nothing to widen: its net mode
+    // is host or deny, nothing outside the engine is deciding about hosts at
+    // all, and the lane such a session earns stays `engine-claimed` for exactly
+    // that reason (`h5i_core::browser_session::Session::lane_for`).
     let from_env: Vec<String> = std::env::var(ALLOW_VAR)
         .unwrap_or_default()
         .split(',')

--- a/crates/h5i-browser-light/src/stream.rs
+++ b/crates/h5i-browser-light/src/stream.rs
@@ -2053,8 +2053,10 @@ fn control_verb_inner(
                 // called Sign in" is an answer, and reporting it as an error
                 // would send an agent correcting a request that was fine.
                 reply["note"] = json!(format!(
-                    "nothing on this page is a `{role}`{}. Try `find` with just the role to \
-                     see what there is, or take a `snapshot`.",
+                    "nothing on this page is a `{role}`{}. The name is matched whole, \
+                     ignoring case and collapsing whitespace, so a partial one finds \
+                     nothing. Try `find` with just the role to see what there is, or take \
+                     a `snapshot`.",
                     name.map(|n| format!(" named \"{n}\"")).unwrap_or_default()
                 ));
             } else if found.len() > MAX_FIND_MATCHES {
@@ -2326,8 +2328,14 @@ fn find_by_role(
             if !found_role.eq_ignore_ascii_case(role) {
                 return None;
             }
+            // Case-insensitively, like the role above it. An accessible name
+            // is what a control is *called*, and a caller reading "Memory
+            // safety" in prose and typing it back got nothing from a page whose
+            // link says "memory safety" — while `--role LINK` had always
+            // matched `link`. The asymmetry was the bug: one half of a locator
+            // ignored case and the other half did not.
             if let Some(wanted) = &wanted_name
-                && &found_name != wanted
+                && !same_name(&found_name, wanted)
             {
                 return None;
             }
@@ -2346,6 +2354,16 @@ fn find_by_role(
                 })
         })
         .collect()
+}
+
+/// Whether two accessible names are the same name.
+///
+/// Whitespace is already collapsed on both sides by the caller. What is left is
+/// case, and `to_lowercase` rather than `eq_ignore_ascii_case` because a page
+/// that names its controls in Greek, Cyrillic or accented Latin is a page whose
+/// caller deserves the same treatment as an English one.
+fn same_name(found: &str, wanted: &str) -> bool {
+    found == wanted || found.to_lowercase() == wanted.to_lowercase()
 }
 
 /// Read whichever handle the caller used.
@@ -3619,6 +3637,51 @@ mod tests {
         );
         assert_eq!(reply["count"], 1, "{reply:?}");
         assert_eq!(reply["matches"][0]["name"], "Save");
+    }
+
+    /// A name is what a thing is *called*, and case is not part of that.
+    ///
+    /// The locator's two halves disagreed: `--role LINK` had always matched
+    /// `link`, and `--name "Memory safety"` did not match a link that spells it
+    /// `memory safety`. A caller reading a name out of prose and typing it back
+    /// got `count: 0` and a note telling them the page has no such link, which
+    /// is a fact about the page and was not true.
+    #[test]
+    fn a_name_matches_however_the_page_capitalised_it() {
+        let mut session = session_with(
+            "<html><body>\
+               <a href=\"/a\">memory safety</a>\
+               <a href=\"/b\">Ünïcode Name</a>\
+             </body></html>",
+        );
+
+        for asked in ["memory safety", "Memory Safety", "MEMORY SAFETY"] {
+            let (found, _) = control_verb(
+                &mut session,
+                &json!({"verb": "find", "role": "link", "name": asked}),
+            );
+            assert_eq!(found["count"], 1, "asked for {asked:?}: {found:?}");
+        }
+
+        // Not only ASCII: a page that names its controls in accented Latin,
+        // Greek or Cyrillic gets the same treatment as an English one.
+        let (found, _) = control_verb(
+            &mut session,
+            &json!({"verb": "find", "role": "link", "name": "ünïcode name"}),
+        );
+        assert_eq!(found["count"], 1, "{found:?}");
+
+        // Still the whole name. Half of one matching would make a locator that
+        // silently acts on the wrong control.
+        let (found, _) = control_verb(
+            &mut session,
+            &json!({"verb": "find", "role": "link", "name": "memory"}),
+        );
+        assert_eq!(found["count"], 0, "{found:?}");
+        assert!(
+            found["note"].as_str().unwrap().contains("matched whole"),
+            "the note must say why a partial name found nothing: {found:?}"
+        );
     }
 
     /// Nothing matching is an answer about the page, not a failed request.

--- a/crates/h5i-core/src/browser_sandbox.rs
+++ b/crates/h5i-core/src/browser_sandbox.rs
@@ -354,9 +354,13 @@ pub fn grants_for(names: &[String]) -> Vec<SecretGrant> {
 /// rather than like the sandbox denied one file. A default sandbox that turns
 /// every public URL into a DNS error is a default nobody would keep.
 ///
-/// Only the browser's profile, not [`sandbox::Profile::builtin`]'s defaults: a
-/// policy's digest is taken over its serialization, so widening the defaults
-/// would change the digest of every box already pinned on disk.
+/// The box profiles now carry the well-known locations themselves, as a static
+/// list (`sandbox_policy`'s `RESOLVER_PATHS`), because a box's policy is
+/// serialized and digested and a runtime-resolved grant would give one profile
+/// a different digest on every host. This is the other half: a browser session
+/// on *this machine* builds its sandbox at runtime and pins no such digest, so
+/// it can follow the link wherever it actually goes and cover the hosts that
+/// list does not name.
 fn resolver_grants() -> Vec<PathBuf> {
     let conf = Path::new("/etc/resolv.conf");
     match conf.canonicalize() {

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -1333,25 +1333,81 @@ pub struct HelperRow {
 /// already run. Refusing to report a result h5i already has because a log line
 /// would not write would lose the result and the record both.
 pub fn record_helper(root: &Path, id: &str, row: &HelperRow) -> Result<(), H5iError> {
+    let dir = dir(root, id);
+    fs::create_dir_all(&dir)
+        .map_err(|e| H5iError::Metadata(format!("could not open the session directory: {e}")))?;
+    append_helper(&dir.join(HELPERS_FILE), row)
+}
+
+/// The helper log for the runs that belong to no session.
+///
+/// `h5i browser transcript --via yt-dlp --url …` names its own media and
+/// renders no page, so it needs no session — and a run with no session has no
+/// session directory to be recorded in. Without somewhere else to write, this
+/// lane's promise that *every* run is recorded would hold only for the runs
+/// that happened to have a session open, which is the kind of gap that is
+/// discovered by someone auditing a run that is not there.
+///
+/// At the root of the browser state directory, beside `sessions/`, because that
+/// is the scope of what it records. [`crate::browser_session::audit`] never
+/// reads it: a session's timeline must not carry runs that were not part of
+/// that session. `h5i browser audit --no-session` is what renders it.
+pub const SESSIONLESS_HELPERS_FILE: &str = "helpers.jsonl";
+
+/// Append one row for a run that had no session. See
+/// [`SESSIONLESS_HELPERS_FILE`]; best effort in the same way [`record_helper`]
+/// is, and for the same reason.
+pub fn record_sessionless_helper(root: &Path, row: &HelperRow) -> Result<(), H5iError> {
+    fs::create_dir_all(root).map_err(|e| {
+        H5iError::Metadata(format!("could not open the browser state directory: {e}"))
+    })?;
+    append_helper(&root.join(SESSIONLESS_HELPERS_FILE), row)
+}
+
+/// Read back the rows written by [`record_sessionless_helper`], oldest first.
+///
+/// A log that is not there is an empty one: no run of this kind has happened,
+/// which is the ordinary case. A log that is there and cannot be read is an
+/// error rather than an empty answer, because the two mean opposite things to
+/// whoever is asking.
+pub fn sessionless_helpers(root: &Path) -> Result<Vec<HelperRow>, H5iError> {
+    let text = match fs::read_to_string(root.join(SESSIONLESS_HELPERS_FILE)) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(H5iError::Metadata(format!(
+                "could not read the helper log at {}: {e}",
+                root.join(SESSIONLESS_HELPERS_FILE).display()
+            )));
+        }
+    };
+    // A line that will not parse is skipped rather than failing the read: this
+    // file is appended to by concurrent runs, and one torn line must not hide
+    // every row written before it.
+    Ok(text
+        .lines()
+        .filter_map(|line| serde_json::from_str::<HelperRow>(line).ok())
+        .collect())
+}
+
+/// Stamp a row and append it, whichever log it belongs in.
+///
+/// Stamped here rather than by the caller. The audit interleaves these with the
+/// engine's rows on time alone, so a second clock reading taken in another
+/// module is a second clock the timeline can be wrong about — and this is the
+/// one lane whose whole value is being h5i's own observation.
+fn append_helper(path: &Path, row: &HelperRow) -> Result<(), H5iError> {
     use std::io::Write;
-    // Stamped here rather than by the caller. The audit interleaves these with
-    // the engine's rows on time alone, so a second clock reading taken in
-    // another module is a second clock the timeline can be wrong about — and
-    // this is the one lane whose whole value is being h5i's own observation.
     let row = HelperRow {
         at: now(),
         ..row.clone()
     };
-    let row = &row;
-    let dir = dir(root, id);
-    fs::create_dir_all(&dir)
-        .map_err(|e| H5iError::Metadata(format!("could not open the session directory: {e}")))?;
     let mut file = fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(dir.join(HELPERS_FILE))
+        .open(path)
         .map_err(|e| H5iError::Metadata(format!("could not open the helper log: {e}")))?;
-    let line = serde_json::to_string(row)
+    let line = serde_json::to_string(&row)
         .map_err(|e| H5iError::Metadata(format!("could not write the helper row: {e}")))?;
     writeln!(file, "{line}")
         .map_err(|e| H5iError::Metadata(format!("could not append to the helper log: {e}")))

--- a/crates/h5i-sandbox/src/sandbox.rs
+++ b/crates/h5i-sandbox/src/sandbox.rs
@@ -4123,6 +4123,34 @@ resources = { mem = "2G", fsize = "100M", cpu = "5s" }
         assert!(err.to_string().contains("profile 'fetch' not found"), "{err}");
     }
 
+    /// A `net.mode = "host"` box that cannot resolve a name is a box that looks
+    /// like a host with no network, and the cause is one symlink: `/etc` is
+    /// granted, `/etc/resolv.conf` points outside it, and Landlock follows the
+    /// link. The grant is the same on every host whether or not the file is
+    /// there, because a digest that varied with `/etc` could not promise that
+    /// two boxes with one digest were allowed the same things.
+    #[test]
+    fn the_resolver_config_is_granted_wherever_it_actually_lives() {
+        let p = Profile::builtin("default", IsolationClaim::Process);
+        // WSL, which is where this was found.
+        assert!(p.fs_read.iter().any(|s| s == "/mnt/wsl/resolv.conf"), "{:?}", p.fs_read);
+        // systemd-resolved, the common case everywhere else.
+        assert!(
+            p.fs_read.iter().any(|s| s == "/run/systemd/resolve/stub-resolv.conf"),
+            "{:?}",
+            p.fs_read
+        );
+        // One file each. `/run` itself is not a grant, and neither is the
+        // directory holding the stub.
+        assert!(!p.fs_read.iter().any(|s| s == "/run"), "{:?}", p.fs_read);
+        assert!(!p.fs_read.iter().any(|s| s == "/mnt/wsl"), "{:?}", p.fs_read);
+
+        // The same list on an unconfined profile's absence of one: nothing is
+        // granted there at all, so the entries cannot leak in through it.
+        let open = Profile::builtin("default", IsolationClaim::Workspace);
+        assert!(open.fs_read.is_empty(), "{:?}", open.fs_read);
+    }
+
     #[test]
     fn builtin_passes_term_for_interactive_sessions() {
         let p = Profile::builtin("default", IsolationClaim::Process);

--- a/crates/h5i-sandbox/src/sandbox_policy.rs
+++ b/crates/h5i-sandbox/src/sandbox_policy.rs
@@ -876,9 +876,46 @@ impl BrowserEngine {
 
 /// Read-only system paths granted by default at the `process` tier — enough to
 /// exec interpreters and link against system libraries, nothing under `$HOME`.
+/// Where `/etc/resolv.conf` actually lives, on the hosts where it is a symlink.
+///
+/// `/etc` is granted, so on a host whose resolver config is a real file inside
+/// it there is nothing to do. It is a symlink on more machines than one would
+/// like — WSL points it at `/mnt/wsl/resolv.conf`, systemd-resolved and
+/// resolvconf at somewhere under `/run` — and a Landlock grant follows the link
+/// to a path the domain never granted. What that costs is worth spelling out,
+/// because it does not read as a sandbox denial: `getaddrinfo` answers
+/// "Temporary failure in name resolution", every fetch fails before the wire,
+/// and a `net.mode = "host"` box looks like a host with no network. It took a
+/// boxed browser session and twenty minutes to find, on the box that has been
+/// this project's own development machine since the beginning.
+///
+/// **A static list rather than `canonicalize()`**, and that is the whole
+/// design. Resolving the link at runtime would grant the right path on every
+/// host and give the *same profile a different digest on each of them* — the
+/// one promise a policy digest makes is that two boxes with the same digest
+/// were allowed the same things, and a digest that varies with `/etc` cannot
+/// make it. These entries are the same everywhere, present or not: a grant for
+/// a path that does not exist is skipped by the Landlock builder, so a host
+/// with none of them enforces exactly what it enforced before.
+///
+/// Read-only, one file each, and none of them is a way out of anything: a
+/// `deny` box has no network to resolve for, and a `host` box already reaches
+/// everything. `/run` itself stays ungranted.
+const RESOLVER_PATHS: &[&str] = &[
+    // WSL2.
+    "/mnt/wsl/resolv.conf",
+    // systemd-resolved, stub and non-stub.
+    "/run/systemd/resolve/stub-resolv.conf",
+    "/run/systemd/resolve/resolv.conf",
+    // Debian's resolvconf, and NetworkManager writing its own.
+    "/run/resolvconf/resolv.conf",
+    "/run/NetworkManager/resolv.conf",
+];
+
 fn default_fs_read() -> Vec<String> {
     ["/usr", "/lib", "/lib64", "/bin", "/sbin", "/etc", "/nix", "/opt", "/tmp", "/dev/null", "/dev/zero", "/dev/urandom", "/proc"]
         .iter()
+        .chain(RESOLVER_PATHS.iter())
         .map(|s| s.to_string())
         .collect()
 }

--- a/docs/_static/blog.css
+++ b/docs/_static/blog.css
@@ -245,8 +245,8 @@ main > section > .container { padding: 0; max-width: none; margin: 0; }
 .section-title {
   font-family: var(--disp); font-weight: 900;
   font-size: clamp(30px, 3.8vw, 54px);
-  letter-spacing: -0.045em; line-height: 0.95;
-  margin: 20px 0 0; max-width: 20ch; color: var(--ink);
+  letter-spacing: -0.045em; word-spacing: 0.12em; line-height: 0.95;
+  margin: 20px 0 0; max-width: 23ch; color: var(--ink);
 }
 .section-title br { display: none; }
 .section-sub {
@@ -693,7 +693,7 @@ article.post .post-cta h3,
 #cta .cta-title {
   font-family: var(--disp); font-weight: 900;
   font-size: clamp(28px, 3.4vw, 44px);
-  letter-spacing: -0.05em; line-height: 0.95;
+  letter-spacing: -0.05em; word-spacing: 0.12em; line-height: 0.95;
   margin: 0; max-width: 16ch; color: var(--ink);
 }
 article.post .post-cta p,

--- a/docs/blog/agents-share-information-never-permissions/index.html
+++ b/docs/blog/agents-share-information-never-permissions/index.html
@@ -92,7 +92,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/blog/choosing-agent-isolation/index.html
+++ b/docs/blog/choosing-agent-isolation/index.html
@@ -76,7 +76,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/blog/evidence-for-agent-work/index.html
+++ b/docs/blog/evidence-for-agent-work/index.html
@@ -76,7 +76,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -54,7 +54,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/blog/prompt-injection-is-a-boundary-problem/index.html
+++ b/docs/blog/prompt-injection-is-a-boundary-problem/index.html
@@ -76,7 +76,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/blog/the-environment-is-the-sandbox/index.html
+++ b/docs/blog/the-environment-is-the-sandbox/index.html
@@ -76,7 +76,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/blog/the-h5i-loop/index.html
+++ b/docs/blog/the-h5i-loop/index.html
@@ -92,7 +92,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/features/index.html
+++ b/docs/features/index.html
@@ -183,7 +183,7 @@
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap">
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet"></noscript>
-  <link rel="stylesheet" href="/_static/blog.css?v=98424fdf62">
+  <link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598">
   <link rel="stylesheet" href="/_static/console-mock.css?v=f390229c34">
   <script type="application/ld+json">
   {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://h5i.dev/"},{"@type":"ListItem","position":2,"name":"Features","item":"https://h5i.dev/features/"}]}

--- a/docs/guides/drive-a-browser-session/index.html
+++ b/docs/guides/drive-a-browser-session/index.html
@@ -92,7 +92,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/guides/first-box/index.html
+++ b/docs/guides/first-box/index.html
@@ -84,7 +84,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -54,7 +54,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/guides/review-a-pull-request/index.html
+++ b/docs/guides/review-a-pull-request/index.html
@@ -84,7 +84,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/guides/run-a-forum/index.html
+++ b/docs/guides/run-a-forum/index.html
@@ -92,7 +92,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/guides/watch-the-browser/index.html
+++ b/docs/guides/watch-the-browser/index.html
@@ -84,7 +84,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/guides/write-a-box-policy/index.html
+++ b/docs/guides/write-a-box-policy/index.html
@@ -84,7 +84,7 @@
 }</script>
 <link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&amp;family=Space+Grotesk:wght@300;400;500;700&amp;family=Space+Mono:wght@400;700&amp;display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/_static/blog.css?v=98424fdf62"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
+<link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598"><link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
 </head>
 <body><nav class="blog-nav">
   <a class="nav-logo" href="/"><img src="/_static/logo.png" alt="h5i"><span>h5i</span></a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -176,7 +176,7 @@
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap">
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet"></noscript>
-  <link rel="stylesheet" href="/_static/blog.css?v=98424fdf62">
+  <link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598">
   <link rel="stylesheet" href="/_static/console-mock.css?v=f390229c34">
   <link rel="stylesheet" href="/_static/highlight.css?v=45984d5155">
   <style>

--- a/docs/man/man1/h5i.1
+++ b/docs/man/man1/h5i.1
@@ -1385,7 +1385,7 @@ Without this, `open` navigates the session it finds, because that is what openin
 \fB\-\-in\fR \fI<BOX>\fR
 Run the session inside this box instead of on this machine.
 
-The box must already exist (`h5i box`). Whether its egress allowlist is *enforced* depends on the tier: `supervised`, `container` and `microvm` apply it at the box\*(Aqs boundary, and only then does the session\*(Aqs request lane become host\-observed. On `workspace` and `process` the network scope is deny\-or\-host, so nothing outside the engine polices which hosts it reaches and the lane stays engine\-claimed. `h5i browser status` prints which of the two this session got; read it rather than assuming, and note the standing Linux trade\-off: the tiers that enforce egress cannot hold a resident session yet.
+The box must already exist (`h5i box`). A box that declares an egress allowlist has a tier that enforces it, because creation is fail\-closed on that combination, so the session\*(Aqs request lane becomes host\-observed: what it reached was also seen outside the engine. A box that declares none corroborates nothing, and the lane stays engine\-claimed. `h5i browser status` prints which of the two this session got; read it rather than assuming the box earned the stronger one. Note the standing Linux trade\-off: the tiers that enforce egress cannot hold a resident session yet, so today that combination is `microvm`, or a one\-shot `h5i browser read \-\-in`.
 .TP
 \fB\-\-allow\fR \fI<ORIGIN>\fR
 Grant an origin. Repeatable. Without any, nothing remote is reachable except the URL\*(Aqs own origin

--- a/docs/man/man1/h5i.1
+++ b/docs/man/man1/h5i.1
@@ -1584,9 +1584,9 @@ Write a PNG of the page this session is on
 Which session, when more than one is open. A name from `\-\-session` at open time, or an opaque id. Defaults to $H5I_BROWSER_SESSION, then to the session `open` last made
 .TP
 \fB\-\-out\fR \fI<PATH>\fR
-Where to write it. Defaults to a host\-named file in the session\*(Aqs own artifacts directory.
+Where to write it, on **this** machine. Defaults to a host\-named file in the session\*(Aqs own artifacts directory.
 
-For a session in a box this path is resolved **inside the box**, because that is the filesystem the engine has.
+The engine paints into a directory it is allowed to write and h5i moves the file here afterwards, so this is any path you can write, not a path the confined engine can. For a session in a box that means the file is carried out of the box \(em which needs a tier whose `/tmp` this machine shares, and says so when it does not.
 .TP
 \fB\-\-url\fR \fI<URL>\fR
 Go here first, then paint
@@ -1994,7 +1994,7 @@ Which session, when more than one is open. A name from `\-\-session` at open tim
 `button`, `link`, `textbox`, `checkbox`, ...
 .TP
 \fB\-\-name\fR \fI<TEXT>\fR
-The accessible name
+The accessible name, matched whole: case is ignored and whitespace collapsed, but half a name finds nothing
 .TP
 \fB\-\-url\fR \fI<URL>\fR
 Go here first, then read. One round trip where `navigate` and then this would be two, and the reply still names the URL it ended up on so a redirect is not silent

--- a/docs/man/man1/h5i.1
+++ b/docs/man/man1/h5i.1
@@ -1385,7 +1385,7 @@ Without this, `open` navigates the session it finds, because that is what openin
 \fB\-\-in\fR \fI<BOX>\fR
 Run the session inside this box instead of on this machine.
 
-The box must already exist (`h5i box`). Its egress allowlist is enforced at the box\*(Aqs boundary, so the session\*(Aqs request lane becomes host\-observed.
+The box must already exist (`h5i box`). Whether its egress allowlist is *enforced* depends on the tier: `supervised`, `container` and `microvm` apply it at the box\*(Aqs boundary, and only then does the session\*(Aqs request lane become host\-observed. On `workspace` and `process` the network scope is deny\-or\-host, so nothing outside the engine polices which hosts it reaches and the lane stays engine\-claimed. `h5i browser status` prints which of the two this session got; read it rather than assuming, and note the standing Linux trade\-off: the tiers that enforce egress cannot hold a resident session yet.
 .TP
 \fB\-\-allow\fR \fI<ORIGIN>\fR
 Grant an origin. Repeatable. Without any, nothing remote is reachable except the URL\*(Aqs own origin
@@ -1799,13 +1799,18 @@ Everything recorded about this session, in one ordered timeline
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBaudit\fR [\fB\-s\fR|\fB\-\-session\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBaudit\fR [\fB\-s\fR|\fB\-\-session\fR] [\fB\-\-no\-session\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
 .TP
 \fB\-s\fR, \fB\-\-session\fR \fI<NAME>\fR
 Which session, when more than one is open. A name from `\-\-session` at open time, or an opaque id. Defaults to $H5I_BROWSER_SESSION, then to the session `open` last made
+.TP
+\fB\-\-no\-session\fR
+The helper runs that belong to no session.
+
+`h5i browser transcript \-\-via yt\-dlp \-\-url <URL>` needs no page and so opens no session; the run is still recorded, and this is where. Kept out of a session\*(Aqs own timeline on purpose: a run that was not part of a session must not appear inside it.
 .TP
 \fB\-\-json\fR
 
@@ -1866,7 +1871,7 @@ Read it with an outside program instead of from the page\*(Aqs markup.
 
 **It is a different lane, not a better one.** yt\-dlp opens its own sockets from a process the engine never sees, so nothing it fetches is in `h5i browser requests` and nothing can be: the reply says so, and `h5i browser audit` carries the run as a host\-observed row. It runs where the session runs, inside the box for a boxed session, and it is never a fallback: an engine read that found no captions stays a read that found none. The reply says what actually saw its traffic, which for a box depends on whether that box\*(Aqs tier enforces egress at all.
 
-With `\-\-via`, `\-\-url` names the media and the session does not move: there is no page here to render.
+With `\-\-via`, `\-\-url` names the media and the session does not move: there is no page here to render. With **no session open at all**, `\-\-url` is the whole of what this lane needs: the run happens on this machine, contained by nothing h5i enforces, says so in its `evidence` line, and is recorded in `h5i browser audit \-\-no\-session`. To place it behind a boundary, open a session with `\-\-in <box>` and it runs in there.
 .TP
 \fB\-\-json\fR
 

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -314,7 +314,7 @@ agent and the human can operate on.</p>
 <hr />
 <h2 id="the-loop">The loop</h2>
 <p>Reading and acting on a page, which needs nothing else:</p>
-<pre><code class="language-bash">h5i browser open https://example.com --allow example.com
+<pre><code class="language-bash">h5i browser open https://example.com       # the page grants itself; `--allow` adds more
 h5i browser snapshot                       # the outline, with @ref handles
 h5i browser click @e3
 h5i browser requests                       # what it reached, and what was refused
@@ -466,6 +466,16 @@ whether or not there is a box.</p>
 status line:</p>
 <pre><code>requests : engine-claimed (fail-closed, and the engine's own account of what it fetched)
 </code></pre>
+<h4 id="the-page-grants-itself">The page grants itself</h4>
+<p>A session reaches the URL it was opened on, and nothing else remote. Naming a
+URL and then naming its origin again is ceremony that teaches nothing, so
+<code>open</code> grants the page it was given exactly as <code>read</code> grants its targets.
+<code>--allow</code> is for the origins beyond it: an API the page calls, a CDN it pulls
+from. Loopback is reachable by default because it is the dev server, and
+<code>--no-loopback</code> takes that back.</p>
+<p>The grant is the page and not "and whatever this page pulls in". An off-origin
+subresource is still refused, and still says so in the request log, which is
+the part a wider default would have given away.</p>
 <h3 id="read-one-page-no-session"><code>read</code>: one page, no session</h3>
 <pre><code class="language-bash">h5i browser read https://example.com
 h5i browser read url1 url2 url3 --json
@@ -641,15 +651,28 @@ problem. A spawn that fails falls back to one process on its own, and says so.</
 h5i browser open https://example.com --in web
 h5i browser snapshot  # identical verb, identical answer
 </code></pre>
-<p><code>--in</code> changes nothing you type. It changes <strong>who saw the network</strong>. The box
-enforces its egress allowlist at its own boundary, which is outside the thing
-being described, so the session's lane is upgraded:</p>
+<p><code>--in</code> changes nothing you type. It changes <strong>who saw the network</strong>, when the
+box's tier is one that applies its egress allowlist at its own boundary. That
+boundary is outside the thing being described, so the session's lane is
+upgraded:</p>
 <pre><code>requests : host-observed (also seen at the box's boundary, outside the engine)
 </code></pre>
 <p>Being in a box is not by itself enough to earn that line. A box whose policy
 lets the engine reach the whole host network corroborates nothing, and such a
 session stays <code>engine-claimed</code>. What earns <code>host-observed</code> is an egress
 allowlist or a <code>deny</code> net mode — enforcement outside the engine.</p>
+<p><strong>What <code>net.egress</code> means on a tier that does not enforce it.</strong> h5i hands the
+box's list to the engine either way, so a session there starts with those
+origins granted. On <code>supervised</code>, <code>container</code> and <code>microvm</code> the same list is
+applied at the boundary, and it bounds what anything in the box can reach. On
+<code>workspace</code> and <code>process</code> the network scope is deny or host and nothing applies
+it per host: the list arrives as a <strong>default</strong> for the engine's own allowlist,
+not as a ceiling, so <code>--allow</code> adds to it and so does naming a start URL. An
+agent inside such a box reaches past the list exactly as <code>curl</code> in that box
+does. That is not the browser getting around something. It is what a tier with
+no network boundary means, and it is why a session there keeps saying
+<code>engine-claimed</code> and why <code>h5i browser status</code> is the line to read rather than
+the tier's name.</p>
 <p>Two mechanics are worth knowing, because they explain the shape of the feature:</p>
 <ul>
 <li><strong>The engine runs as a service, not as a run.</strong> <code>h5i box run</code> holds the box's
@@ -772,7 +795,8 @@ host-observed row carrying the exact argv h5i executed:</p>
   stays a read that found none. A silent fallback would move a session's traffic
   outside the engine's log without anyone asking, which is the one thing that
   log promises cannot happen.</li>
-<li><strong>It runs where the session runs.</strong> A boxed session runs yt-dlp <em>inside its
+<li><strong>It runs where the session runs, and with no session it runs here.</strong> A
+  boxed session runs yt-dlp <em>inside its
   box</em>, and a boxed session whose box has no yt-dlp is refused rather than
   served from the host: running it outside would move the session's network to a
   boundary its caller did not choose. Whether that box has an egress boundary at
@@ -807,6 +831,16 @@ if any part of a run failed, so a run that wrote the transcript and then hit a
 rate limit on a second language is a complete answer reported as a failure. h5i
 reports it as an answer, and puts the partial failure in the note beside it,
 because that is what explains a missing title.</p>
+<p><strong>No session is needed when <code>--url</code> names the media.</strong> There is no page here to
+render, so the only thing a session was ever contributing to this lane is a
+placement, and a run with none happens on this machine. It says exactly that in
+its <code>evidence</code> line, it opens no session and leaves none behind, and it is
+still written down: <code>h5i browser audit --no-session</code> lists the runs that belong
+to no session, with the same argv and the same host-observed lane as a row
+inside a session's timeline. They are kept out of that timeline on purpose,
+because a run that was not part of a session must not appear inside one. To put
+the run behind a boundary, open a session with <code>--in &lt;box&gt;</code> and it runs in
+there.</p>
 <p>A host session's helper is contained by whatever started h5i, and the reply says
 that too rather than implying a boundary that is not there. Automatic captions
 are labelled as automatic, because a machine transcription mishears names and a

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -48,7 +48,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
   <noscript><link href="https://fonts.googleapis.com/css2?family=Archivo:wght@700;800;900&family=Space+Grotesk:wght@300;400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet"></noscript>
-  <link rel="stylesheet" href="/_static/blog.css?v=98424fdf62">
+  <link rel="stylesheet" href="/_static/blog.css?v=ccfaa76598">
   <style>
     /* The manual is the site's article layout with a two-level index: the
        measure sits beside a sticky section list, both hung off the sheet's

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -661,18 +661,29 @@ upgraded:</p>
 lets the engine reach the whole host network corroborates nothing, and such a
 session stays <code>engine-claimed</code>. What earns <code>host-observed</code> is an egress
 allowlist or a <code>deny</code> net mode — enforcement outside the engine.</p>
-<p><strong>What <code>net.egress</code> means on a tier that does not enforce it.</strong> h5i hands the
-box's list to the engine either way, so a session there starts with those
-origins granted. On <code>supervised</code>, <code>container</code> and <code>microvm</code> the same list is
-applied at the boundary, and it bounds what anything in the box can reach. On
-<code>workspace</code> and <code>process</code> the network scope is deny or host and nothing applies
-it per host: the list arrives as a <strong>default</strong> for the engine's own allowlist,
-not as a ceiling, so <code>--allow</code> adds to it and so does naming a start URL. An
-agent inside such a box reaches past the list exactly as <code>curl</code> in that box
-does. That is not the browser getting around something. It is what a tier with
-no network boundary means, and it is why a session there keeps saying
-<code>engine-claimed</code> and why <code>h5i browser status</code> is the line to read rather than
-the tier's name.</p>
+<p><strong>Can <code>--allow</code> get around the box's <code>net.egress</code>?</strong> No, and the reason is at
+creation rather than in the browser. A profile that declares an egress
+allowlist cannot be created at a tier that cannot enforce one:</p>
+<pre><code>$ h5i box create webtest --profile browser --isolation process
+Error: profile 'browser' sets a net.egress domain allowlist, but isolation
+'process' cannot enforce it (process-v1 supports net.mode deny|host only) —
+use a supervisor/container backend or drop net.egress (fail-closed)
+</code></pre>
+<p>So a box whose list reaches the engine is a box with a boundary underneath it.
+h5i does hand that list to the engine, and <code>--allow</code> and the start URL add to
+it, but what they add is what the engine will <em>ask</em> for. What leaves the box is
+still decided outside it:</p>
+<pre><code>$ h5i browser read https://example.com --in webbox   # webbox allows en.wikipedia.org
+  confined : box webbox, policy 2bb35dc2fa6c...
+https://example.com: could not open https://example.com/: denied by policy:
+`example.com` could not be resolved: Temporary failure in name resolution
+</code></pre>
+<p>The engine granted the target it was handed, exactly as <code>read</code> always does, and
+the box's pinned DNS refused it anyway.</p>
+<p>A box that declares no egress list has nothing to widen: its net mode is host
+or deny, nothing outside the engine is deciding about hosts, and a session
+there keeps saying <code>engine-claimed</code>. That line, not the tier's name, is what
+says whether anything corroborated the request log.</p>
 <p>Two mechanics are worth knowing, because they explain the shape of the feature:</p>
 <ul>
 <li><strong>The engine runs as a service, not as a run.</strong> <code>h5i box run</code> holds the box's

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -2632,6 +2632,18 @@ so "what was enforced" is never a matter of trust.</p>
 <p>Runtime scoping is not cosmetic: a Claude box must not get Codex's credentials
 or egress to OpenAI, because a prompt-injected agent could otherwise read the
 <em>other</em> runtime's token and use it against an allowlisted host.</p>
+<p>A note on the one grant nobody would think to write. The built-in read set
+carries the handful of paths <code>/etc/resolv.conf</code> is a symlink <em>to</em>
+(<code>/mnt/wsl/resolv.conf</code> on WSL, the systemd-resolved and resolvconf locations
+under <code>/run</code>), one file each. <code>/etc</code> alone is not enough, because Landlock
+follows the link to a path the box was never granted, and what that costs does
+not look like a denied file: <code>getaddrinfo</code> answers "Temporary failure in name
+resolution" and a <code>net.mode = "host"</code> box reads as a machine with no network.
+The entries are the same on every host whether the files exist or not, because
+a grant resolved from the local <code>/etc</code> would give one profile a different
+policy digest on every machine. <strong>A custom profile that sets <code>fs.read</code>
+replaces that list</strong>, so a box of your own with <code>mode = "host"</code> needs the line
+for your host, which <code>readlink -f /etc/resolv.conf</code> names.</p>
 <p>Custom profiles live in <code>.h5i/env.toml</code>:</p>
 <pre><code class="language-toml">[profile.review]
 isolation = &quot;supervised&quot;

--- a/skills/h5i/SKILL.md
+++ b/skills/h5i/SKILL.md
@@ -26,7 +26,7 @@ Reach for it before guessing at a flag.
 ## 1. Browsing
 
 ```bash
-h5i browser open https://example.com --allow example.com
+h5i browser open https://example.com   # the page grants itself; `--allow` adds origins
 h5i browser snapshot             # the outline, with @ref handles — read this, not HTML
 h5i browser click @e3
 h5i browser type @e5 "test@example.com"

--- a/skills/h5i/references/browser.md
+++ b/skills/h5i/references/browser.md
@@ -26,12 +26,12 @@ verb table and cannot go stale.
 either: a session on this machine is not sandboxed, and a box that lets the
 browser reach the whole network does not upgrade the lane.
 
-A box's `net.egress` bounds what the session can reach only on a tier that
-enforces egress (`supervised`, `container`, `microvm`). On `workspace` and
-`process` the network scope is deny or host, so that list reaches the engine as
-a default for its allowlist rather than as a ceiling: `--allow` adds to it, and
-so does the start URL. Nothing outside the engine polices it there, which is
-what `engine-claimed` is saying.
+`--allow` cannot get around a box's `net.egress`. A profile that declares one
+cannot be created at a tier that cannot enforce it (creation is fail-closed), so
+a box with a list has a boundary underneath it: the flag widens what the engine
+will *ask* for, and what leaves the box is still decided outside it. A box that
+declares no list has nothing to widen, its net mode being host or deny, and a
+session there stays `engine-claimed`.
 
 `--in` needs a box on a tier that can hold a resident process. If yours cannot,
 `start` says so before it starts anything, and names the fix.

--- a/skills/h5i/references/browser.md
+++ b/skills/h5i/references/browser.md
@@ -4,7 +4,7 @@ A **session** is the unit. It holds one page state, one cookie jar, one request
 log and one policy, and it is addressed by an id:
 
 ```bash
-h5i browser open https://example.com --allow example.com   # -> br_7k2xqa
+h5i browser open https://example.com   # -> br_7k2xqa; the page grants itself
 h5i browser <verb> br_7k2xqa ...
 h5i browser close
 ```
@@ -26,8 +26,23 @@ verb table and cannot go stale.
 either: a session on this machine is not sandboxed, and a box that lets the
 browser reach the whole network does not upgrade the lane.
 
+A box's `net.egress` bounds what the session can reach only on a tier that
+enforces egress (`supervised`, `container`, `microvm`). On `workspace` and
+`process` the network scope is deny or host, so that list reaches the engine as
+a default for its allowlist rather than as a ceiling: `--allow` adds to it, and
+so does the start URL. Nothing outside the engine polices it there, which is
+what `engine-claimed` is saying.
+
 `--in` needs a box on a tier that can hold a resident process. If yours cannot,
 `start` says so before it starts anything, and names the fix.
+
+## What a session may reach
+
+The page it was opened on, loopback, and whatever `--allow` names. Nothing
+else: an off-origin subresource is refused and says so in `h5i browser
+requests`, which is the log's whole point. The grant is fixed when the engine
+starts, so `--allow` on a second `open` is refused rather than ignored, and
+`--no-loopback` takes back the dev-server exemption.
 
 ## Which engine
 
@@ -110,6 +125,23 @@ read.
 Every read verb takes `--url`, which goes there first and then reads. Prefer it:
 one round trip where `navigate` and then the read would be two, and the reply
 still names the URL it ended up on, so a redirect is not silent.
+
+## What the page's media says
+
+```bash
+h5i browser transcript                                    # the page's `<track>` captions
+h5i browser transcript --via yt-dlp --url <video url>     # captions no markup carries
+```
+
+`--via yt-dlp` is a different lane, not a better one: yt-dlp opens its own
+sockets, so nothing it fetches is in `h5i browser requests` and nothing can be.
+The reply says so, and the run lands in `h5i browser audit` as a host-observed
+row. It is never a fallback. An engine read that found no captions stays a read
+that found none.
+
+It runs where the session runs, inside the box for a boxed session. With `--url`
+and no session open it runs on this machine, contained by nothing h5i enforces,
+and is recorded in `h5i browser audit --no-session`.
 
 ## Naming an element without a `@ref`
 

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -322,11 +322,14 @@ pub enum BrowserCommands {
         /// $H5I_BROWSER_SESSION, then to the session `open` last made.
         #[arg(long, short = 's', value_name = "NAME")]
         session: Option<String>,
-        /// Where to write it. Defaults to a host-named file in the session's
-        /// own artifacts directory.
+        /// Where to write it, on **this** machine. Defaults to a host-named
+        /// file in the session's own artifacts directory.
         ///
-        /// For a session in a box this path is resolved **inside the box**,
-        /// because that is the filesystem the engine has.
+        /// The engine paints into a directory it is allowed to write and h5i
+        /// moves the file here afterwards, so this is any path you can write,
+        /// not a path the confined engine can. For a session in a box that
+        /// means the file is carried out of the box — which needs a tier whose
+        /// `/tmp` this machine shares, and says so when it does not.
         #[arg(long, value_name = "PATH")]
         out: Option<PathBuf>,
         /// Go here first, then paint.
@@ -679,7 +682,8 @@ pub enum BrowserCommands {
         /// `button`, `link`, `textbox`, `checkbox`, …
         #[arg(long, value_name = "ROLE")]
         role: String,
-        /// The accessible name.
+        /// The accessible name, matched whole: case is ignored and whitespace
+        /// collapsed, but half a name finds nothing.
         #[arg(long, value_name = "TEXT")]
         name: Option<String>,
         /// Go here first, then read. One round trip where `navigate` and then
@@ -1682,15 +1686,19 @@ fn preflight_box(
         );
     }
 
-    // 2. The box's h5i has to be one that carries an engine.
+    // 2. The box's h5i has to be one it can run, and one that carries an
+    //    engine. **Two failures, and they are told apart by the shell's own
+    //    exit codes** rather than by guessing.
     //
-    //    A weaker check than the one this replaced, and a more useful one. The
-    //    old check asked whether a *second binary* could be executed at all,
-    //    because Landlock makes `~/.cargo/bin` readable and not executable and
-    //    `command -v` could not tell. That cannot happen now. What can is a box
-    //    running an older or `--no-default-features` h5i, which has no
-    //    `__engine` — and the failure looks identical from outside either way:
-    //    the session never advertises.
+    //    An earlier version of this comment said the first could not happen any
+    //    more. It happens on the machine this was written on: a `cargo install`
+    //    h5i lives in `~/.cargo/bin`, which every profile grants **read** and
+    //    none grants **exec**, so `command -v h5i` inside the box finds it and
+    //    running it dies with `Permission denied`. Reporting that as "no
+    //    browser engine in it" sends whoever reads it to rebuild a binary that
+    //    was fine. `sh` answers 126 for "found it, could not execute it" and
+    //    127 for "no such command", which is exactly the distinction, and it
+    //    survives the redirection that keeps the probe quiet.
     let probe = Command::new(std::env::current_exe()?)
         .arg("box")
         .arg("run")
@@ -1703,18 +1711,33 @@ fn preflight_box(
             h5i_in_box()
         ))
         .output()?;
-    if !probe.status.success() {
-        anyhow::bail!(
-            "the `{}` inside box `{name}` has no browser engine in it.\n\n  \
+    let binary = h5i_in_box();
+    match probe.status.code() {
+        Some(0) => Ok(()),
+        // Found and not executable. Almost always the h5i on `PATH` being a
+        // `cargo install` one, so the fix is named rather than described.
+        Some(126) => anyhow::bail!(
+            "box `{name}` cannot execute `{binary}`.\n\n  \
+             A box grants `~/.cargo/bin` and `~/.local/bin` **read** and not **exec**, so an \
+             h5i installed there is visible inside the box and cannot be run. Install one \
+             where the box may execute it:\n    \
+             sudo install -m755 $(command -v h5i) /usr/local/bin/h5i\n\n  \
+             Or set $H5I_IN_BOX to a path inside the box that is executable there."
+        ),
+        Some(127) => anyhow::bail!(
+            "there is no `{binary}` in box `{name}`.\n\n  \
+             `--in` carries every verb into the box by running h5i there, so the box needs \
+             one on its `PATH`. Install it at a system path, or set $H5I_IN_BOX to where it \
+             actually is inside the box."
+        ),
+        _ => anyhow::bail!(
+            "the `{binary}` inside box `{name}` has no browser engine in it.\n\n  \
              The engine is part of the h5i binary, so the box needs an h5i new enough to \
              carry one, built with the `browser` feature. Check what it has:\n    \
-             h5i box run {name} -- {} --version\n\n  \
-             Set $H5I_IN_BOX to point at a different one inside the box.",
-            h5i_in_box(),
-            h5i_in_box()
-        );
+             h5i box run {name} -- {binary} --version\n\n  \
+             Set $H5I_IN_BOX to point at a different one inside the box."
+        ),
     }
-    Ok(())
 }
 
 fn spawn_in_box(name: &str, dir: &Path, opts: &StartOptions) -> anyhow::Result<Spawned> {
@@ -2199,8 +2222,11 @@ fn seed_storage(root: &Path, from: &str, into: &Path) -> anyhow::Result<()> {
 ///   writable there — and the reply says it is inside the box rather than
 ///   printing a host path that does not exist.
 ///
-/// An explicit `--out` is taken as given in both cases, because a caller who
-/// named a path named it for a reason.
+/// `--out` is a **host** path in both cases, and h5i is what puts the file
+/// there. The engine paints where it is allowed to and never where the caller
+/// pointed: it is confined, h5i is not, and a path the caller named is h5i's to
+/// write. Handing it through was what made `--out ~/shot.png` fail with a bare
+/// `Permission denied` from a sandbox the caller never asked about.
 fn screenshot(
     root: &Path,
     selector: Option<&str>,
@@ -2216,57 +2242,138 @@ fn screenshot(
         }
     };
 
-    let path = match out {
-        Some(path) => path,
-        None => {
-            // Milliseconds, so two shots in one second are two files. A
-            // screenshot that silently replaced the previous one would lose the
-            // before-and-after that is most of why an agent takes two.
-            let stamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis())
-                .unwrap_or(0);
-            let name = format!("screenshot-{stamp}.png");
-            match &session.placement {
-                bs::Placement::Host => {
-                    let path = bs::artifact_path(root, &session.id, &name);
-                    if let Some(parent) = path.parent() {
-                        std::fs::create_dir_all(parent)?;
-                    }
-                    path
-                }
-                bs::Placement::Box { name: box_name } => {
-                    // The box's own /tmp, via the socket the record already
-                    // holds. Nothing here can create the directory: it is on
-                    // the far side of the boundary, and it exists because the
-                    // socket is bound in it.
-                    let control = session.control.file.clone().ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "this session in `{box_name}` names no control socket, so there is \
-                             no path inside the box to default to. Pass `--out <path>` naming \
-                             a file the box can write."
-                        )
-                    })?;
-                    let dir = control
-                        .parent()
-                        .map(Path::to_path_buf)
-                        .unwrap_or_else(|| PathBuf::from("/tmp"));
-                    dir.join(bs::safe_name(&name))
-                }
+    // Milliseconds, so two shots in one second are two files. A screenshot that
+    // silently replaced the previous one would lose the before-and-after that is
+    // most of why an agent takes two.
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let name = format!("screenshot-{stamp}.png");
+
+    // **The engine always paints into a directory it may write**, and h5i moves
+    // the file afterwards. Handing `--out` straight to the engine is what this
+    // used to do, and a confined session may write only its own directory, so
+    // `--out ~/shot.png` came back as a bare `Permission denied` — h5i asking a
+    // sandboxed process to write somewhere h5i itself could have written, and
+    // then reporting the sandbox's refusal as though the path were at fault.
+    // Which process holds the authority for a path the *caller* named is not a
+    // question the engine should be asked: it is the same rule the cookie jar
+    // already follows, h5i chooses the path and the engine only chooses the
+    // bytes.
+    let (painted, host_view) = match &session.placement {
+        bs::Placement::Host => {
+            let path = bs::artifact_path(root, &session.id, &name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
             }
+            (path.clone(), Some(path))
+        }
+        bs::Placement::Box { name: box_name } => {
+            // The box's own /tmp, via the socket the record already holds.
+            // Nothing here can create the directory: it is on the far side of
+            // the boundary, and it exists because the socket is bound in it.
+            let control = session.control.file.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "this session in `{box_name}` names no control socket, so there is no \
+                     path inside the box to paint into. Reopen the session, or take the \
+                     screenshot from a session on this machine."
+                )
+            })?;
+            let in_box = control
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(bs::safe_name(&name));
+            // Where this machine sees that same file, when it can see it at
+            // all. An image-backed tier keeps its `/tmp` inside the image, and
+            // then the file exists and is unreachable from here — which is a
+            // fact to report rather than to paper over.
+            let on_host = session
+                .control
+                .witness
+                .as_ref()
+                .and_then(|p| p.parent())
+                .map(|dir| dir.join(bs::safe_name(&name)));
+            (in_box, on_host)
         }
     };
 
     let mut argv = vec![
         "screenshot".to_string(),
         "--path".to_string(),
-        path.display().to_string(),
+        painted.display().to_string(),
     ];
     argv.extend(url_arg(url));
     // Painting does not move the page. Going somewhere first does, and the
     // control lock exists so a human at the wheel is not steered from under.
     let moves_the_page = argv.iter().any(|a| a == "--url");
-    verb(root, selector, argv, moves_the_page, json)
+
+    verb_then(root, selector, argv, moves_the_page, json, |answer| {
+        let Some(out) = out else {
+            return Ok(());
+        };
+        deliver_file(&painted, host_view.as_deref(), &out, &session)?;
+        // The reply names where the file *is*. An answer still pointing into
+        // the session's artifacts would send a caller to the copy h5i just
+        // moved away.
+        answer["path"] = Value::String(out.display().to_string());
+        Ok(())
+    })
+}
+
+/// Move the file the engine painted to where the caller asked for it.
+///
+/// The bytes are never lost. A copy that fails leaves the shot where the engine
+/// put it and says both paths, because "the screenshot could not be written" is
+/// false when it was written and only the second step failed.
+fn deliver_file(
+    painted: &Path,
+    host_view: Option<&Path>,
+    out: &Path,
+    session: &bs::Session,
+) -> anyhow::Result<()> {
+    let Some(source) = host_view else {
+        anyhow::bail!(
+            "the screenshot was painted inside the box, at {}, and this machine cannot see \
+             that filesystem — the box keeps its /tmp inside its image — so h5i cannot \
+             bring it out to {}.\n\n  \
+             Take it without `--out` and read it from inside the box, or place the session \
+             on a tier whose /tmp this machine shares.",
+            painted.display(),
+            out.display()
+        );
+    };
+    if source == out {
+        return Ok(());
+    }
+    if let Some(parent) = out.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            anyhow::anyhow!(
+                "the screenshot is at {}, and {} could not be created for it: {e}",
+                source.display(),
+                parent.display()
+            )
+        })?;
+    }
+    // Copy then remove, rather than `rename`: the two paths are routinely on
+    // different filesystems (a box's /tmp, a scratch mount), and a `rename`
+    // across one fails with `EXDEV` for a reason that has nothing to do with
+    // what the caller asked.
+    std::fs::copy(source, out).map_err(|e| {
+        anyhow::anyhow!(
+            "the screenshot was taken and is at {}, but it could not be copied to {}: {e}",
+            source.display(),
+            out.display()
+        )
+    })?;
+    // Best effort: the file is where it was asked for, and a leftover in the
+    // session's own directory is not worth failing a screenshot over. Kept for
+    // a boxed session, where the file is the box's and h5i took a copy.
+    if matches!(session.placement, bs::Placement::Host) {
+        let _ = std::fs::remove_file(source);
+    }
+    Ok(())
 }
 
 /// Send one verb to a session and print what came back.
@@ -2286,6 +2393,23 @@ fn verb(
     argv: Vec<String>,
     mutating: bool,
     json: bool,
+) -> anyhow::Result<()> {
+    verb_then(root, selector, argv, mutating, json, |_| Ok(()))
+}
+
+/// The same, with something to do to the answer before it is printed.
+///
+/// One caller: `screenshot --out`, which has to move a file the confined engine
+/// wrote and then say where it ended up. It runs only on an answer that was not
+/// a refusal, and it runs *before* the printing, because an answer naming a
+/// path the file is no longer at would be worse than no answer.
+fn verb_then(
+    root: &Path,
+    selector: Option<&str>,
+    argv: Vec<String>,
+    mutating: bool,
+    json: bool,
+    after: impl FnOnce(&mut Value) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     let session = match bs::resolve(root, selector) {
         Ok(session) => session,
@@ -2318,6 +2442,9 @@ fn verb(
     // script that checks the status code would read "denied by policy" as
     // success, which is the failure this whole design is arranged against.
     let refused = answer.get("ok").and_then(Value::as_bool) == Some(false);
+    if !refused {
+        after(&mut answer)?;
+    }
 
     if json {
         println!("{}", serde_json::to_string_pretty(&answer)?);

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -106,9 +106,16 @@ pub enum BrowserCommands {
 
         /// Run the session inside this box instead of on this machine.
         ///
-        /// The box must already exist (`h5i box`). Its egress allowlist is
-        /// enforced at the box's boundary, so the session's request lane
-        /// becomes host-observed.
+        /// The box must already exist (`h5i box`). Whether its egress
+        /// allowlist is *enforced* depends on the tier: `supervised`,
+        /// `container` and `microvm` apply it at the box's boundary, and only
+        /// then does the session's request lane become host-observed. On
+        /// `workspace` and `process` the network scope is deny-or-host, so
+        /// nothing outside the engine polices which hosts it reaches and the
+        /// lane stays engine-claimed. `h5i browser status` prints which of the
+        /// two this session got; read it rather than assuming, and note the
+        /// standing Linux trade-off: the tiers that enforce egress cannot hold
+        /// a resident session yet.
         #[arg(long = "in", value_name = "BOX")]
         in_box: Option<String>,
 
@@ -472,6 +479,14 @@ pub enum BrowserCommands {
         /// $H5I_BROWSER_SESSION, then to the session `open` last made.
         #[arg(long, short = 's', value_name = "NAME")]
         session: Option<String>,
+        /// The helper runs that belong to no session.
+        ///
+        /// `h5i browser transcript --via yt-dlp --url <URL>` needs no page and
+        /// so opens no session; the run is still recorded, and this is where.
+        /// Kept out of a session's own timeline on purpose: a run that was not
+        /// part of a session must not appear inside it.
+        #[arg(long = "no-session", conflicts_with = "session")]
+        no_session: bool,
         #[arg(long)]
         json: bool,
     },
@@ -556,7 +571,12 @@ pub enum BrowserCommands {
         /// egress at all.
         ///
         /// With `--via`, `--url` names the media and the session does not move:
-        /// there is no page here to render.
+        /// there is no page here to render. With **no session open at all**,
+        /// `--url` is the whole of what this lane needs: the run happens on
+        /// this machine, contained by nothing h5i enforces, says so in its
+        /// `evidence` line, and is recorded in
+        /// `h5i browser audit --no-session`. To place it behind a boundary,
+        /// open a session with `--in <box>` and it runs in there.
         #[arg(long, value_name = "HELPER")]
         via: Option<String>,
         #[arg(long)]
@@ -1051,7 +1071,17 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
             }
             verb(&root, session.as_deref(), argv, false, json)
         }
-        BrowserCommands::Audit { session, json } => audit(&root, session.as_deref(), json),
+        BrowserCommands::Audit {
+            session,
+            no_session,
+            json,
+        } => {
+            if no_session {
+                sessionless_audit(&root, json)
+            } else {
+                audit(&root, session.as_deref(), json)
+            }
+        }
         BrowserCommands::Env { session, json } => {
             verb(&root, session.as_deref(), vec!["env".into()], false, json)
         }
@@ -1983,14 +2013,53 @@ fn locator(
 
 fn net_args(opts: &StartOptions) -> Vec<String> {
     let mut argv = Vec::new();
-    for origin in &opts.allow {
+    for origin in granted_origins(opts) {
         argv.push("--allow".to_string());
-        argv.push(origin.clone());
+        argv.push(origin);
     }
     if opts.no_loopback {
         argv.push("--no-loopback".into());
     }
     argv
+}
+
+/// What this session is allowed to reach: the origins the caller named, and the
+/// page it asked to open.
+///
+/// The second half is not a convenience, it is the difference between `open`
+/// working and not. The engine is fail-closed and a navigation is policy-checked
+/// like any other request, so a session started with an empty allowlist denied
+/// the very page it was told to open — `h5i browser open https://example.com`
+/// came back "origin `https://example.com` is not in the allowlist", while
+/// `--allow`'s own help promised that a URL's own origin is reachable without
+/// it. Loopback is exempt by default, which is why every test and every dev
+/// server missed this and why the first remote URL anyone typed hit it.
+///
+/// `read` has granted its targets this way since it was written
+/// ([`origins_of`]), and this is the same rule for the session lane: the page
+/// and nothing else. An off-origin subresource is still refused and still says
+/// so in the request log, and widening the grant to "and whatever this page
+/// pulls in" is the thing neither lane does.
+///
+/// Handed to the engine verbatim, because its `--allow` normalizes with the
+/// same code that later checks a request — a second notion of "origin" here is
+/// a second one to drift. Only a `http`/`https` target grants anything: a page
+/// opened from a file needs no grant, and a bare path normalizes to a host that
+/// was never asked for.
+fn granted_origins(opts: &StartOptions) -> Vec<String> {
+    let mut origins = opts.allow.clone();
+    if is_web_url(&opts.url) && !origins.contains(&opts.url) {
+        origins.push(opts.url.clone());
+    }
+    origins
+}
+
+/// Whether a target is fetched over the network, judged by its scheme alone.
+fn is_web_url(target: &str) -> bool {
+    let target = target.trim_start();
+    ["http://", "https://"]
+        .iter()
+        .any(|scheme| target.len() > scheme.len() && target[..scheme.len()].eq_ignore_ascii_case(scheme))
 }
 
 /// The digest of what a host session was allowed to do.
@@ -1999,9 +2068,18 @@ fn net_args(opts: &StartOptions) -> Vec<String> {
 /// allowlist and the two switches it was started with. Digesting them means
 /// two sessions with the same digest were allowed the same things, which is the
 /// only promise the field makes anywhere.
+///
+/// The *effective* allowlist, [`granted_origins`], and not the flags alone: the
+/// page a session was opened on is in its policy, so two sessions opened
+/// somewhere else entirely were allowed different things and must not digest
+/// the same. It is the start URL as typed rather than the origin derived from
+/// it, so two sessions opened on two pages of one site digest differently
+/// though their grants match — the promise is that an equal digest means equal
+/// grants, and this keeps that direction true without a second notion of
+/// "origin" here to drift from the engine's.
 fn host_policy_digest(opts: &StartOptions) -> String {
     use sha2::{Digest, Sha256};
-    let mut allow = opts.allow.clone();
+    let mut allow = granted_origins(opts);
     allow.sort();
     let material = format!(
         "host\nallow={}\nloopback={}\nscript={}\n",
@@ -2285,29 +2363,51 @@ fn via_helper(
         );
     }
 
+    // A session when there is one, and none when there is not.
+    //
+    // **Only when the caller named neither a session nor a URL is a missing
+    // session an error.** `--url` names the media and this lane renders no
+    // page, so a session would contribute nothing here but a placement; asking
+    // for one anyway is what made `h5i browser transcript --via yt-dlp --url …`
+    // answer with the closing note of a session that had nothing to do with the
+    // question. A `--session` that names something gone is still an error,
+    // because running somewhere else would move the lane to a boundary the
+    // caller did not choose — the same rule that keeps a boxed run out of the
+    // host.
     let session = match bs::resolve(root, selector) {
-        Ok(session) => session,
-        Err(gone) => {
+        Ok(session) => Some(session),
+        Err(gone) if selector.is_some() || url.is_none() => {
             eprintln!("{gone}");
             std::process::exit(bs::EXIT_SESSION_GONE);
         }
+        Err(_) => None,
     };
-    let dir = bs::dir(root, &session.id);
 
     // Not a mutation: nothing here touches the page. The lock is still asked,
     // because a human at the controls of a session is a human whose box should
-    // not have a second program started against it behind their back.
-    if let Some(explanation) = h5i_core::control::check(&dir, false).explain() {
+    // not have a second program started against it behind their back. A run
+    // with no session steers nothing and asks nobody.
+    if let Some(session) = &session
+        && let Some(explanation) =
+            h5i_core::control::check(&bs::dir(root, &session.id), false).explain()
+    {
         anyhow::bail!("{explanation}");
     }
 
     // The page the session is actually on, when the caller did not name a URL.
     // Asked rather than read off the record: `session.url` is what `open` was
     // *told*, and a redirect or a click has moved it since.
-    let target = match url {
-        Some(named) => named,
-        None => {
-            let status = deliver(&session, &dir, vec!["status".to_string()])?;
+    let target = match (&url, &session) {
+        (Some(named), _) => named.clone(),
+        // Unreachable by the arms above: a caller with no URL and no session
+        // has already been sent away with the session's own explanation.
+        (None, None) => anyhow::bail!(
+            "there is no session to read a URL from and none was named. \
+             Name one with `--url`."
+        ),
+        (None, Some(session)) => {
+            let dir = bs::dir(root, &session.id);
+            let status = deliver(session, &dir, vec!["status".to_string()])?;
             status
                 .get("url")
                 .and_then(Value::as_str)
@@ -2321,9 +2421,14 @@ fn via_helper(
         }
     };
 
+    let site = match &session {
+        Some(session) => helper::Site::Session(session),
+        None => helper::Site::sessionless(),
+    };
+
     let outcome = helper::transcript(
         root,
-        &session,
+        &site,
         &target,
         lang.as_deref(),
         max_bytes.unwrap_or(h5i_browser_light::transcript::DEFAULT_MAX_BYTES),
@@ -2949,6 +3054,58 @@ fn audit(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()> 
     }
     if audit.events.is_empty() {
         println!("  nothing recorded for this session yet.");
+    }
+    Ok(())
+}
+
+/// The helper runs that belong to no session.
+///
+/// A separate command rather than a section of the timeline above, because
+/// these runs were not part of any session and putting them in one session's
+/// audit would be a claim about that session that is not true. They are the
+/// same rows in the same shape, read from
+/// [`bs::SESSIONLESS_HELPERS_FILE`](h5i_core::browser_session::SESSIONLESS_HELPERS_FILE),
+/// and every one of them is host-observed: h5i built the argv and ran the
+/// program, so the row is an observation rather than the helper's account of
+/// itself.
+fn sessionless_audit(root: &Path, json: bool) -> anyhow::Result<()> {
+    let rows = bs::sessionless_helpers(root)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("  no helper has run outside a session on this machine.");
+        return Ok(());
+    }
+
+    println!("  runs     : {} with no session", rows.len());
+    println!(
+        "  {}     h5i ran these itself, so every row is an observation.",
+        style("note").dim()
+    );
+    println!(
+        "           None of their fetches are in `h5i browser requests`: \
+         they were not the engine's."
+    );
+    println!();
+    for row in &rows {
+        let outcome = match row.status {
+            Some(0) | None => String::new(),
+            Some(code) => format!("  (exit {code})"),
+        };
+        println!(
+            "  {}  {}  helper {} {}{outcome}",
+            style("host  ").green(),
+            row.at,
+            row.name,
+            row.argv.join(" ")
+        );
+        if let Some(note) = &row.note {
+            println!("          {}", style(bs::scrub_text(note)).dim());
+        }
     }
     Ok(())
 }

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -106,16 +106,16 @@ pub enum BrowserCommands {
 
         /// Run the session inside this box instead of on this machine.
         ///
-        /// The box must already exist (`h5i box`). Whether its egress
-        /// allowlist is *enforced* depends on the tier: `supervised`,
-        /// `container` and `microvm` apply it at the box's boundary, and only
-        /// then does the session's request lane become host-observed. On
-        /// `workspace` and `process` the network scope is deny-or-host, so
-        /// nothing outside the engine polices which hosts it reaches and the
-        /// lane stays engine-claimed. `h5i browser status` prints which of the
-        /// two this session got; read it rather than assuming, and note the
-        /// standing Linux trade-off: the tiers that enforce egress cannot hold
-        /// a resident session yet.
+        /// The box must already exist (`h5i box`). A box that declares an
+        /// egress allowlist has a tier that enforces it, because creation is
+        /// fail-closed on that combination, so the session's request lane
+        /// becomes host-observed: what it reached was also seen outside the
+        /// engine. A box that declares none corroborates nothing, and the lane
+        /// stays engine-claimed. `h5i browser status` prints which of the two
+        /// this session got; read it rather than assuming the box earned the
+        /// stronger one. Note the standing Linux trade-off: the tiers that
+        /// enforce egress cannot hold a resident session yet, so today that
+        /// combination is `microvm`, or a one-shot `h5i browser read --in`.
         #[arg(long = "in", value_name = "BOX")]
         in_box: Option<String>,
 

--- a/src/cli/helper.rs
+++ b/src/cli/helper.rs
@@ -85,6 +85,13 @@ pub const NAME: &str = "yt-dlp";
 /// something else entirely.
 const FALLBACKS: &[&str] = &["/usr/local/bin/yt-dlp", "/usr/bin/yt-dlp"];
 
+/// Where a run with no session writes, under the browser state directory.
+///
+/// One directory per run, named for the run, because [`scrub`] reads back
+/// whatever it finds in there and reports it as the transcript: two runs
+/// sharing a directory is two runs able to answer with each other's captions.
+const SESSIONLESS_WORK: &str = "helpers";
+
 /// How long the helper may run before it is killed.
 ///
 /// A transcript is a metadata fetch and a subtitle file. Two minutes is
@@ -164,15 +171,69 @@ pub struct Outcome {
 /// reads the page it is on, and the helper reads a URL directly, so moving the
 /// session to a page nobody is going to read would be a page load spent on
 /// nothing.
+/// Where a run is placed, and what it is recorded against.
+///
+/// The three facts this lane takes from a session and no others: an id to name
+/// the workspace and the log, a placement to run in, and a lane to report
+/// honestly. Naming them makes the second case expressible — a `--via` run with
+/// a `--url` needs no page, so it needs no session, and demanding one was a
+/// requirement of the code rather than of the design.
+pub enum Site<'a> {
+    /// A session: the helper runs where that session runs, inside its box for a
+    /// boxed one, and its row lands in that session's helper log.
+    Session(&'a bs::Session),
+    /// No session at all. `--url` named the media, so nothing was left for a
+    /// session to contribute but a placement, and the placement is this
+    /// machine, contained by whatever the shell that started h5i is contained
+    /// by. Recorded in [`bs::SESSIONLESS_HELPERS_FILE`], because a run nobody
+    /// wrote down is the one thing this lane may not produce.
+    Sessionless { id: String },
+}
+
+impl Site<'_> {
+    /// A fresh home for a run with no session.
+    ///
+    /// The id carries the clock and the process, which is enough to be unique
+    /// among the runs one machine can start: [`scrub`] refuses a directory it
+    /// did not just create, so a collision is a refusal rather than one run
+    /// reading another's output.
+    pub fn sessionless() -> Site<'static> {
+        let at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_micros())
+            .unwrap_or_default();
+        Site::Sessionless {
+            id: format!("{}-{at}", std::process::id()),
+        }
+    }
+
+    fn id(&self) -> &str {
+        match self {
+            Site::Session(session) => &session.id,
+            Site::Sessionless { id } => id,
+        }
+    }
+
+    /// Where the helper runs. A run with no session runs here: there is no
+    /// session whose boundary it could have been placed inside.
+    fn placement(&self) -> &bs::Placement {
+        const HERE: bs::Placement = bs::Placement::Host;
+        match self {
+            Site::Session(session) => &session.placement,
+            Site::Sessionless { .. } => &HERE,
+        }
+    }
+}
+
 pub fn transcript(
     root: &Path,
-    session: &bs::Session,
+    site: &Site,
     url: &str,
     lang: Option<&str>,
     max_bytes: usize,
 ) -> anyhow::Result<Outcome> {
     let url = check_url(url)?;
-    let work = workspace(root, session)?;
+    let work = workspace(root, site)?;
     scrub(&work)?;
 
     // The default is written down once, here, and used for **both** the pattern
@@ -204,7 +265,7 @@ pub fn transcript(
     // serve a flag whose only honest meaning here was "the same words in forty
     // languages". It is gone, and so is the machinery.
     let argv = build_argv(&url, want, &work.in_helper);
-    let (status, said) = run(session, &argv, &work)?;
+    let (status, said) = run(site, &argv, &work)?;
     let read = collect(&work.host, Some(literal_prefix(want)), max_bytes);
 
     let mut note = describe(&read, want, status, &said);
@@ -219,14 +280,13 @@ pub fn transcript(
     // whole value is that its claims are exact. Two places that decorate one
     // string is a bug waiting for an edit; one place cannot double it, and the
     // row and the reply now say the same sentence for the same reason.
-    if let Some(receipt) = box_receipt(session, &work) {
+    if let Some(receipt) = box_receipt(site, &work) {
         note.push_str(&format!(" Box receipt {receipt}."));
     }
-    record(root, session, &work, &argv, status, &note);
-
+    record(root, site, &work, &argv, status, &note);
 
     Ok(Outcome {
-        reply: render(&url, session, &read, &note),
+        reply: render(&url, site, &read, &note),
         argv,
         status,
         answered: !read.cues.is_empty(),
@@ -241,7 +301,7 @@ pub fn transcript(
 /// successes would report a quiet session where a program ran and failed.
 fn record(
     root: &Path,
-    session: &bs::Session,
+    site: &Site,
     _work: &Workspace,
     argv: &[String],
     status: Option<i32>,
@@ -249,18 +309,21 @@ fn record(
 ) {
     // Written verbatim. Decorating here as well as at the call site is what
     // doubled the receipt claim once already.
-    let _ = bs::record_helper(
-        root,
-        &session.id,
-        &bs::HelperRow {
-            // Stamped by `record_helper`, from the clock the audit sorts on.
-            at: String::new(),
-            name: NAME.to_string(),
-            argv: argv.to_vec(),
-            status,
-            note: Some(note.to_string()),
-        },
-    );
+    let row = bs::HelperRow {
+        // Stamped when it is appended, from the clock the audit sorts on.
+        at: String::new(),
+        name: NAME.to_string(),
+        argv: argv.to_vec(),
+        status,
+        note: Some(note.to_string()),
+    };
+    // A run with no session has no session log to land in, and dropping the row
+    // rather than writing it elsewhere would make "every run is recorded" true
+    // only of the runs that had a session open.
+    let _ = match site {
+        Site::Session(session) => bs::record_helper(root, &session.id, &row),
+        Site::Sessionless { .. } => bs::record_sessionless_helper(root, &row),
+    };
 }
 
 /// The literal head of a `--sub-langs` value.
@@ -388,11 +451,22 @@ struct Workspace {
 ///
 /// The id rather than the name: a name can be reused once the session it named
 /// has ended, which is what makes it comfortable to type and useless here.
-fn leaf(session: &bs::Session) -> String {
-    format!("helper-{}", session.id)
+fn leaf(site: &Site) -> String {
+    format!("helper-{}", site.id())
 }
 
-fn workspace(root: &Path, session: &bs::Session) -> anyhow::Result<Workspace> {
+fn workspace(root: &Path, site: &Site) -> anyhow::Result<Workspace> {
+    // No session, and so no session directory. Beside `sessions/` rather than
+    // in it: the browser state directory is h5i's own, which is the one
+    // property this needs, and a run that is not a session must not leave
+    // something session-shaped behind for `h5i browser list` to explain.
+    let Site::Session(session) = site else {
+        let dir = root.join(SESSIONLESS_WORK).join(leaf(site));
+        return Ok(Workspace {
+            in_helper: dir.join("%(id)s").display().to_string(),
+            host: dir,
+        });
+    };
     match &session.placement {
         bs::Placement::Host => {
             // Already per-session here, since the parent is the session's own
@@ -400,7 +474,7 @@ fn workspace(root: &Path, session: &bs::Session) -> anyhow::Result<Workspace> {
             // helper writes is one rule to check, and a reader comparing the
             // two arms should not have to work out whether the difference
             // matters.
-            let dir = bs::dir(root, &session.id).join(leaf(session));
+            let dir = bs::dir(root, &session.id).join(leaf(site));
             Ok(Workspace {
                 in_helper: dir.join("%(id)s").display().to_string(),
                 host: dir,
@@ -415,7 +489,7 @@ fn workspace(root: &Path, session: &bs::Session) -> anyhow::Result<Workspace> {
                 .ok_or_else(|| {
                     anyhow::anyhow!("this session's record does not name the box's own /tmp")
                 })?
-                .join(leaf(session));
+                .join(leaf(site));
             // `None` means this machine cannot see the box's `/tmp` at all: an
             // image-backed tier is the designed reason, and a session that died
             // before its record was complete is the accidental one. Either way
@@ -441,7 +515,7 @@ fn workspace(root: &Path, session: &bs::Session) -> anyhow::Result<Workspace> {
                          or read this URL with `--via` unset."
                     )
                 })?
-                .join(leaf(session));
+                .join(leaf(site));
             Ok(Workspace {
                 in_helper: in_box.join("%(id)s").display().to_string(),
                 host: on_host,
@@ -505,11 +579,11 @@ fn build_argv(url: &str, langs: &str, out: &str) -> Vec<String> {
 
 /// Run it where the session runs, and nowhere else.
 fn run(
-    session: &bs::Session,
+    site: &Site,
     argv: &[String],
     work: &Workspace,
 ) -> anyhow::Result<(Option<i32>, String)> {
-    let mut command = match &session.placement {
+    let mut command = match site.placement() {
         bs::Placement::Host => {
             let binary = locate().ok_or_else(|| {
                 anyhow::anyhow!(
@@ -577,7 +651,7 @@ fn run(
         }
     };
 
-    let mut said = complaint(&session.placement, work);
+    let mut said = complaint(site.placement(), work);
     if timed_out {
         said.push_str(&format!(
             "\nh5i stopped `{NAME}` after {}s, its whole budget for one transcript.",
@@ -630,12 +704,12 @@ fn complaint(placement: &bs::Placement, work: &Workspace) -> String {
 /// row in the box's own receipt log, written by h5i from outside the helper,
 /// naming the policy the run was subject to. The audit row carries it so the
 /// two records can be put beside each other.
-fn box_receipt(session: &bs::Session, work: &Workspace) -> Option<String> {
+fn box_receipt(site: &Site, work: &Workspace) -> Option<String> {
     // Only where there *is* a box. On the host, `stderr.log` is yt-dlp's own
     // stderr, and any line of it carrying `receipt ` and eight hex digits would
     // have this claim a box receipt for a run that never entered one — a false
     // evidence claim, in the one lane whose entire value is evidence honesty.
-    if !matches!(session.placement, bs::Placement::Box { .. }) {
+    if !matches!(site.placement(), bs::Placement::Box { .. }) {
         return None;
     }
     let text = std::fs::read_to_string(work.host.join("stderr.log")).ok()?;
@@ -908,7 +982,7 @@ fn describe(read: &Read, want: &str, status: Option<i32>, stderr: &str) -> Strin
 /// transcript should not have to learn a second reading for the same question
 /// asked a different way — what differs is `source` and `evidence`, which is
 /// exactly the part that *should* differ and the part it must not miss.
-fn render(url: &str, session: &bs::Session, read: &Read, note: &str) -> Value {
+fn render(url: &str, site: &Site, read: &Read, note: &str) -> Value {
     let track = json!({
         "kind": "captions",
         "language": read.language,
@@ -939,10 +1013,10 @@ fn render(url: &str, session: &bs::Session, read: &Read, note: &str) -> Value {
         // The sentence that keeps the request log's claim true. Said in the
         // reply and not only in the audit, because the reply is what a model
         // reads and the audit is what a person reads afterwards.
-        "evidence": evidence(session),
+        "evidence": evidence(site),
         "media": [media],
         "note": note,
-        "text": text(url, session, read, note),
+        "text": text(url, site, read, note),
     })
 }
 
@@ -961,9 +1035,21 @@ fn render(url: &str, session: &bs::Session, read: &Read, note: &str) -> Value {
 /// so a boxed session is on `workspace` or `process`, and neither has a network
 /// boundary at all. `lane_for`'s own comment names this as the one error the
 /// product cannot afford, in the direction it cannot afford it in.
-fn evidence(session: &bs::Session) -> String {
+fn evidence(site: &Site) -> String {
     let common = "It is not the engine, so none of its fetches are in `h5i browser requests`. \
                   The run itself is in `h5i browser audit`.";
+    let Site::Session(session) = site else {
+        // No session, so no placement anyone chose and no session policy to
+        // have been checked against. Said as plainly as the host arm below,
+        // and pointing at the log this run actually landed in rather than at a
+        // session audit that does not contain it.
+        return format!(
+            "helper-observed. `{NAME}` ran on this machine with no browser session open, \
+             outside the engine and outside any boundary h5i enforces. It is not the engine, \
+             so none of its fetches are in `h5i browser requests`. The run itself is in \
+             `h5i browser audit --no-session`."
+        );
+    };
     match (&session.placement, session.lane) {
         (bs::Placement::Box { name }, bs::Lane::HostObserved) => format!(
             "helper-observed. `{NAME}` ran inside box `{name}`, whose boundary enforces egress, \
@@ -990,10 +1076,10 @@ fn evidence(session: &bs::Session) -> String {
 /// A transcript fetched by a helper is a stranger's words exactly as one parsed
 /// out of a `<track>` is, and it reaches the same reader making the same
 /// decision. The fence is not about which program did the fetching.
-fn text(url: &str, session: &bs::Session, read: &Read, note: &str) -> String {
+fn text(url: &str, site: &Site, read: &Read, note: &str) -> String {
     use h5i_browser_light::snapshot::{CONTENT_BEGIN, CONTENT_END};
 
-    let mut out = format!("url: {url}\nsource: {NAME}\nevidence: {}\n", evidence(session));
+    let mut out = format!("url: {url}\nsource: {NAME}\nevidence: {}\n", evidence(site));
     if let Some(title) = &read.title {
         out.push_str(&format!("title: {}\n", collapse(title)));
     }
@@ -1220,6 +1306,13 @@ mod tests {
         assert_eq!(argv[at + 1], "en", "not `en.*`: {argv:?}");
     }
 
+    /// A session, as the thing that gives a run its home. The tests below are
+    /// about what a *placement* produces, so the wrapping is noise in every one
+    /// of them.
+    fn placed(session: &bs::Session) -> Site<'_> {
+        Site::Session(session)
+    }
+
     fn session_at(placement: bs::Placement, lane: bs::Lane) -> bs::Session {
         session_with_control(placement, lane, None, None)
     }
@@ -1243,6 +1336,103 @@ mod tests {
         session
     }
 
+    /// A run with no session is a run this lane can do, and it says so.
+    ///
+    /// `--url` names the media and this lane renders no page, so a session was
+    /// never contributing anything here but a placement — and requiring one
+    /// meant `h5i browser transcript --via yt-dlp --url <a video>` answered
+    /// with the closing note of whatever session had last been open, which had
+    /// nothing to do with the question asked.
+    #[test]
+    fn a_run_with_no_session_is_placed_here_and_says_so() {
+        let site = Site::sessionless();
+        let said = evidence(&site);
+        assert!(said.contains("no browser session open"), "{said}");
+        // The same two claims every other arm makes: not the engine, and not
+        // in the engine's request log.
+        assert!(said.contains("not the engine"), "{said}");
+        assert!(
+            said.contains("none of its fetches are in `h5i browser requests`"),
+            "{said}"
+        );
+        // And it points at the log this run actually lands in, rather than at
+        // a session audit that does not contain it.
+        assert!(said.contains("audit --no-session"), "{said}");
+        // Nothing outside the engine held it, and it must not read as though
+        // something had.
+        assert!(!said.contains("enforces egress"), "{said}");
+    }
+
+    /// It writes beside the sessions rather than inside one: a run that is not
+    /// a session must leave nothing session-shaped behind for
+    /// `h5i browser list` to have to explain.
+    #[test]
+    fn a_run_with_no_session_writes_beside_the_sessions() {
+        let site = Site::sessionless();
+        let work = workspace(Path::new("/state"), &site).expect("a workspace");
+        assert!(
+            work.host.starts_with("/state/helpers/"),
+            "{:?}",
+            work.host
+        );
+        assert!(
+            !work.host.to_string_lossy().contains("/sessions/"),
+            "a run with no session claimed a session directory: {:?}",
+            work.host
+        );
+        assert_eq!(
+            work.in_helper,
+            work.host.join("%(id)s").display().to_string(),
+            "here the two views are one directory"
+        );
+
+        // One directory per run: `scrub` reports whatever it finds in there as
+        // the transcript, so two runs sharing one is two runs able to answer
+        // with each other's captions.
+        let second = workspace(Path::new("/state"), &Site::sessionless()).unwrap();
+        assert_ne!(work.host, second.host);
+    }
+
+    /// Every run is recorded, including the ones with no session to record it
+    /// in. A lane whose whole value is that it is written down cannot have a
+    /// case that quietly is not.
+    #[test]
+    fn a_run_with_no_session_is_still_written_down() {
+        let root = std::env::temp_dir().join(format!("h5i-loose-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let work_dir = root.join("work");
+        std::fs::create_dir_all(&work_dir).unwrap();
+
+        record(
+            &root,
+            &Site::sessionless(),
+            &workspace_at(&work_dir),
+            &["yt-dlp".to_string(), "--skip-download".to_string()],
+            Some(0),
+            "1 cue(s) in en.",
+        );
+
+        let rows = bs::sessionless_helpers(&root).expect("the log h5i just wrote");
+        assert_eq!(rows.len(), 1, "{rows:?}");
+        assert_eq!(rows[0].name, NAME);
+        assert!(rows[0].argv.contains(&"--skip-download".to_string()));
+        // Stamped when it was appended, from the clock an audit sorts on.
+        assert!(!rows[0].at.is_empty(), "{rows:?}");
+        // And it is not in any session's log, because it was not part of one.
+        assert!(!root.join("sessions").exists(), "it invented a session");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// An empty answer and an unreadable log are opposite facts, and the
+    /// ordinary case is that no run of this kind has ever happened.
+    #[test]
+    fn a_helper_log_that_is_not_there_is_no_runs_rather_than_an_error() {
+        let root = std::env::temp_dir().join(format!("h5i-loose-none-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        assert!(bs::sessionless_helpers(&root).unwrap().is_empty());
+    }
+
     /// Being in a box is not the same as being behind a boundary. On Linux
     /// today the tiers that enforce egress cannot hold a resident browser
     /// session at all, so every boxed session is on a tier that confines files
@@ -1250,24 +1440,28 @@ mod tests {
     /// the boundary for all of them.
     #[test]
     fn a_box_without_an_egress_boundary_is_not_reported_as_having_one() {
-        let unenforced = evidence(&session_at(
+        let unenforced = evidence(&placed(&session_at(
             bs::Placement::Box { name: "capbox".into() },
             bs::Lane::EngineClaimed,
-        ));
+        )));
         assert!(unenforced.contains("not** its network"), "{unenforced}");
         assert!(
             !unenforced.contains("crossed the same enforcement"),
             "a process-tier box polices files, not egress: {unenforced}"
         );
 
-        let enforced = evidence(&session_at(
+        let enforced = evidence(&placed(&session_at(
             bs::Placement::Box { name: "capbox".into() },
             bs::Lane::HostObserved,
-        ));
+        )));
         assert!(enforced.contains("enforces egress"), "{enforced}");
 
         // And neither of them ever claims the request log saw it.
-        for text in [unenforced, enforced, evidence(&session_at(bs::Placement::Host, bs::Lane::EngineClaimed))] {
+        for text in [
+            unenforced,
+            enforced,
+            evidence(&placed(&session_at(bs::Placement::Host, bs::Lane::EngineClaimed))),
+        ] {
             assert!(text.contains("not the engine"), "{text}");
             assert!(
                 text.contains("none of its fetches are in `h5i browser requests`"),
@@ -1288,7 +1482,7 @@ mod tests {
             Some("/tmp/h5i-browser.sock"),
             Some("/home/u/.h5i/env/wsbox/tmp/h5i-browser.sock"),
         );
-        let work = workspace(Path::new("/state"), &session).expect("both views");
+        let work = workspace(Path::new("/state"), &placed(&session)).expect("both views");
         assert_eq!(work.in_helper, "/tmp/helper-br_test/%(id)s", "the box's own path");
         assert_eq!(
             work.host,
@@ -1308,7 +1502,7 @@ mod tests {
             Some("/tmp/h5i-browser.sock"),
             None,
         );
-        let err = workspace(Path::new("/state"), &session)
+        let err = workspace(Path::new("/state"), &placed(&session))
             .expect_err("no host view, no run")
             .to_string();
         assert!(err.contains("cannot see box `imagebox`'s /tmp"), "{err}");
@@ -1320,7 +1514,7 @@ mod tests {
     #[test]
     fn a_host_run_writes_beside_the_session() {
         let session = session_at(bs::Placement::Host, bs::Lane::EngineClaimed);
-        let work = workspace(Path::new("/state"), &session).expect("a host workspace");
+        let work = workspace(Path::new("/state"), &placed(&session)).expect("a host workspace");
         assert!(work.host.ends_with("helper-br_test"), "{:?}", work.host);
         assert!(
             work.in_helper.ends_with("helper-br_test/%(id)s"),
@@ -1402,7 +1596,7 @@ mod tests {
             bs::Lane::EngineClaimed,
         );
         assert_eq!(
-            box_receipt(&boxed_session, &work).as_deref(),
+            box_receipt(&placed(&boxed_session), &work).as_deref(),
             Some("f31bdc823671183e")
         );
         // And never for a run that had no box: on the host that same file is
@@ -1410,7 +1604,7 @@ mod tests {
         // false evidence claim in the reply.
         let host_session = session_at(bs::Placement::Host, bs::Lane::EngineClaimed);
         assert!(
-            box_receipt(&host_session, &work).is_none(),
+            box_receipt(&placed(&host_session), &work).is_none(),
             "a host run has no box receipt to claim"
         );
 
@@ -1444,7 +1638,7 @@ mod tests {
 
         record(
             &root,
-            &session,
+            &placed(&session),
             &work,
             &["yt-dlp".to_string()],
             Some(0),
@@ -1481,7 +1675,7 @@ mod tests {
             bs::Lane::EngineClaimed,
         );
         assert!(
-            box_receipt(&boxed_session, &work).is_none(),
+            box_receipt(&placed(&boxed_session), &work).is_none(),
             "no receipt file, no receipt"
         );
 
@@ -1507,8 +1701,8 @@ mod tests {
         let mut b = a.clone();
         b.id = "br_other".into();
 
-        let wa = workspace(Path::new("/state"), &a).unwrap();
-        let wb = workspace(Path::new("/state"), &b).unwrap();
+        let wa = workspace(Path::new("/state"), &placed(&a)).unwrap();
+        let wb = workspace(Path::new("/state"), &placed(&b)).unwrap();
         assert_ne!(wa.host, wb.host, "two sessions, two directories");
         assert_ne!(wa.in_helper, wb.in_helper);
         assert!(wa.host.to_string_lossy().contains("br_test"), "{:?}", wa.host);

--- a/src/cli/helper.rs
+++ b/src/cli/helper.rs
@@ -600,6 +600,25 @@ fn run(
         // Never on the host as a fallback: that would move the session's
         // network to a boundary its caller did not choose.
         bs::Placement::Box { name } => {
+            // Asked before the run, the way [`locate`] asks on the host, and
+            // for the same reason: a box with no yt-dlp in it otherwise
+            // produced `failed: it said nothing`. `h5i box run` fails to exec
+            // the program and says so on **its** stderr, which [`complaint`]
+            // deliberately does not read — it holds h5i's receipt line, not the
+            // helper's words — so the one fact the caller needed was the one
+            // thing discarded. `sh` answers 127 for a command it cannot find.
+            if !present_in_box(name)? {
+                anyhow::bail!(
+                    "`{NAME}` is not in box `{name}`, and this session runs there.\n\n  \
+                     A box sees the system paths and not your `$HOME`, so an install under \
+                     `~/.local/bin` or in a virtualenv is invisible in there. Put it where \
+                     the box can reach it:\n    \
+                     sudo install -m755 $(command -v {NAME}) /usr/local/bin/{NAME}\n\n  \
+                     Or read this URL with `--via` unset. h5i does not fall back to the \
+                     host: running it out there would move this session's network to a \
+                     boundary its caller did not choose."
+                );
+            }
             let mut command = Command::new(std::env::current_exe()?);
             command
                 .arg("box")
@@ -719,6 +738,25 @@ fn box_receipt(site: &Site, work: &Workspace) -> Option<String> {
         .take_while(|c| c.is_ascii_hexdigit())
         .collect();
     (id.len() >= 8).then_some(id)
+}
+
+/// Is the helper in that box at all?
+///
+/// Through `sh` rather than by execing the program directly, because the answer
+/// wanted here is the shell's: 127 is "no such command", and `h5i box run`
+/// asked to exec a program that is not there reports its own error with its own
+/// exit code instead.
+fn present_in_box(name: &str) -> anyhow::Result<bool> {
+    let probe = Command::new(std::env::current_exe()?)
+        .arg("box")
+        .arg("run")
+        .arg(name)
+        .arg("--")
+        .arg("sh")
+        .arg("-c")
+        .arg(format!("command -v {NAME} >/dev/null 2>&1"))
+        .output()?;
+    Ok(probe.status.success())
 }
 
 /// `yt-dlp`, from `PATH` or from the two places an install lands.

--- a/tests/browser_session_cli.rs
+++ b/tests/browser_session_cli.rs
@@ -866,6 +866,48 @@ fn a_named_session_that_has_ended_is_refused_rather_than_run_here() {
     assert!(why.contains(&id), "{why}");
 }
 
+/// `--out` is a path on **this** machine, and h5i is what writes it.
+///
+/// The engine is confined to its own directory, so handing it the caller's path
+/// made `--out ~/shot.png` fail with a bare `Permission denied` from a sandbox
+/// the caller never asked about. It paints where it may write and h5i moves the
+/// file, which is the rule the cookie jar already follows: h5i chooses the
+/// path, the engine only chooses the bytes.
+#[test]
+fn a_screenshot_goes_where_the_caller_asked_and_not_where_the_engine_may_write() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let id = fx.open(&[]);
+
+    // Deliberately outside everything the session's sandbox can write: a
+    // directory made after the engine started, which no grant can name.
+    let elsewhere = tempfile::tempdir().expect("a directory of our own");
+    let out = elsewhere.path().join("deeper").join("shot.png");
+
+    let taken = fx.run(&["browser", "screenshot", "--out", out.to_str().unwrap(), "--json"]);
+    assert!(
+        taken.status.success(),
+        "screenshot failed: {}",
+        String::from_utf8_lossy(&taken.stderr)
+    );
+    let answer: serde_json::Value = serde_json::from_slice(&taken.stdout).unwrap();
+    // The reply names where the file is, not where it was painted.
+    assert_eq!(answer["path"].as_str(), out.to_str(), "{answer}");
+    let written = std::fs::metadata(&out).expect("the file the reply named");
+    assert!(written.len() > 0, "an empty screenshot");
+    assert_eq!(answer["bytes"].as_u64(), Some(written.len()), "{answer}");
+
+    // And nothing was left behind in the session's own artifacts: the file
+    // moved, it was not copied twice.
+    let leftovers: Vec<_> = std::fs::read_dir(fx.dir(&id).join("artifacts"))
+        .map(|d| d.flatten().map(|e| e.file_name()).collect())
+        .unwrap_or_default();
+    assert!(leftovers.is_empty(), "the shot was left in the session too: {leftovers:?}");
+
+    let _ = fx.run(&["browser", "close"]);
+}
+
 /// A read grants the targets it was given, and only those.
 ///
 /// The first half is why there is no `--allow`: a URL the caller typed is a URL

--- a/tests/browser_session_cli.rs
+++ b/tests/browser_session_cli.rs
@@ -657,6 +657,215 @@ fn a_read_leaves_no_session() {
     assert!(listed.is_empty(), "a read left a session behind: {listed:?}");
 }
 
+/// `open` grants the page it was told to open, and only that page.
+///
+/// The engine is fail-closed and a navigation is policy-checked like any other
+/// request, so without this grant a session denied the very URL it was started
+/// on: `h5i browser open https://example.com` came back "origin
+/// `https://example.com` is not in the allowlist" while `--allow`'s own help
+/// promised that a URL's own origin needs no grant. Loopback is exempt by
+/// default, which is why every test here — and every dev server — sailed past
+/// it, and why the first remote URL anyone typed hit it.
+///
+/// `--no-loopback` is what makes this test able to see it at all: it removes
+/// the exemption, so the only thing that can load a page on 127.0.0.1 is the
+/// grant `open` makes for the URL it was given.
+#[test]
+fn an_open_grants_the_page_it_was_opened_on() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let url = format!("{}/third-party", fx.site.base);
+    // No `--allow`: naming the URL is what grants it, exactly as it is for
+    // `read`.
+    let out = fx.run(&["browser", "open", &url, "--no-loopback", "--json"]);
+    assert!(
+        out.status.success(),
+        "a session was denied the page it was opened on: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let snapshot = fx.run(&["browser", "snapshot"]);
+    assert!(
+        String::from_utf8_lossy(&snapshot.stdout).contains("third party"),
+        "the page did not load: {}",
+        String::from_utf8_lossy(&snapshot.stdout)
+    );
+
+    // And the grant is the page, not "and whatever this page pulls in": the
+    // off-origin image is still refused, and still says so in the log.
+    let out = fx.run(&["browser", "requests", "--json"]);
+    let answer: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let requests = answer["requests"].as_array().expect("a request log");
+    assert!(
+        requests.iter().any(|r| r["allowed"] == false),
+        "an off-origin subresource was not refused: {answer}"
+    );
+    let _ = fx.run(&["browser", "close"]);
+}
+
+/// Two sessions allowed different things must not digest the same.
+///
+/// The policy digest is the only durable claim about what a host session could
+/// reach, and the page a session was opened on is part of its allowlist now. A
+/// digest taken over the flags alone would have called two sessions with
+/// different reach identical, which is the one direction this field must not be
+/// wrong in.
+#[test]
+fn the_policy_digest_follows_the_page_the_session_was_opened_on() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let one = fx.run(&["browser", "open", &fx.site.base, "--json"]);
+    let one: serde_json::Value = serde_json::from_slice(&one.stdout).unwrap();
+    let again = fx.run(&["browser", "open", &fx.site.base, "--new", "--json"]);
+    let again: serde_json::Value = serde_json::from_slice(&again.stdout).unwrap();
+    // The same start, so the same grants, so the same digest. Two sessions
+    // allowed the same things is exactly what an equal digest claims.
+    assert_eq!(one["policy_digest"], again["policy_digest"], "{one} {again}");
+
+    // Somewhere else entirely. It cannot serve a page, but the record a failed
+    // start leaves behind still carries the policy it was started with, which
+    // is the part under test.
+    let elsewhere = fx.run(&["browser", "open", "http://127.0.0.2:9/", "--new", "--json"]);
+    let listed = fx.run(&["browser", "list", "--all", "--json"]);
+    let listed: Vec<serde_json::Value> = serde_json::from_slice(&listed.stdout).unwrap();
+    let other = listed
+        .iter()
+        .find(|s| s["url"].as_str() == Some("http://127.0.0.2:9/"))
+        .unwrap_or_else(|| panic!("the failed start left no record: {:?}", elsewhere.status));
+    assert_ne!(
+        other["policy_digest"], one["policy_digest"],
+        "two sessions granted different origins digested the same"
+    );
+    let _ = fx.run(&["browser", "close", "--all"]);
+}
+
+/// The helper lane runs with no session, when `--url` names the media.
+///
+/// This is the shape an agent actually types for a video — `h5i browser
+/// transcript --via yt-dlp --url <url>` — and it used to answer with the
+/// closing note of whatever session had last been open, because the lane
+/// resolved a session before it did anything else. There is no page here to
+/// render and nothing for a session to contribute but a placement, so a run
+/// with none happens on this machine, says exactly that, and is still written
+/// down.
+///
+/// yt-dlp is stood in for. The lane's contract is that h5i builds the argv,
+/// runs the program where the session is, and records what it ran; none of
+/// that needs the real program, and a test that needed the network to pass
+/// would not be run.
+#[cfg(unix)]
+#[test]
+fn a_helper_run_needs_no_session_when_a_url_names_the_media() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let bin = fx.home.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let script = bin.join("yt-dlp");
+    // It expands `%(id)s` the way yt-dlp does and writes the two files h5i
+    // reads back: the captions and the metadata beside them.
+    std::fs::write(
+        &script,
+        r#"#!/bin/sh
+out=""
+while [ $# -gt 0 ]; do
+  if [ "$1" = "-o" ]; then out="$2"; fi
+  shift
+done
+out=$(printf '%s' "$out" | sed 's/%(id)s/vid/')
+printf 'WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhello from the helper\n' > "$out.en.vtt"
+printf '{"title":"A talk","subtitles":{"en":[]}}' > "$out.info.json"
+"#,
+    )
+    .unwrap();
+    std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = fx.run_with(
+        &[
+            "browser",
+            "transcript",
+            "--via",
+            "yt-dlp",
+            "--url",
+            "https://video.example/watch?v=1",
+        ],
+        &[("PATH", path.as_str())],
+    );
+    assert!(
+        out.status.success(),
+        "a helper run with no session failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(text.contains("hello from the helper"), "{text}");
+    // And it says what held it, which was nothing.
+    assert!(text.contains("no browser session open"), "{text}");
+
+    // It invents no session on the way past.
+    let listed = fx.run(&["browser", "list", "--all", "--json"]);
+    let listed: Vec<serde_json::Value> = serde_json::from_slice(&listed.stdout).unwrap();
+    assert!(listed.is_empty(), "the helper lane left a session behind: {listed:?}");
+
+    // The run is recorded, and it is findable: a lane whose whole value is
+    // being written down cannot have a case that quietly is not.
+    let audit = fx.run(&["browser", "audit", "--no-session", "--json"]);
+    assert!(audit.status.success(), "{}", String::from_utf8_lossy(&audit.stderr));
+    let rows: Vec<serde_json::Value> = serde_json::from_slice(&audit.stdout).unwrap();
+    assert_eq!(rows.len(), 1, "{rows:?}");
+    assert_eq!(rows[0]["name"], "yt-dlp");
+    let argv: Vec<&str> = rows[0]["argv"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a.as_str().unwrap())
+        .collect();
+    assert!(
+        argv.contains(&"https://video.example/watch?v=1"),
+        "the row does not name what ran: {argv:?}"
+    );
+    // What h5i built, not what the helper says it did: the flags that keep the
+    // recorded argv a complete account travel with it.
+    assert!(argv.contains(&"--ignore-config"), "{argv:?}");
+}
+
+/// A `--session` that names something gone is still an error, even with a URL.
+///
+/// The rule the sessionless case must not erode: running somewhere else would
+/// move the lane to a boundary the caller did not choose, which is the same
+/// reason a boxed run is never served from the host.
+#[cfg(unix)]
+#[test]
+fn a_named_session_that_has_ended_is_refused_rather_than_run_here() {
+    let Some(fx) = Fixture::new() else {
+        return skip("no h5i binary to drive");
+    };
+    let id = fx.open(&[]);
+    assert!(fx.run(&["browser", "close"]).status.success());
+
+    let out = fx.run(&[
+        "browser",
+        "transcript",
+        "--via",
+        "yt-dlp",
+        "--session",
+        &id,
+        "--url",
+        "https://video.example/watch?v=1",
+    ]);
+    assert_eq!(out.status.code(), Some(EXIT_SESSION_GONE));
+    let why = String::from_utf8_lossy(&out.stderr);
+    assert!(why.contains(&id), "{why}");
+}
+
 /// A read grants the targets it was given, and only those.
 ///
 /// The first half is why there is no `--allow`: a URL the caller typed is a URL


### PR DESCRIPTION
…on, and a boundary claim withdrawn

Three things a real URL found the moment one was typed.

`open` denied the page it was told to open. The engine is fail-closed and a navigation is policy-checked like any other request, so a session started with an empty allowlist answered `h5i browser open https://example.com` with "origin `https://example.com` is not in the allowlist" — while `--allow`'s own help promised that a URL's own origin needs no grant. `read` has granted its targets since it was written; the session lane now does the same, through `granted_origins`, and the digest is taken over the effective list so two sessions allowed different things cannot digest the same. Loopback is exempt by default, which is why every test and every dev server sailed past this.

`transcript --via yt-dlp --url <video>` demanded a session it had no use for. There is no page here to render, so the only thing a session contributed was a placement, and the verb answered instead with the closing note of whatever session had last been open. The lane now takes a `Site`: a session when there is one, and this machine when there is not. A run with no session says so in its `evidence` line, invents no session, and is still written down — in `helpers.jsonl` at the root of the browser state directory, rendered by `h5i browser audit --no-session`, kept out of any session's timeline because it was not part of one. A `--session` naming something gone is still refused: running elsewhere would move the lane to a boundary its caller did not choose.

And `build_policy` claimed an agent could not widen a box's policy with `--allow` "because the sandbox's own egress enforcement is still the boundary underneath". True on supervised, container and microvm; false on workspace and process, whose network scope is deny-or-host. There the box's `net.egress` reaches the engine as a default rather than as a ceiling, and an agent in that box reaches past it exactly as `curl` does. The comment, the `--in` help, MANUAL.md and the browser skill now say that, which is what `engine-claimed` was already saying. The union stays a union: an intersection would read as enforcement while being bypassable by the agent that owns the environment it arrives in.