### PR TITLE
browser: the prelude compiled once and hidden inside the fetch, a Boa fork of one commit, and a crash that only happened at thread exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,8 +524,7 @@ dependencies = [
 [[package]]
 name = "boa_ast"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9221b0a090572b4a118b46c5874c0781fe4bc9546b85f0a615b8bfb609ca4ed7"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "bitflags 2.13.1",
  "boa_interner",
@@ -540,8 +539,7 @@ dependencies = [
 [[package]]
 name = "boa_engine"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6aaf7fdc4299df68adb67e1a5440a51d34630a1f5271b9698fd74bc97b60d9"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "aligned-vec",
  "arrayvec",
@@ -591,8 +589,7 @@ dependencies = [
 [[package]]
 name = "boa_gc"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af82119558ab1002d1978c8459b53a3ebb506177d29a3aca37c07c1777b1d966"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "arrayvec",
  "boa_macros",
@@ -604,8 +601,7 @@ dependencies = [
 [[package]]
 name = "boa_interner"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317c631e791f5cb7d0017e43c0a758b0eaffd40c34c4c360e2a6be7752b78cd1"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "boa_gc",
  "boa_macros",
@@ -620,8 +616,7 @@ dependencies = [
 [[package]]
 name = "boa_macros"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b882fd440dc0f4b7441367cf89567bb077920356750c9a76a16c002d8ec2fa5c"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "cfg-if",
  "cow-utils",
@@ -634,8 +629,7 @@ dependencies = [
 [[package]]
 name = "boa_parser"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641e81b3c8cbb7a2140547fb3ea534e9edf210b4e8c920b5fa864a919e11fbcf"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "bitflags 2.13.1",
  "boa_ast",
@@ -652,8 +646,7 @@ dependencies = [
 [[package]]
 name = "boa_string"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bf86c2bcff5bf2547acbfc516c5d3108ca527cb131511d749bf6fbef762c0e"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "fast-float2",
  "itoa",
@@ -1231,7 +1224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4970,8 +4963,7 @@ dependencies = [
 [[package]]
 name = "small_btree"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 dependencies = [
  "arrayvec",
 ]
@@ -5350,8 +5342,7 @@ dependencies = [
 [[package]]
 name = "tag_ptr"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+source = "git+https://github.com/h5i-dev/boa?rev=05a10e4ecf7ae72324138d80be2e9c47e99e7b3d#05a10e4ecf7ae72324138d80be2e9c47e99e7b3d"
 
 [[package]]
 name = "tagptr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,3 +152,32 @@ debug = false
 # will maintain, whatever the WPT arithmetic says. `:has()` is a named gap
 # again (`selector :has()` in the unsupported channel) until a Blitz release
 # depends on stylo >= 0.20, which is where to check `parse_has` next.
+
+# Boa, patched — and the distinction from the ruling above is the point.
+#
+# That ruling was against an in-tree *copy* of an engine crate: a vendored
+# directory this project would have had to maintain, diverging silently from
+# the crate it was forked from. This is the other shape. The fork lives outside
+# the tree, is pinned to one commit, and carries one commit of difference:
+# `Script::bind_to_realm`, which compiles a script once and runs it in many
+# fresh realms. Nothing in it is specific to this engine or this project, it is
+# written as an upstream pull request, and the exit is the same as every pin
+# here — when it lands upstream this goes back to plain crates.io.
+#
+# What it buys is in §B15.12a: parse and compile were 67 ms of the 83 ms a
+# realm cost, on every page, for a source that never changes. That section
+# refused a fork and asked for an upstream issue instead; the owner has since
+# ruled a minimal fork acceptable. Of its other two conclusions, one stands and
+# one did not survive being checked. Realm *reuse* stays refused, permanently,
+# and `bind_to_realm` is careful not to be it. The claim that inline caches
+# would carry one page's object shapes into the next was wrong — entries are
+# weak and matched by shape identity, so a second realm can never hit them —
+# but the remedy it named, clearing them, is still right for a different
+# reason: the megamorphic flag is permanent and would otherwise accumulate.
+#
+# `boa_gc` is patched with it because this crate depends on it directly: left
+# on crates.io it would resolve to a second copy, and the cancellation token
+# would then be two incompatible types with the same name.
+[patch.crates-io]
+boa_engine = { git = "https://github.com/h5i-dev/boa", rev = "05a10e4ecf7ae72324138d80be2e9c47e99e7b3d" }
+boa_gc = { git = "https://github.com/h5i-dev/boa", rev = "05a10e4ecf7ae72324138d80be2e9c47e99e7b3d" }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6224,9 +6224,71 @@ per *thread*, and a renderer serves a session's navigations on one. So a session
 pays the compile on its first page and never again, and every number above is
 that second-page-onward case. A one-shot `h5i browser read <url>` builds one
 realm in a fresh process and is not helped at all — it pays exactly what it paid
-before. Making the first page cheaper is a different problem: the compile would
-have to overlap the navigation's network fetch, which is nearly always longer
-than 67 ms and is where this should go next.
+before. Making the first page cheaper is a different problem, and it is the one
+below.
+
+### B15.12b The compile moved into the navigation's own wait, 2026-08-29
+
+The first realm on a thread still paid the whole 67 ms, and a one-shot
+`h5i browser open` never has a second. That compile is now paid while the
+navigation's own request is in flight: `Broker::send_while` hands the renderer's
+idle window to a caller with something to do, and `BrokerClient` writes the
+request, runs the work, then blocks on the answer. The broker is a separate
+process, so that window is real. It is a reordering rather than parallelism —
+Boa's heap is thread-local and `Gc` is not `Send`, so the compile can never go
+to a worker thread.
+
+**It is speculative, which is the whole difficulty.** The decision comes before
+the document exists, so it cannot ask whether the page has script, and a page
+with none builds no realm and would have paid nothing. `worth_warming` asks the
+two things it can know: scripting must be on, and there must be a wait to hide
+the compile in.
+
+**Measured before building.** Over the corpus, 64 pages: 92% run script, and the
+scriptless ones fetch *slower* than the scripted ones — 117 ms at the fastest
+against a ~67 ms compile. Not one page lost, and the compile would have to
+nearly double before one did. Six pages were dropped as bot-challenge responses,
+which are not the page, arrive fast, and carry their own script, so they land as
+false wins in exactly the region that decides this. Every page measured was
+remote, so loopback and the non-network schemes are excluded in code rather than
+assumed to behave like the rest.
+
+**Measured after, and the first answer was wrong.** An end-to-end A/B of two
+binaries said 171 ms saved. That is more than the compile being hidden, so it
+could not be the change, and it was not: `before` and `after` ran back to back on
+the same URL, handing the second warm DNS, a resumable TLS session and a warm
+CDN. With the order alternating, the eight-page median fell to **−6 ms** — the
+effect is 67 ms against pages that take 0.9 to 39 seconds and swing by hundreds
+of milliseconds, so it simply is not resolvable there.
+
+It is resolvable on pages fast enough to show it. Three pages under 1.5 s, 20
+repetitions, order alternating, **59 paired runs**:
+
+    after faster in 44/59            sign test p = 0.0001
+    median delta                     +106 ms
+    95% bootstrap CI                 [+53, +139] ms
+    predicted (the compile hidden)   +63 to +82 ms
+
+The interval excludes zero and contains the prediction. The point estimate sits
+above the ceiling, which is what a wide interval on a noisy box looks like
+rather than a saving larger than the thing being saved.
+
+**The bug this shipped with, because it is the more useful half.** Warming
+before a realm exists inverted the order in which two thread-locals are first
+touched — the template's and Boa's GC heap — and the template then dropped `Gc`
+handles into a heap already torn down. The symptom is not a wrong answer:
+everything succeeds, and the process aborts as the thread ends with
+`tcache_thread_shutdown(): unaligned tcache chunk detected`. Every test passed
+on the commit before, because building a realm touches Boa's heap first and the
+order happened to be safe. The fix is `ManuallyDrop`, so the thread-local has no
+destructor and the order cannot matter.
+
+Three things about it are worth keeping. Rust does not specify thread-local
+destructor order, so anything holding a `Gc` in one **must not be dropped** —
+this is a rule, not an incident. A latent crash can hide behind a green suite
+when the failure is in teardown rather than in the work. And it was found only
+because a test was written for the *link* the wall clock could not measure;
+the measurement that could not see the win did not see the crash either.
 
 **And the one that looked free was measured and was not there.** The settle loop
 made *five* separate `context.eval` calls per round, three of them on the hot

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4344,12 +4344,19 @@ affected: `finish_page` is the sole caller in the product.
 
 ```
 reading a page                no script     script     outline
-10 sections  (~90 nodes)          2.0ms      72ms       60 lines
-100 sections (~900 nodes)        13.0ms      86ms      500 lines
-500 sections (~4500 nodes)       66.0ms     185ms      500 lines
+10 sections  (~90 nodes)           2.8ms    25.6ms       60 lines
+100 sections (~900 nodes)         14.7ms    45.2ms      500 lines
+500 sections (~4500 nodes)        81.5ms   160.5ms      500 lines
 
-starting the script realm          63ms per page
-the floor under a scripted page    66ms      (one section: almost all fixed cost)
+starting the script realm          21ms per page
+the floor under a scripted page    22ms      (one section: almost all fixed cost)
+
+the realm, by phase             first realm   later realms
+  context                            368 µs        3.0 ms
+  primitives                          53 µs         35 µs
+  prelude compile                   67.0 ms        0.9 µs
+  prelude run                       15.5 ms       12.4 ms
+  total                             83.0 ms       15.4 ms
 
 a DOM property read
   plain object                      68 ns
@@ -4368,17 +4375,44 @@ queries, 200 calls each
   iterating a 400-node result      213 µs
 ```
 
-**The realm is still most of a small page**, at 93% of the ten-section row when
-this pass began and about 87% now. Inside it, parse and compile are two thirds:
-33 ms and 9 ms of the 63, against 272 KiB of *code*. Boa parses eagerly, so
-every page pays for every line whether or not it runs one.
+**The realm went from 63 ms to 21 ms a page**, and it is no longer most of a
+small page: 87% of the ten-section row before, about 60% now. What moved is the
+prelude's parse and compile, paid by every page for a source that never changes
+and now paid once per thread. §B15.12a records why that was refused for as long
+as it was and what changed.
 
-Code, not bytes: blanking all 164 KiB of comments in a 448 KiB prelude changed
+Read the phase table as a within-run comparison and nothing more. The two
+columns come from one run on one thread, which is what makes them comparable;
+across three runs the first-realm total was 83.0, 101.3 and 79.8 ms and the
+later-realm total 15.4, 20.1 and 16.1 ms. The ratio holds at about five to one
+and the saving at 60–80 ms, but no single digit in that table is worth quoting
+on its own, and the older 63 ms figure was measured on a quieter day than the
+83 ms one beside it.
+
+Two things in the phase table are worth reading rather than skipping. **The
+compile does not shrink, it relocates**: the first realm on a thread still pays
+all 67 ms, so a one-shot `h5i browser read` is helped only by what overlaps it,
+while a session serving many navigations pays it once. And **a later realm's
+context costs ~3 ms against the first realm's ~400 µs**, reproducibly across all
+three runs — it builds its intrinsics against a GC heap that already holds the
+template and a previous realm. How much of that the template is responsible for
+is not known: a second realm in a process was probably always dearer than the
+first, and there was no phase column to show it before. It is 3 ms against 67
+either way, which is why it was recorded rather than chased.
+
+The per-read and per-call rows were re-measured and left alone. They moved
+between runs by as much as 25% on this box in either direction, which is wider
+than the 10% this section claims and wide enough that nothing below the page
+level should be read as having changed.
+
+Code, not bytes: blanking all 164 KiB of comments in a 443 KiB prelude changed
 parse time by **nothing measurable**. The documentation is free; only what the
 parser tokenises is not. `the_eagerly_parsed_prelude_stays_within_its_budget`
 holds the line at 275 KiB, because the file grew 4,692 lines in two commits
 during a coverage push and took the realm from 15.9 ms to 82.8 ms with nothing
-saying so — every test passed, since a slower engine is not a wrong one.
+saying so — every test passed, since a slower engine is not a wrong one. What a
+KiB costs has fallen with the compile: about 45 µs per page to *run*, plus
+245 µs on the first page of a thread to compile, against ~150 µs per page before.
 
 #### What came out, and what each was worth
 
@@ -6113,17 +6147,19 @@ restart, while `docs/Persist-cookies-and-storage.md` promises a file. §B6 alrea
 commits us to in-memory storage; the lesson is that the *documentation* has to
 say so.
 
-### B15.12a The performance items, measured: all three answers are no
+### B15.12a The performance items, measured: two noes and one that was refused twice before it was built
 
 §B11.5.13 and §B11.5.14 list two performance items — reuse the realm across
-navigations, and cache the prelude's bytecode. Both were attempted. Neither
-should be built, and a third optimisation that looked obvious was measured and
-reverted. Recorded together because the pattern is the point.
+navigations, and cache the prelude's bytecode. Both were attempted. The first
+must never be built; the second was built in August 2026 and is the largest
+single saving this engine has taken. A third optimisation that looked obvious
+was measured and reverted. Recorded together because the pattern is the point,
+and the pattern turned out to cut both ways.
 
-The prices have moved since this was written and the answers have not. The realm
-was ~20 ms a page then and is ~63 ms now; the prelude was three thousand lines
-and is ten thousand. §B8.9 carries the current numbers, and a better reason for
-the second refusal than the one below.
+The prices moved while this section was being wrong about them. The realm was
+~20 ms a page when this was written, ~63 ms by the time it was re-examined, and
+is ~15 ms now. The prelude was three thousand lines and is ten thousand. §B8.9
+carries the current numbers.
 
 **Realm reuse: refused, on grounds §B11.5 did not weigh.** A realm carries
 everything the previous document's script put in it — globals, patched
@@ -6135,23 +6171,62 @@ space, drops and recreates its entire JS runtime on every navigation for exactly
 this reason, and says so in the code. The note now lives on `Page::run_scripts`
 so the item is refused in review rather than re-attempted.
 
-**Prelude bytecode caching: not buildable with this Boa**, for a checkable
-reason rather than a hard one. `boa_engine::Script::parse` interns identifiers
-into *the context's own* interner (`context.interner_mut()`) and binds the
-result to that context's realm; every page builds a fresh `Context`. A parsed
-script is not a portable artifact, so there is nothing to cache across pages.
+**Prelude bytecode caching: built, 2026-08-29, and this section had two reasons
+for refusing it that were both wrong.** Kept in full, because being wrong twice
+in the same place about the same thing is the useful part.
 
-Re-examined on Boa 0.22, where the decisive reason turns out to be a different
-and sharper one: a `CodeBlock` owns its `InlineCache` entries, and those hold
-live shape-to-slot mappings filled in as the code runs. Reusing one across
-realms would carry the last page's object shapes into the next page's property
-lookups, which is the same cross-page contamination the realm refusal above
-exists to prevent, arriving through the cache instead of through the globals.
-The upstream change that would unblock it is small and namable: reset the caches
-on reuse, or hang them off the realm rather than the code block. Worth 42 ms of
-the 63, and worth an upstream issue rather than a fork.
-Revisit if Boa grows a shared interner or a serialisable code block. The note
-lives at the prelude's eval site.
+The first reason was that `boa_engine::Script::parse` interns identifiers into
+the context's own interner and binds the result to that context's realm, so a
+parsed script is not a portable artifact. True of the *parse*, and irrelevant to
+the artifact: by the time compilation is done a `CodeBlock` holds no `Sym` at
+all. Its constants are `JsString`, `Gc<CodeBlock>`, `JsBigInt` and `Scope`, and
+nothing in it can reach an interner. The claim was made about the input and
+believed about the output.
+
+The second reason, added when this was re-examined on Boa 0.22, was that a
+`CodeBlock` owns its `InlineCache` entries and reusing one across realms would
+carry the last page's object shapes into the next page's property lookups.
+Also wrong, and checkably so: a `CacheEntry` holds a **`WeakShape`**, and a
+lookup compares it by address after upgrading it. An object in the next realm
+has that realm's shapes, so it can never match an entry left by the last one;
+a dead entry is dropped on the next lookup rather than hit. There was no
+contamination to prevent. What does accumulate is the `megamorphic` flag, which
+is permanent, so code reused across many realms would eventually stop caching
+altogether — a performance decay, not a leak, and fixed by the same one-line
+reset that was proposed for the wrong reason.
+
+What made it buildable was the owner's ruling that a minimal Boa fork is
+acceptable where a vendored in-tree engine crate (§B22, stylo) is not. The
+fork carries one commit: `Script::bind_to_realm`, which returns a script sharing
+this one's compiled code but running in another realm, with the inline caches
+cleared and fresh `[[LoadedModules]]`. It refuses a script whose top level
+declares `let`, `const` or `class` — those become bindings the compiler
+addresses by *position* in the scope of the realm it compiled against, so a
+second realm's scope would not have them. Top-level `var` and `function` are
+instantiated by name on the global object and are portable. The prelude is one
+IIFE and declares nothing at the top level at all, which is why it qualifies.
+
+**The isolation this does not touch.** The realm refusal above stands unchanged,
+and the distinction is the whole safety argument: instructions are shared,
+state is not. Every page still gets its own realm, its own global object, its
+own prototypes and its own module map. `a_realm_shares_the_preludes_code_and_
+none_of_its_state` asserts it from the page's side and the fork's own
+`what_one_realm_does_to_the_shared_code_is_not_visible_to_the_next` from Boa's.
+
+Worth 67 ms of the 83 a realm cost, taking it to ~15 ms, and taking a
+ten-section scripted page from 72 ms to 26 ms. §B8.9 carries the phase table and
+the two costs that did not go away: the first realm on a thread still pays the
+whole compile, and building a context on a warmer GC heap costs ~3 ms more than
+it did.
+
+**Who this helps, stated plainly, because it is not everyone.** The saving is
+per *thread*, and a renderer serves a session's navigations on one. So a session
+pays the compile on its first page and never again, and every number above is
+that second-page-onward case. A one-shot `h5i browser read <url>` builds one
+realm in a fresh process and is not helped at all — it pays exactly what it paid
+before. Making the first page cheaper is a different problem: the compile would
+have to overlap the navigation's network fetch, which is nearly always longer
+than 67 ms and is where this should go next.
 
 **And the one that looked free was measured and was not there.** The settle loop
 made *five* separate `context.eval` calls per round, three of them on the hot
@@ -6166,12 +6241,35 @@ No gain, inside noise, possibly worse. Parsing a twenty-character string is not
 what a page load costs, and the change added a packed-integer protocol between
 Rust and JS for nothing. Reverted.
 
-The lesson is §B8's own, arriving from the other direction: **the rule against
-building what no page asked for applies to performance too.** All three of these
-were reasoned from the shape of the code rather than from a measurement, and all
-three were wrong — two dangerous, one merely useless. The ceiling on this whole
-area is small anyway: the corpus runs 35 pages in 9.7s, so a realm at 20ms is
-about 7% of the total even if it were free.
+The lesson was §B8's own, arriving from the other direction: **the rule against
+building what no page asked for applies to performance too.** All three were
+reasoned from the shape of the code rather than from a measurement, and all
+three were wrong — two dangerous, one merely useless.
+
+**The lesson now has a second half, and it is the more expensive one.** The
+refusals were reasoned from the shape of the code too, and one of them was
+wrong for six months. Both of its stated reasons named a specific structure —
+the interner, the inline caches — and neither was checked against that
+structure; `CodeBlock` has no interner reference and `CacheEntry` holds a weak
+shape, and thirty minutes of reading either file would have said so. A refusal
+recorded with a plausible mechanism reads exactly like a refusal recorded with a
+verified one, and it stops the next person looking. So: **when this file refuses
+something for a reason in the code, the reason has to cite the code**, the way
+§B8.9's rejections cite their measurements.
+
+The closing claim here was wrong in the same way, and correcting it corrects
+the shape of the win too. "The ceiling on this whole area is small anyway: the
+corpus runs 35 pages in 9.7s, so a realm at 20ms is about 7% of the total even
+if it were free" — the realm was 63 ms by then, not 20, so it was about a third
+of that run rather than 7%.
+
+But the corpus cannot show the saving at all, and it is worth being exact about
+why. `corpus/run.py` calls `subprocess.run` **once per URL**: every page gets a
+process, every process builds exactly one realm, and the first realm on a thread
+is the one that pays the whole compile. The corpus should be unchanged, and if
+it ever *improves*, something is sharing a process between pages that should not
+be. The yardstick for this change is a session — `h5i browser open` and then
+navigate — where the compile is paid on the first page and by no other.
 
 ### B15.13 The queue: built, 2026-08-19
 

--- a/crates/h5i-browser-light/examples/perf.rs
+++ b/crates/h5i-browser-light/examples/perf.rs
@@ -160,10 +160,51 @@ fn main() {
         drop(pages);
     }
 
+    // ── the realm, by phase ─────────────────────────────────────────────────
+    //
+    // The prelude is compiled once per thread and run once per realm, so the
+    // first realm on a thread is the only one that pays for the compile. That
+    // makes these two columns a before-and-after of the change, measured in one
+    // run rather than argued across two builds.
+    //
+    // On a thread of its own because the template is per-thread, and a realm
+    // built anywhere above would already have paid the compile.
+    {
+        let phases = std::thread::spawn(|| {
+            let url = url::Url::parse("https://bench.example/").unwrap();
+            let (factory, broker) = factory(true);
+            let page = factory.from_html(&document(10), &url);
+            let first = h5i_browser_light::script::Script::new(page.dom(), broker.clone(), &url)
+                .expect("realm")
+                .cost();
+            let later = h5i_browser_light::script::Script::new(page.dom(), broker.clone(), &url)
+                .expect("realm")
+                .cost();
+            (first, later)
+        })
+        .join()
+        .expect("realm phases");
+
+        println!("\nstarting the script realm, by phase");
+        println!("                       first realm   later realms");
+        let row = |name: &str, first: Duration, later: Duration| {
+            println!("  {name:<19} {first:>10.1?}   {later:>10.1?}");
+        };
+        row("context", phases.0.context, phases.1.context);
+        row("primitives", phases.0.primitives, phases.1.primitives);
+        row(
+            "prelude compile",
+            phases.0.prelude_compile,
+            phases.1.prelude_compile,
+        );
+        row("prelude run", phases.0.prelude_run, phases.1.prelude_run);
+        row("total", phases.0.total(), phases.1.total());
+    }
+
     // ── starting the realm ──────────────────────────────────────────────────
     //
     // A fixed cost paid once per page, which dominates a small one: the prelude
-    // is parsed and evaluated from scratch every time.
+    // is run from scratch for every realm, even though it is compiled only once.
     {
         let url = url::Url::parse("https://bench.example/").unwrap();
         let (factory, broker) = factory(true);
@@ -192,7 +233,8 @@ fn main() {
             ("has", include_str!("../src/script/prelude/has.js")),
         ];
         println!(
-            "  the core prelude is {} KiB of code ({} KiB with its comments), parsed every time",
+            "  the core prelude is {} KiB of code ({} KiB with its comments), compiled once \
+             per thread and run per realm",
             code(core) / 1024,
             core.len() / 1024
         );

--- a/crates/h5i-browser-light/perf/ab.py
+++ b/crates/h5i-browser-light/perf/ab.py
@@ -1,0 +1,185 @@
+"""Time the same pages through two engine binaries, and say whether the
+difference is real.
+
+ROADMAP §B15.12b. `examples/perf.rs` measures phases inside one build; this
+measures whole page loads across two, which is the only way to check that a
+saving on paper reaches a person waiting for a page.
+
+    cargo build --release -p h5i        # the "after" binary
+    git stash && cargo build --release -p h5i && cp target/release/h5i /tmp/before
+    python3 perf/ab.py /tmp/before target/release/h5i
+
+    python3 perf/ab.py A B --fast --reps 20   # the pages fast enough to resolve
+    python3 perf/ab.py A B --ceiling-ms 82    # the largest effect that is possible
+
+**Read the ceiling first.** A change that hides a 67 ms compile cannot save more
+than 67 ms. If the measured median comes out well above `--ceiling-ms`, the
+instrument is wrong, not the engine, and the honest move is to find the bias
+rather than to report the number. This is not hypothetical: the first run of this
+comparison said 171 ms against a 67 ms mechanism, because `before` and `after`
+ran back to back on the same URL and the second inherited warm DNS, a resumable
+TLS session and a warm CDN. Hence `--reps` alternating the order below.
+
+**Pick pages that can show the effect.** The default eight span 0.9 to 39
+seconds and swing by hundreds of milliseconds; a 67 ms signal is not resolvable
+against that, and the honest result there was a median of -6 ms. `--fast`
+selects the pages under ~1.5 s, where the same change reads +106 ms with a 95%
+interval of [+53, +139]. That is not cherry-picking as long as the prediction is
+stated first and the ceiling is checked, which is what this prints.
+"""
+
+import argparse
+import json
+import math
+import pathlib
+import random
+import statistics
+import subprocess
+import sys
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+CRATE = HERE.parent
+sys.path.insert(0, str(CRATE))
+import harness  # noqa: E402
+
+# Whole-corpus shape: documentation, an application, a news page, a spec.
+PAGES = [
+    "https://developer.mozilla.org/en-US/docs/Web/API/fetch",
+    "https://doc.rust-lang.org/book/ch01-00-getting-started.html",
+    "https://docs.python.org/3/library/json.html",
+    "https://en.wikipedia.org/wiki/Kelp",
+    "https://www.rust-lang.org/",
+    "https://go.dev/doc/",
+    "https://nodejs.org/api/fs.html",
+    "https://lobste.rs/",
+]
+
+# The subset that loads in about a second, where a ~67 ms effect is a visible
+# fraction of the total rather than a rounding error on it.
+FAST = [
+    "https://www.rust-lang.org/",
+    "https://lobste.rs/",
+    "https://docs.python.org/3/library/json.html",
+]
+
+
+def once(binary, url, script_seconds):
+    argv = harness.instrument_argv(
+        binary, "open", "--script", "--json",
+        "--max-snapshot-lines", "1",
+        "--script-seconds", str(int(script_seconds)),
+        url,
+    )
+    start = time.perf_counter()
+    try:
+        done = subprocess.run(argv, capture_output=True, timeout=120)
+    except subprocess.TimeoutExpired:
+        return None
+    elapsed = (time.perf_counter() - start) * 1000.0
+    if done.returncode != 0:
+        return None
+    try:
+        json.loads(done.stdout)
+    except Exception:
+        return None
+    return elapsed
+
+
+def binom_tail(k, n):
+    """P(X >= k) for X ~ Binomial(n, 1/2). The sign test, without scipy."""
+    return sum(math.comb(n, i) * 0.5 ** n for i in range(k, n + 1))
+
+
+def bootstrap_ci(values, draws=20000, seed=7):
+    rng = random.Random(seed)
+    meds = sorted(statistics.median(rng.choices(values, k=len(values)))
+                  for _ in range(draws))
+    return meds[int(0.025 * draws)], meds[int(0.975 * draws)]
+
+
+def report(rows, urls, ceiling_ms):
+    print(f"\n{'page':<44} {'n':>3} {'before':>9} {'after':>9} {'delta':>8}")
+    for url in urls:
+        b, a = rows.get(f"{url}|before", []), rows.get(f"{url}|after", [])
+        if not b or not a:
+            print(f"{url[8:52]:<44} {'-':>3} {'-':>9} {'-':>9} {'no data':>8}")
+            continue
+        mb, ma = statistics.median(b), statistics.median(a)
+        print(f"{url[8:52]:<44} {min(len(b), len(a)):>3} "
+              f"{mb:>8.0f}m {ma:>8.0f}m {mb - ma:>+7.0f}m")
+
+    # Every paired run, not the per-page medians: the spread is the part that
+    # decides whether any of this is resolvable.
+    paired = []
+    for url in urls:
+        b, a = rows.get(f"{url}|before", []), rows.get(f"{url}|after", [])
+        paired += [x - y for x, y in zip(b, a)]
+    if not paired:
+        sys.exit("no paired runs; did the binaries work?")
+
+    n = len(paired)
+    med = statistics.median(paired)
+    pos = sum(1 for d in paired if d > 0)
+    lo, hi = bootstrap_ci(paired)
+
+    print(f"\n{n} paired runs")
+    print(f"  after faster in {pos}/{n}   sign test p = {binom_tail(pos, n):.2g}")
+    print(f"  median delta {med:+.0f} ms   95% bootstrap CI [{lo:+.0f}, {hi:+.0f}] ms")
+    print(f"  ceiling (the most the change could save) {ceiling_ms:+.0f} ms")
+
+    p = binom_tail(pos, n)
+    if p > 0.05:
+        # The interval can exclude zero on a handful of runs while the direction
+        # is still a coin toss. The sign test is the cheaper question and it
+        # goes first, so a short run cannot report a result it has not earned.
+        print(f"  verdict: direction not established (p = {p:.2g}); "
+              f"more repetitions, or pages with less spread")
+    elif lo <= 0 <= hi:
+        print("  verdict: no effect resolvable at this sample size")
+    elif lo > ceiling_ms:
+        print("  verdict: ENTIRELY above the ceiling, so the instrument is biased, "
+              "not the engine. Check that the arms alternate order.")
+    elif med > ceiling_ms:
+        print("  verdict: real, and consistent with the ceiling once the interval "
+              "is taken into account; the point estimate is high for a noisy box")
+    else:
+        print("  verdict: real and within the ceiling")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("before")
+    parser.add_argument("after")
+    parser.add_argument("--reps", type=int, default=6)
+    parser.add_argument("--fast", action="store_true",
+                        help="only the pages quick enough to resolve a ~67 ms effect")
+    parser.add_argument("--ceiling-ms", type=float, default=82.0,
+                        help="the largest saving the change could possibly produce")
+    parser.add_argument("--script-seconds", type=float, default=10.0)
+    parser.add_argument("--out", default=None)
+    opts = parser.parse_args()
+
+    urls = FAST if opts.fast else PAGES
+    rows = {}
+    for rep in range(opts.reps):
+        for url in urls:
+            # Alternate which binary goes first. A fixed order hands the second
+            # one warm DNS, a resumable TLS session and whatever the CDN cached a
+            # second ago, which is worth more than the change being measured.
+            arms = [("before", opts.before), ("after", opts.after)]
+            if rep % 2:
+                arms.reverse()
+            for name, binary in arms:
+                ms = once(binary, url, opts.script_seconds)
+                if ms is not None:
+                    rows.setdefault(f"{url}|{name}", []).append(ms)
+        if opts.out:
+            pathlib.Path(opts.out).write_text(json.dumps(rows, indent=1))
+        print(f"  rep {rep + 1}/{opts.reps}", flush=True)
+
+    report(rows, urls, opts.ceiling_ms)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/h5i-browser-light/perf/overlap.py
+++ b/crates/h5i-browser-light/perf/overlap.py
@@ -1,0 +1,214 @@
+"""Would compiling the prelude during the navigation's fetch pay for itself?
+
+ROADMAP §B15.12b. The engine compiles the browser prelude while the document it
+is navigating to is still on the wire, which is worth ~67 ms on the first page a
+process loads. It has to decide *before* the document exists, so it cannot ask
+the question that would settle it -- whether the page has any script -- and a
+page with none builds no realm and would have paid the compile for nothing.
+
+This forecasts the trade over the corpus, so `worth_warming` in `engine.rs` is
+gated on a measurement rather than on a guess. Per page, with C the compile and
+F the main-document fetch:
+
+    scripted    saved = min(F, C)
+    scriptless  lost  = max(0, C - F)
+
+The realm's other costs cancel out of both arms, so only F, C and whether the
+page is scripted matter.
+
+    python3 perf/overlap.py                 # the whole corpus
+    python3 perf/overlap.py --compile-ms 90 # what a bigger prelude would cost
+
+Fetch time is measured with curl rather than through the engine's own broker:
+the question is how long the *network* takes, and putting the engine in the loop
+would add its policy and proxy path to a number meant to be about the wire. The
+engine's window is the same or larger, so this is the conservative direction.
+
+**Two traps, both of which caught this instrument once.**
+
+Bot-challenge pages are not the page. They come back ~3 KB, they carry their own
+script, and they arrive fast, so left in the sample they count as scripted *and*
+land in the fast-fetch region that decides the whole question. Non-200 responses
+are dropped rather than guessed at, and the browser-shaped headers below exist
+to provoke fewer of them.
+
+Everything here is remote. A loopback dev server answers in about a millisecond,
+so a scriptless local page would pay the whole compile as added latency. That
+case is not in this evidence, which is exactly why `worth_warming` excludes
+loopback and the non-network schemes in code instead of assuming they behave
+like the rest.
+"""
+
+import argparse
+import ast
+import concurrent.futures
+import json
+import pathlib
+import re
+import statistics
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+CRATE = HERE.parent
+
+# Read the site lists out of the corpus rather than copying them, so this cannot
+# drift from what the project actually measures. Statically, because importing
+# `corpus/run.py` runs its argument parser.
+CORPUS_PY = CRATE / "corpus" / "run.py"
+WANTED = ("DOCUMENTS", "INTERNATIONAL", "STRUCTURES", "APPLICATIONS")
+
+UA = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
+HEADERS = [
+    "-H", "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,"
+          "image/avif,image/webp,*/*;q=0.8",
+    "-H", "Accept-Language: en-US,en;q=0.9",
+    "-H", "Sec-Fetch-Dest: document",
+    "-H", "Sec-Fetch-Mode: navigate",
+    "-H", "Sec-Fetch-Site: none",
+    "-H", "Upgrade-Insecure-Requests: 1",
+]
+
+# What `Page::run_scripts` actually decides on: any <script> that is not an
+# import map -- a map declares imports that never happen and is not code -- or an
+# inline event-handler attribute.
+SCRIPT_TAG = re.compile(rb"<script\b([^>]*)>", re.I)
+TYPE_ATTR = re.compile(rb"""type\s*=\s*["']?([^"'\s>]+)""", re.I)
+INLINE_HANDLER = re.compile(rb"""<[^>]+\son[a-z]+\s*=\s*["']""", re.I)
+NON_CODE_TYPES = {b"importmap", b"application/json", b"application/ld+json",
+                  b"text/template", b"text/html"}
+
+
+def corpora():
+    found = {}
+    for node in ast.parse(CORPUS_PY.read_text()).body:
+        if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+            if name in WANTED:
+                found[name.lower()] = ast.literal_eval(node.value)
+    missing = [w for w in WANTED if w.lower() not in found]
+    if missing:
+        sys.exit(f"{CORPUS_PY} no longer defines {missing}")
+    return found
+
+
+def has_code(body):
+    """Whether this document would make the engine build a realm."""
+    for m in SCRIPT_TAG.finditer(body):
+        t = TYPE_ATTR.search(m.group(1))
+        if t is None or t.group(1).lower() not in NON_CODE_TYPES:
+            return True
+    return bool(INLINE_HANDLER.search(body))
+
+
+def fetch(url, bodies):
+    body_path = bodies / (re.sub(r"\W+", "_", url)[:80] + ".html")
+    fmt = "%{time_total} %{size_download} %{http_code}"
+    try:
+        done = subprocess.run(
+            ["curl", "-sL", "--compressed", "-A", UA, *HEADERS,
+             "--max-time", "45", "-o", str(body_path), "-w", fmt, url],
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return {"url": url, "error": "timeout"}
+    if done.returncode != 0:
+        return {"url": url, "error": f"curl exit {done.returncode}"}
+    try:
+        total, size, code = done.stdout.split()
+    except ValueError:
+        return {"url": url, "error": f"unparseable: {done.stdout[:60]}"}
+    return {
+        "url": url,
+        "fetch_ms": float(total) * 1000.0,
+        "bytes": int(size),
+        "status": int(code),
+        "scripted": has_code(body_path.read_bytes()),
+    }
+
+
+def usable(row):
+    return "error" not in row and row.get("status") == 200 and row.get("bytes", 0) > 0
+
+
+def delta(row, compile_ms):
+    """Milliseconds saved (positive) or lost (negative) by speculating."""
+    if row["scripted"]:
+        return min(row["fetch_ms"], compile_ms)
+    return -max(0.0, compile_ms - row["fetch_ms"])
+
+
+def report(rows, compile_ms):
+    ok = [r for r in rows if usable(r)]
+    dropped = [r for r in rows if not usable(r)]
+    if not ok:
+        sys.exit("no usable pages; is there a network?")
+
+    print(f"{len(ok)} pages measured, {len(dropped)} unusable")
+    for r in dropped:
+        print(f"   dropped: {r['url'][:62]} ({r.get('error') or 'HTTP ' + str(r.get('status'))})")
+
+    scripted = [r for r in ok if r["scripted"]]
+    plain = [r for r in ok if not r["scripted"]]
+    print(f"\nscripted {len(scripted)}  scriptless {len(plain)} "
+          f"({100 * len(scripted) / len(ok):.0f}% scripted)")
+    for name, group in (("scripted", scripted), ("scriptless", plain)):
+        if group:
+            f = sorted(r["fetch_ms"] for r in group)
+            print(f"  {name:<11} fetch ms  median {statistics.median(f):6.0f}"
+                  f"  min {f[0]:6.0f}  max {f[-1]:7.0f}")
+
+    # The scriptless minimum is the whole safety margin: below it, speculating
+    # starts costing a page that was never going to use the realm.
+    if plain:
+        floor = min(r["fetch_ms"] for r in plain)
+        print(f"\nthe compile could grow to {floor:.0f} ms before one page here "
+              f"regressed (currently {compile_ms:.0f} ms)")
+
+    print(f"\n{'compile':>8} {'net(ms)':>10} {'per page':>9} {'won':>5} {'lost':>5} {'worst':>8}")
+    for c in sorted({40.0, 63.0, compile_ms, 82.0, 100.0}):
+        ds = [delta(r, c) for r in ok]
+        print(f"{c:>8.0f} {sum(ds):>10.0f} {sum(ds) / len(ds):>9.1f} "
+              f"{sum(1 for d in ds if d > 0.5):>5} {sum(1 for d in ds if d < -0.5):>5} "
+              f"{min(ds):>8.1f}")
+
+    ds = [delta(r, compile_ms) for r in ok]
+    verdict = ("speculating pays" if min(ds) > -0.5 and sum(ds) > 0
+               else "speculating costs some pages; tighten the guard")
+    print(f"\nat {compile_ms:.0f} ms: {verdict}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compile-ms", type=float, default=67.0,
+                        help="what the prelude costs to compile (perf example, §B8.9)")
+    parser.add_argument("--jobs", type=int, default=4)
+    parser.add_argument("--out", default=None, help="write the rows here as JSON")
+    parser.add_argument("--bodies", default=None,
+                        help="keep the fetched documents here (default: a temp dir)")
+    opts = parser.parse_args()
+
+    import tempfile
+    keep = opts.bodies or tempfile.mkdtemp(prefix="h5i-overlap-")
+    bodies = pathlib.Path(keep)
+    bodies.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=opts.jobs) as pool:
+        futures = {}
+        for name, urls in corpora().items():
+            for url in urls:
+                futures[pool.submit(fetch, url, bodies)] = name
+        for fut in concurrent.futures.as_completed(futures):
+            row = fut.result()
+            row["corpus"] = futures[fut]
+            rows.append(row)
+
+    if opts.out:
+        pathlib.Path(opts.out).write_text(json.dumps(rows, indent=1))
+    report(rows, opts.compile_ms)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/h5i-browser-light/src/broker.rs
+++ b/crates/h5i-browser-light/src/broker.rs
@@ -163,6 +163,26 @@ pub trait Broker: Send + Sync {
     /// convenience over this one.
     fn send(&self, fetch: &Fetch) -> FetchOutcome;
 
+    /// The same send, with `while_waiting` run while the answer is in flight.
+    ///
+    /// For work that would otherwise sit on the critical path behind a request
+    /// this process is only waiting on. The renderer's broker is a *separate
+    /// process*, so [`Self::send`] is one round trip and the renderer thread is
+    /// idle for all of it — which is long enough to hide the browser prelude's
+    /// compile in (§B15.12a). Boa's heap is thread-local, so that compile
+    /// cannot go to a worker thread; this is the only way it overlaps anything.
+    ///
+    /// **`while_waiting` must be speculative work**, in the sense that skipping
+    /// it entirely has to be correct. The default implementation does exactly
+    /// that: a broker doing the fetch on this thread has no idle window, and
+    /// running the closure *before* the fetch would not be an overlap but a
+    /// serial addition to the very path this exists to shorten. It must also
+    /// not touch this broker, which is mid-request.
+    fn send_while(&self, fetch: &Fetch, while_waiting: &mut dyn FnMut()) -> FetchOutcome {
+        let _ = while_waiting;
+        self.send(fetch)
+    }
+
     /// The requests this broker has decided about, in the order it recorded
     /// them.
     ///
@@ -299,6 +319,17 @@ pub trait Broker: Send + Sync {
     /// Fetch a URL the agent named.
     fn fetch(&self, url: &Url, initiator: Initiator) -> FetchOutcome {
         self.send(&Fetch::get(url, initiator))
+    }
+
+    /// The same fetch, with speculative work run while it is in flight. See
+    /// [`Self::send_while`] for what may go in the closure.
+    fn fetch_while(
+        &self,
+        url: &Url,
+        initiator: Initiator,
+        while_waiting: &mut dyn FnMut(),
+    ) -> FetchOutcome {
+        self.send_while(&Fetch::get(url, initiator), while_waiting)
     }
 
     /// Fetch something a *document* asked for.

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -824,6 +824,15 @@ impl Page {
     /// Obscura, a much larger engine in the same space, drops and recreates its
     /// whole JS runtime on every navigation for exactly this reason. The cost
     /// is real and it is the right one to pay.
+    ///
+    /// **Sharing the prelude's compiled code is a different thing and is
+    /// built.** The distinction is the whole safety argument, so it is worth
+    /// being exact: what is shared between realms is instructions, and what is
+    /// never shared is state. A second realm gets its own global object, its own
+    /// prototypes, its own module map and cleared inline caches — nothing a page
+    /// wrote is reachable from the next one, which is what the paragraph above
+    /// protects. It saved 67 ms of the 83 a realm cost; see §B15.12a, and
+    /// `a_realm_shares_the_preludes_code_and_none_of_its_state` for the guard.
     pub fn run_scripts(&mut self, broker: Arc<dyn Broker>) -> Result<(), H5iError> {
         // In document order, inline and external together, because execution
         // order is semantics: a bundle that defines a global in one script and
@@ -939,9 +948,10 @@ impl Page {
         };
 
         // Nothing to run means nothing to build. Starting the realm costs about
-        // 15ms — the prelude is 113 KiB of JavaScript, parsed and evaluated from
-        // scratch — and a page with no script elements was paying all of it for
-        // a realm that would never be asked a question.
+        // 15 ms — 273 KiB of JavaScript evaluated from scratch, the prelude's
+        // compile no longer being part of it (§B8.9) — and a page with no
+        // script elements was paying all of it for a realm that would never be
+        // asked a question.
         // A page whose only `<script>` is an import map has no code to run: the
         // map is a declaration for imports that never happen. Filtered here
         // rather than in the walk, so the walk stays one pass and this stays

--- a/crates/h5i-browser-light/src/engine.rs
+++ b/crates/h5i-browser-light/src/engine.rs
@@ -477,6 +477,49 @@ fn load_frames(page: &mut Page, broker: &Arc<dyn Broker>) {
     }
 }
 
+/// Whether to compile the browser prelude while this navigation is in flight.
+///
+/// The compile is ~67 ms and was the last fixed cost on the critical path of a
+/// page that runs script (§B15.12a). It can be hidden inside the navigation's
+/// own network wait, but only speculatively: the decision has to be made before
+/// the document exists, so it cannot ask the one question that would settle it,
+/// which is whether the page has any script.
+///
+/// So it asks the two things it *can* know, and both are about whether the bet
+/// can lose rather than whether it will win.
+///
+/// **Scripting has to be on.** With `script` off no realm is ever built for any
+/// page, so this would be waste on all of them rather than on some.
+///
+/// **There has to be a wait to hide it in.** Loopback and the non-network
+/// schemes answer in about a millisecond, so a local page that turns out to
+/// have no script would pay the whole compile as added latency. Measured over
+/// the project's corpus (64 pages, 2026-08-29) the bet never once lost: 92% of
+/// pages run script, and the scriptless ones are *slower* to fetch than the
+/// scripted ones, the fastest at 117 ms against a ~67 ms compile — the compile
+/// would have to nearly double before one corpus page regressed. But every page
+/// in that corpus was remote. Local ones are not in the evidence, which is why
+/// they are excluded here instead of assumed to behave like the rest.
+/// Being wrong in the cautious direction costs an optimisation; being wrong the
+/// other way costs 67 ms of somebody's page load. So the trailing dot of a
+/// fully-qualified `localhost.` is stripped before asking, which
+/// [`crate::policy::is_loopback`] does not do. That function is *not* changed to
+/// match: it decides what the allowlist lets through by default, and widening
+/// what counts as the local machine is a policy decision that should be taken
+/// on its own terms rather than as a side effect of making pages faster.
+fn worth_warming(url: &Url, options: &PageOptions) -> bool {
+    if !options.script {
+        return false;
+    }
+    if !matches!(url.scheme(), "http" | "https") {
+        return false;
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    !crate::policy::is_loopback(host.strip_suffix('.').unwrap_or(host))
+}
+
 impl Page {
     /// Fetch a URL and load it.
     ///
@@ -497,7 +540,13 @@ impl Page {
         let mut followed: Vec<String> = Vec::new();
 
         for _ in 0..=MAX_META_REFRESH_HOPS {
-            let outcome = broker.fetch(&target, Initiator::Navigation);
+            let outcome = if worth_warming(&target, &options) {
+                broker.fetch_while(&target, Initiator::Navigation, &mut || {
+                    crate::script::warm_prelude();
+                })
+            } else {
+                broker.fetch(&target, Initiator::Navigation)
+            };
             if let Some(error) = outcome.error {
                 return Err(H5iError::Metadata(format!("could not open {target}: {error}")));
             }
@@ -2616,6 +2665,49 @@ mod tests {
     use super::*;
     use crate::policy::Policy;
     use crate::receipt::MemorySink;
+
+    #[test]
+    fn the_prelude_is_warmed_only_where_the_bet_cannot_lose() {
+        let scripted = PageOptions {
+            script: true,
+            ..Default::default()
+        };
+        let at = |s: &str| Url::parse(s).expect("url");
+
+        // A remote page that may run script: the case the measurement covers,
+        // where 92% of pages use the realm and the rest are slow enough to hide
+        // the compile in anyway.
+        assert!(worth_warming(&at("https://docs.example/guide"), &scripted));
+        assert!(worth_warming(&at("http://docs.example/guide"), &scripted));
+
+        // Scripting off means no realm is ever built, so this would be waste on
+        // every page rather than on some.
+        assert!(!worth_warming(&at("https://docs.example/"), &PageOptions::default()));
+
+        // Nothing local. These answer in about a millisecond, so a scriptless
+        // one would pay the whole compile as added latency — and local pages are
+        // exactly what the corpus measurement does not cover.
+        for local in [
+            "http://localhost:3000/",
+            "http://localhost./",
+            "http://dev.localhost/",
+            "http://127.0.0.1:8080/app",
+            "http://127.13.9.4/",
+            "http://[::1]:5173/",
+            "file:///tmp/page.html",
+            "data:text/html,<p>hi",
+        ] {
+            assert!(
+                !worth_warming(&at(local), &scripted),
+                "{local} has no wait to hide a 67ms compile in"
+            );
+        }
+
+        // A name that merely looks like loopback is not loopback, and must not
+        // lose the optimisation by string-matching.
+        assert!(worth_warming(&at("http://127.0.0.1.evil.test/"), &scripted));
+        assert!(worth_warming(&at("https://localhost.evil.test/"), &scripted));
+    }
 
     fn page_from(html: &str, policy: Policy, sink: Arc<MemorySink>) -> Page {
         let broker = crate::net::LocalBroker::new(policy, sink, None).expect("broker");

--- a/crates/h5i-browser-light/src/ipc.rs
+++ b/crates/h5i-browser-light/src/ipc.rs
@@ -76,7 +76,7 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 use std::sync::{Arc, Mutex};
 
 use h5i_error::H5iError;
@@ -398,6 +398,21 @@ impl BrokerClient {
     /// refusal its own signature can express, because "the broker is gone" is
     /// not a state any of them can render around.
     fn ask(&self, ask: Ask, blob: &[u8]) -> Option<(Said, Vec<u8>)> {
+        self.begin(ask, blob)?.recv().ok()
+    }
+
+    /// Ask, and hand back the receiver rather than waiting on it.
+    ///
+    /// Split out of [`Self::ask`] so a caller with something useful to do can
+    /// do it while the broker works — the renderer compiling its prelude during
+    /// a navigation, which is the only reason this exists. See
+    /// `Broker::send_while`.
+    ///
+    /// The caller owns the waiting from here. Dropping the receiver without
+    /// reading it leaves an entry in `waiting` that the reply thread will find
+    /// and send into a dead channel, which it already tolerates: the send
+    /// fails, and nothing else depends on it.
+    fn begin(&self, ask: Ask, blob: &[u8]) -> Option<Receiver<(Said, Vec<u8>)>> {
         let id = self.next.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = sync_channel(1);
         {
@@ -424,7 +439,7 @@ impl BrokerClient {
             self.waiting.lock().ok()?.remove(&id);
             return None;
         }
-        rx.recv().ok()
+        Some(rx)
     }
 
     /// The answers whose shape is a single value, unwrapped.
@@ -473,15 +488,37 @@ impl Drop for RemoteChannel {
 
 impl Broker for BrokerClient {
     fn send(&self, fetch: &Fetch) -> FetchOutcome {
-        match self.ask(Ask::Send(fetch.clone()), &fetch.body) {
+        self.send_while(fetch, &mut || {})
+    }
+
+    /// The renderer's side of the overlap: the request goes out, the caller's
+    /// work happens, and only then does this thread block on the answer.
+    ///
+    /// This is the implementation the default in `Broker` cannot be. The broker
+    /// is another process, so everything between the write and the `recv` is
+    /// time this thread would otherwise spend idle.
+    fn send_while(&self, fetch: &Fetch, while_waiting: &mut dyn FnMut()) -> FetchOutcome {
+        let gone = || {
+            FetchOutcome::refused(
+                fetch.url.clone(),
+                "the broker is no longer running, so nothing was fetched".to_string(),
+            )
+        };
+        let Some(pending) = self.begin(Ask::Send(fetch.clone()), &fetch.body) else {
+            return gone();
+        };
+
+        // After the write and before the wait. A panic here would leave the
+        // request outstanding and the entry in `waiting`, which the reply
+        // thread already handles, so this needs no guard of its own.
+        while_waiting();
+
+        match pending.recv().ok() {
             Some((Said::Outcome(mut outcome), body)) => {
                 outcome.body = body;
                 outcome
             }
-            _ => FetchOutcome::refused(
-                fetch.url.clone(),
-                "the broker is no longer running, so nothing was fetched".to_string(),
-            ),
+            _ => gone(),
         }
     }
 
@@ -1269,6 +1306,80 @@ mod tests {
         assert!(methods.iter().any(|m| m == "WS-OPEN"), "{methods:?}");
         assert!(methods.iter().any(|m| m == "WS-RECV"), "{methods:?}");
         assert!(methods.iter().any(|m| m == "WS-SEND"), "{methods:?}");
+    }
+
+    #[test]
+    fn work_given_to_send_while_runs_with_the_request_already_in_flight() {
+        // The value of the overlap is entirely in *when* the work happens: a
+        // closure run before the request went out would pass any ordering check
+        // made on this side and buy nothing at all. So the claim is checked from
+        // the server's end — the closure is not allowed to finish until the
+        // server has actually read the request off the socket.
+        use std::io::{BufRead, BufReader, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().unwrap().port();
+        let (arrived, seen) = std::sync::mpsc::channel::<()>();
+        let server = std::thread::spawn(move || {
+            let Ok((stream, _)) = listener.accept() else {
+                return;
+            };
+            let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+            loop {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap_or(0) == 0 {
+                    return;
+                }
+                if line == "\r\n" || line == "\n" {
+                    break;
+                }
+            }
+            let _ = arrived.send(());
+            // Held open so the answer cannot win the race by accident.
+            std::thread::sleep(std::time::Duration::from_millis(150));
+            let mut stream = stream;
+            let _ = write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi"
+            );
+        });
+
+        let (client, _broker, _served) = paired();
+        let url = Url::parse(&format!("http://127.0.0.1:{port}/")).expect("url");
+
+        let mut in_flight = false;
+        let outcome = client.send_while(&Fetch::get(&url, Initiator::Navigation), &mut || {
+            in_flight = seen
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .is_ok();
+        });
+
+        assert!(outcome.is_ok(), "{outcome:?}");
+        assert!(
+            in_flight,
+            "send_while ran its work before the request reached the server, so it \
+             overlapped nothing"
+        );
+        let _ = server.join();
+    }
+
+    #[test]
+    fn a_broker_that_cannot_overlap_declines_the_work_rather_than_serialising_it() {
+        // `LocalBroker` does the fetch on the calling thread, so there is no
+        // window to hide anything in. Running the closure anyway would add its
+        // cost to the path this exists to shorten, which is why the default
+        // implementation drops it. Safe only because the work is speculative:
+        // the prelude still compiles when the realm asks for it.
+        let broker = LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+            .expect("broker builds");
+        let url = Url::parse("https://denied.test/").expect("url");
+
+        let mut ran = false;
+        let outcome = broker.send_while(&Fetch::get(&url, Initiator::Navigation), &mut || {
+            ran = true;
+        });
+
+        assert!(!ran, "a broker with no idle window ran the speculative work");
+        assert!(outcome.error.is_some(), "the allowlist is empty, so this is refused");
     }
 
     /// One request, answered with the body it was sent. Enough HTTP to carry a

--- a/crates/h5i-browser-light/src/policy.rs
+++ b/crates/h5i-browser-light/src/policy.rs
@@ -412,7 +412,7 @@ pub fn is_internal_address(addr: std::net::IpAddr) -> bool {
     }
 }
 
-fn is_loopback(host: &str) -> bool {
+pub(crate) fn is_loopback(host: &str) -> bool {
     // `localhost` and its subdomains resolve to loopback by convention.
     if host == "localhost" || host.ends_with(".localhost") {
         return true;

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -117,11 +117,41 @@ thread_local! {
     /// the compiler resolved names against and nothing else, so holding it for
     /// the life of the thread cannot pin a page's DOM — which storing the
     /// *first page's* context here would have done.
-    static PRELUDE_TEMPLATE: std::cell::RefCell<Option<PreludeTemplate>> =
+    /// **Deliberately holds nothing that will be dropped.** See
+    /// [`PreludeTemplate`].
+    static PRELUDE_TEMPLATE:
+        std::cell::RefCell<Option<std::mem::ManuallyDrop<PreludeTemplate>>> =
         const { std::cell::RefCell::new(None) };
 }
 
 /// The compiled prelude and the realm it was compiled against.
+///
+/// # Why this is never dropped
+///
+/// It holds `Gc` handles, and freeing those needs Boa's garbage-collected heap
+/// — which lives in a thread-local of its own (`BOA_GC`). Rust does not specify
+/// the order thread-local destructors run in, so a thread ending could destroy
+/// that heap first and leave this dropping handles into freed memory. It does
+/// exactly that, reproducibly, and the symptom is not a panic but
+/// `tcache_thread_shutdown(): unaligned tcache chunk detected` and `SIGABRT` as
+/// the thread exits, with the work already finished and correct.
+///
+/// It depended on the order the two thread-locals were *first touched*, which is
+/// why it appeared only once the compile moved into the navigation. Building a
+/// realm touches Boa's heap before it touches this, so its destructor was
+/// registered first and ran last, and everything was fine. Warming touches this
+/// one first, inverting the order — and warming before a realm exists is the
+/// whole point of the overlap (§B15.12a).
+///
+/// Wrapping it in `ManuallyDrop` means this thread-local has no drop glue at
+/// all, so no destructor is registered for it and the order cannot matter. What
+/// is left behind is the `Context` and `Script` structs; the GC heap they point
+/// into is freed by `BOA_GC`'s own teardown, so this leaks a bounded amount per
+/// thread that compiled a prelude rather than a growing one.
+///
+/// `the_compile_survives_a_thread_that_warmed_before_it_had_a_realm` is the
+/// guard, and it fails as an abort rather than an assertion, so it has to run
+/// in a thread that then exits.
 struct PreludeTemplate {
     /// Held only to keep the compilation realm alive; never run.
     _context: Context,
@@ -148,10 +178,10 @@ fn compiled_prelude() -> Result<boa_engine::Script, String> {
             script
                 .codeblock(&mut context)
                 .map_err(|e| format!("the browser prelude did not compile: {e}"))?;
-            *slot = Some(PreludeTemplate {
+            *slot = Some(std::mem::ManuallyDrop::new(PreludeTemplate {
                 _context: context,
                 script,
-            });
+            }));
         }
         Ok(slot
             .as_ref()

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -44,22 +44,28 @@ const PRELUDE: &str = include_str!("prelude.js");
 
 /// The pieces of the prelude a page has to *ask* for.
 ///
-/// Two of the three costs of the prelude are a straight function of the *code*
-/// handed to Boa: parse and compile are 33 ms and 9 ms of the ~59 ms a realm
-/// takes, and Boa parses eagerly — there is no lazy compilation to hide behind,
-/// so every page pays for every line whether or not it runs one.
+/// **What this is worth changed, and it is worth less than it was.** Parse and
+/// compile were 67 ms of the 83 a realm cost and were paid by every page; they
+/// are now paid once per thread (see [`compiled_prelude`]) and a later realm
+/// spends under a microsecond there. What a tier still saves per page is the
+/// *running* of its code — building its classes and prototypes — which is
+/// 12.4 ms for the whole 273 KiB core, so roughly 45 µs per KiB rather than the
+/// ~150 µs per KiB it was when the parse was in the number too.
 ///
-/// Code, not bytes: blanking all 164 KiB of comments in a 448 KiB prelude
+/// It still saves the compile for the first page a renderer serves, and that is
+/// the page a person is waiting on.
+///
+/// Code, not bytes: blanking all 164 KiB of comments in a 443 KiB prelude
 /// changed parse time by nothing measurable, so the documentation is free and
-/// only what the parser tokenises is not. The only way not to pay for a line is
-/// not to hand it over. So a surface most pages never touch lives in its own
-/// file, is never given to the parser, and arrives when something reads the
-/// name it defines — see `lazyGlobals` in the core prelude, which installs the
-/// getter that calls back into [`load_tier`].
+/// only what the parser tokenises is not. So a surface most pages never touch
+/// lives in its own file, is not given to the parser with the core, and arrives
+/// when something reads the name it defines — see `lazyGlobals` in the core
+/// prelude, which installs the getter that calls back into [`load_tier`].
 ///
 /// The bar for moving something here is that a page which *does* use it pays
-/// slightly more (one extra parse of a small file) and a page which does not
-/// pays nothing. That trade only holds while the tier is genuinely optional:
+/// slightly more (one extra parse of a small file, on every realm that asks —
+/// tiers are not shared the way the core is) and a page which does not pays
+/// nothing. That trade only holds while the tier is genuinely optional:
 /// anything the first paint of an ordinary page touches belongs in the core.
 const TIERS: &[(&str, &str)] = &[
     ("conformance", include_str!("prelude/conformance.js")),
@@ -98,6 +104,89 @@ fn load_tier(
         Some(std::path::Path::new(&path)),
     ))?;
     Ok(boa_engine::JsValue::undefined())
+}
+
+thread_local! {
+    /// The prelude, parsed and compiled once for this thread.
+    ///
+    /// A renderer serves every navigation of a session on one thread, so this
+    /// is once per process in the product and once per test in the suite.
+    ///
+    /// The context it was compiled against is kept with it, and is deliberately
+    /// a plain one: no host, no document, no broker. It exists to own the realm
+    /// the compiler resolved names against and nothing else, so holding it for
+    /// the life of the thread cannot pin a page's DOM — which storing the
+    /// *first page's* context here would have done.
+    static PRELUDE_TEMPLATE: std::cell::RefCell<Option<PreludeTemplate>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// The compiled prelude and the realm it was compiled against.
+struct PreludeTemplate {
+    /// Held only to keep the compilation realm alive; never run.
+    _context: Context,
+    script: boa_engine::Script,
+}
+
+/// The compiled prelude for this thread, compiling it if this is the first ask.
+///
+/// The returned handle shares the code block rather than copying it: what comes
+/// back is cheap, and what it costs to *make* is paid once.
+fn compiled_prelude() -> Result<boa_engine::Script, String> {
+    PRELUDE_TEMPLATE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        if slot.is_none() {
+            let mut context = Context::default();
+            let script = boa_engine::Script::parse(
+                Source::from_reader(PRELUDE.as_bytes(), Some(std::path::Path::new(PRELUDE_PATH))),
+                None,
+                &mut context,
+            )
+            .map_err(|e| format!("the browser prelude did not parse: {e}"))?;
+            // Compiled here rather than left to the first `bind_to_realm`, so
+            // the cost lands on this function and the phase it is measured in.
+            script
+                .codeblock(&mut context)
+                .map_err(|e| format!("the browser prelude did not compile: {e}"))?;
+            *slot = Some(PreludeTemplate {
+                _context: context,
+                script,
+            });
+        }
+        Ok(slot
+            .as_ref()
+            .expect("the template was just built")
+            .script
+            .clone())
+    })
+}
+
+/// What building one realm cost, by phase.
+///
+/// Kept because the realm is most of what a small page costs (§B8.9) and the
+/// phases move independently: the prelude's *compile* is now paid once per
+/// thread while its *run* is paid per page, and a total alone could not tell
+/// those apart or show the sharing still working.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RealmCost {
+    /// Building the Boa context: the language's own globals and intrinsics.
+    pub context: Duration,
+    /// Installing this engine's native primitives, and the globals the prelude
+    /// reads on its way up.
+    pub primitives: Duration,
+    /// Parsing and compiling the prelude. Near zero after the first realm on a
+    /// thread; that it is near zero is the whole point.
+    pub prelude_compile: Duration,
+    /// Running the prelude: building the object model this realm hands the page.
+    pub prelude_run: Duration,
+}
+
+impl RealmCost {
+    /// What the realm cost in total.
+    #[must_use]
+    pub fn total(&self) -> Duration {
+        self.context + self.primitives + self.prelude_compile + self.prelude_run
+    }
 }
 
 /// What a stack frame inside this engine's own prelude is called.
@@ -450,6 +539,9 @@ pub struct Script {
     /// How long the job queue may run. Overridable so a test can prove the
     /// deadline fires without waiting the real budget out.
     job_budget: Duration,
+
+    /// What building this realm cost, by phase. See [`RealmCost`].
+    cost: RealmCost,
 }
 
 impl Script {
@@ -469,6 +561,8 @@ impl Script {
         base: &url::Url,
         options: RealmOptions,
     ) -> Result<Self, String> {
+        let mut cost = RealmCost::default();
+        let at = std::time::Instant::now();
         let url = base.to_string();
         let host = Rc::new(Host::new(dom, broker, base.clone()));
         // The loader is built before the context because the context owns it,
@@ -504,6 +598,9 @@ impl Script {
             .runtime_limits_mut()
             .set_loop_iteration_limit(LOOP_ITERATION_LIMIT);
 
+        cost.context = at.elapsed();
+
+        let at = std::time::Instant::now();
         context.insert_data(HostHandle(host.clone()));
 
         dom_api::install(&mut context).map_err(|e| e.to_string())?;
@@ -531,20 +628,6 @@ impl Script {
                 boa_engine::property::Attribute::empty(),
             )
             .map_err(|e| e.to_string())?;
-        // Parsed on every realm, and it cannot be otherwise with this Boa.
-        //
-        // ROADMAP §B11.5.14 wanted this cached: three thousand lines of
-        // JavaScript re-parsed per page is a real cost, and §B8.9 measured the
-        // realm at ~20ms. It is not buildable here, for a checkable reason
-        // rather than a hard one. `boa_engine::Script::parse` interns its
-        // identifiers into *this context's* interner (`context.interner_mut()`)
-        // and binds the result to this context's realm, and every page builds a
-        // fresh `Context`. A parsed script is therefore not a portable
-        // artifact; there is nothing to cache across pages. Revisit if Boa
-        // grows a shared interner or a serialisable code block.
-        //
-        // The sibling item, reusing the realm itself across navigations, is
-        // refused on other grounds — see `Page::run_scripts`.
         // Read by the core prelude at the one point the decoration has to
         // happen: after every prototype is populated and before the interfaces
         // reach the page.
@@ -555,20 +638,48 @@ impl Script {
                 boa_engine::property::Attribute::empty(),
             )
             .map_err(|e| e.to_string())?;
-        context
-            .eval(Source::from_reader(
-                PRELUDE.as_bytes(),
-                Some(std::path::Path::new(PRELUDE_PATH)),
-            ))
+        cost.primitives = at.elapsed();
+
+        // Compiled once for this thread, run once per realm.
+        //
+        // Parse and compile were 67 ms of the 83 a realm cost (§B8.9), paid
+        // again by every page for a source that never changes. They are now
+        // paid by the first page a renderer serves and by no other, taking a
+        // later realm to ~15 ms — the largest saving this engine has taken.
+        //
+        // The sibling item, reusing the *realm* across navigations, stays
+        // refused — see `Page::run_scripts`. This is not that. Only the
+        // instructions are shared; every page still gets its own realm, its own
+        // globals and its own prototypes, and nothing a page did is reachable
+        // from the next one. See `bind_to_realm` in our Boa fork for what makes
+        // the sharing safe, and §B15.12a for the reasoning it replaces.
+        let at = std::time::Instant::now();
+        let template = compiled_prelude()?;
+        cost.prelude_compile = at.elapsed();
+
+        let at = std::time::Instant::now();
+        let realm = context.realm().clone();
+        template
+            .bind_to_realm(realm)
+            .map_err(|e| format!("the browser prelude could not be bound to this realm: {e}"))?
+            .evaluate(&mut context)
             .map_err(|e| format!("the browser prelude failed to load: {e}"))?;
+        cost.prelude_run = at.elapsed();
 
         Ok(Self {
             context,
             cancel,
             job_budget: JOB_QUEUE_BUDGET,
+            cost,
             host,
             pending_modules: Vec::new(),
         })
+    }
+
+    /// What building this realm cost, by phase.
+    #[must_use]
+    pub fn cost(&self) -> RealmCost {
+        self.cost
     }
 
     /// Run one script from the page. An error is returned, not swallowed: a

--- a/crates/h5i-browser-light/src/script/mod.rs
+++ b/crates/h5i-browser-light/src/script/mod.rs
@@ -161,6 +161,23 @@ fn compiled_prelude() -> Result<boa_engine::Script, String> {
     })
 }
 
+/// Compile the prelude now, so the next realm on this thread does not have to.
+///
+/// Speculative by nature: this is called while a navigation is in flight, before
+/// anyone knows whether the page has any script at all, because that is the only
+/// window in which the compile overlaps anything (§B15.12a). A page that turns
+/// out to have no script has thrown the work away — which is why the caller is
+/// careful about *when* it speculates, and why the compile is only ever paid
+/// once per thread however many times this is called.
+///
+/// Errors are dropped rather than returned. A prelude that will not compile is a
+/// broken build, it will fail again at [`Script::with_options`] a moment later
+/// with the realm's own error, and reporting it here would attach it to the
+/// navigation instead of to the realm it actually stops.
+pub fn warm_prelude() {
+    let _ = compiled_prelude();
+}
+
 /// What building one realm cost, by phase.
 ///
 /// Kept because the realm is most of what a small page costs (§B8.9) and the

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -3579,6 +3579,82 @@ fn the_prelude_is_compiled_once_for_a_thread_and_run_for_every_realm() {
     );
 }
 
+/// A thread that warmed before it had a realm must be able to end.
+///
+/// This is a regression test for a crash, not for a wrong answer, and it has an
+/// unusual shape because of it: everything the thread does succeeds, and the
+/// process then aborts as the thread exits, with
+/// `tcache_thread_shutdown(): unaligned tcache chunk detected`. So the failure
+/// is the test binary dying rather than an assertion, and the thread has to be
+/// spawned and joined for the teardown to happen at all.
+///
+/// The order is the entire content of the test. Building a realm first touches
+/// Boa's garbage-collected heap before it touches [`PRELUDE_TEMPLATE`], and the
+/// thread-local destructors then run in an order that happens to be safe.
+/// Warming first inverts it, and the template drops `Gc` handles into a heap
+/// that has already been torn down. Warming before a realm exists is precisely
+/// what the overlap does, so this is the shape the product runs in.
+///
+/// See [`PreludeTemplate`] for why the fix is that the template is never
+/// dropped at all.
+#[test]
+fn the_compile_survives_a_thread_that_warmed_before_it_had_a_realm() {
+    std::thread::spawn(|| {
+        warm_prelude();
+        let (_page, mut script) = page_and_script("<html><body><p>x</p></body></html>");
+        // Something after the warm that actually uses the realm, so this cannot
+        // pass by never getting there.
+        assert_eq!(
+            script.eval_value("document.querySelector('p').textContent").unwrap(),
+            "x"
+        );
+    })
+    .join()
+    .expect("the thread that warmed before building its realm");
+}
+
+/// Warming leaves the realm with no compiling left to do.
+///
+/// The link between "the compile happens during the fetch" and "the page is
+/// faster", asserted where a stopwatch cannot argue with it. `ipc.rs` proves the
+/// work runs while the request is in flight and `engine.rs` proves it is only
+/// attempted where there is a wait to hide it in; this is the third side, that
+/// the work is the thing the realm would otherwise have had to do.
+///
+/// Two threads, because the template is per-thread: one realm pays the compile
+/// the way an unwarmed page does, and the other must find it already paid.
+#[test]
+fn warming_takes_the_compile_out_of_the_realm_build() {
+    let cold = std::thread::spawn(|| {
+        let (_page, script) = page_and_script("<html><body></body></html>");
+        script.cost()
+    })
+    .join()
+    .expect("cold realm");
+
+    let warmed = std::thread::spawn(|| {
+        warm_prelude();
+        let (_page, script) = page_and_script("<html><body></body></html>");
+        script.cost()
+    })
+    .join()
+    .expect("warmed realm");
+
+    assert!(
+        cold.prelude_compile > Duration::from_millis(5),
+        "an unwarmed realm compiled the prelude in {:?}, so this test is no \
+         longer measuring the cost it exists to move",
+        cold.prelude_compile
+    );
+    assert!(
+        warmed.prelude_compile * 50 < cold.prelude_compile,
+        "a warmed realm still spent {:?} compiling against an unwarmed realm's \
+         {:?}; the warm did not take",
+        warmed.prelude_compile,
+        cold.prelude_compile
+    );
+}
+
 #[test]
 fn a_tier_is_not_parsed_until_the_page_asks_for_it() {
     // The deferral has to be observable, or it is a claim rather than a fact:

--- a/crates/h5i-browser-light/src/script/tests.rs
+++ b/crates/h5i-browser-light/src/script/tests.rs
@@ -3452,22 +3452,25 @@ fn code_bytes(source: &str) -> usize {
 
 #[test]
 fn the_eagerly_parsed_prelude_stays_within_its_budget() {
-    // **Parse and compile are two thirds of what a script realm costs** — 42 ms
-    // of 59 — and both are a straight function of the code handed to Boa. There
-    // is no lazy compilation to hide behind: every page pays for every line,
-    // whether or not it ever runs one.
+    // **The exchange rate fell, and the budget is still the floor under
+    // noticing.** Parse and compile were 67 ms of the 83 a realm cost and were
+    // paid per page; sharing the compiled prelude across realms moved them to
+    // once per thread, and a later realm now spends under a microsecond there.
+    // What every page still pays for a KiB is the *running* of it — 12.4 ms for
+    // the whole 273 KiB — so about **45 µs of per-page realm cost per KiB**,
+    // against the ~150 µs it was. The first page a renderer serves still pays
+    // the compile, at roughly 245 µs per KiB, and that is the page a person is
+    // waiting on.
     //
-    // This number is a floor under noticing. The prelude grew by 4,692 lines in
+    // The reason for a budget is unchanged. The prelude grew by 4,692 lines in
     // two commits during a coverage push, the realm went from 15.9 ms to 82.8 ms
     // per page, and nothing said so — the tests all passed, because a slower
     // engine is not a wrong one. A budget that has to be raised on purpose puts
     // the price in the diff that pays it.
     //
-    // Raising it is a normal thing to do, not a failure. The exchange rate is
-    // roughly **150 µs of per-page realm cost per KiB of code**, so a KiB spent
-    // here is a KiB every page pays for whether or not it uses the feature. The
-    // question the number asks is only whether it could be a tier instead: see
-    // `TIERS` in `mod.rs`, and `lazyGlobals` in the prelude.
+    // Raising it is a normal thing to do, not a failure. The question the number
+    // asks is only whether it could be a tier instead: see `TIERS` in `mod.rs`,
+    // and `lazyGlobals` in the prelude.
     const BUDGET_KIB: usize = 275;
 
     assert!(
@@ -3480,10 +3483,99 @@ fn the_eagerly_parsed_prelude_stays_within_its_budget() {
     assert!(
         code <= BUDGET_KIB,
         "the eagerly parsed prelude is {code} KiB of code, over its {BUDGET_KIB} KiB \
-         budget. Every page pays about 150 µs per KiB of this, at realm build, \
-         used or not. Either move the new surface into a tier (`TIERS` in \
+         budget. Every page pays about 45 µs per KiB of this to run it, used or \
+         not, and the first page a renderer serves pays about 245 µs per KiB more \
+         to compile it. Either move the new surface into a tier (`TIERS` in \
          `mod.rs`) or raise BUDGET_KIB deliberately and say what the page is \
          getting for it."
+    );
+}
+
+/// Two realms in a row, and the second must not be able to tell that the first
+/// existed.
+///
+/// This is the guard on sharing the prelude's compiled code between realms
+/// (`bind_to_realm` in our Boa fork). The saving is real — parse and compile
+/// were 42 ms of the 63 a realm cost — but the thing being shared is one step
+/// away from the thing §B15.12a refuses outright: reusing the *realm*, which
+/// would let a page set attacker-controlled state, navigate, and have the next
+/// document see it. Sharing instructions is safe and sharing state is not, so
+/// the difference is asserted here rather than left to the argument for it.
+#[test]
+fn a_realm_shares_the_preludes_code_and_none_of_its_state() {
+    let broker = crate::net::LocalBroker::new(Policy::new(), Arc::new(MemorySink::new()), None)
+        .expect("broker");
+    let fonts = crate::fonts::load(&[], &crate::fonts::default_font_dirs(), Some(2));
+    let factory = PageFactory::new(broker.clone(), fonts.sources.clone(), PageOptions::default());
+    let base = url::Url::parse("https://app.example/").unwrap();
+    let page = factory.from_html("<html><body><p id='p'>one</p></body></html>", &base);
+
+    let mut first = Script::new(page.dom(), broker.clone(), &base).expect("first realm");
+    // Everything a hostile page has to reach the next document with: a global,
+    // a patched prototype, and a shadowed built-in.
+    first
+        .eval(
+            "globalThis.__carried = 'from the first realm';
+             Element.prototype.__carried = 'on the prototype';
+             document.querySelector('#p').textContent;",
+        )
+        .expect("the first realm runs");
+
+    let mut second = Script::new(page.dom(), broker.clone(), &base).expect("second realm");
+    assert_eq!(
+        second.eval_value("typeof globalThis.__carried").unwrap(),
+        "undefined",
+        "a global the previous realm set is visible in this one"
+    );
+    assert_eq!(
+        second
+            .eval_value("typeof Element.prototype.__carried")
+            .unwrap(),
+        "undefined",
+        "a prototype the previous realm patched is patched in this one"
+    );
+    // And the shared code still works: an engine that isolated the realms by
+    // failing to install the prelude would pass both assertions above.
+    assert_eq!(
+        second
+            .eval_value("document.querySelector('#p').textContent")
+            .unwrap(),
+        "one"
+    );
+}
+
+/// The compile is paid once for a thread; the run is paid by every realm.
+///
+/// On a thread of its own because that is what the template is scoped to, and
+/// a suite running single-threaded would otherwise have some other test's realm
+/// pay the compile before this one looked.
+#[test]
+fn the_prelude_is_compiled_once_for_a_thread_and_run_for_every_realm() {
+    let (first, later) = std::thread::spawn(|| {
+        let (_page, first) = page_and_script("<html><body></body></html>");
+        let (_page, later) = page_and_script("<html><body></body></html>");
+        (first.cost(), later.cost())
+    })
+    .join()
+    .expect("realms built");
+
+    assert!(
+        later.prelude_compile * 10 < first.prelude_compile,
+        "the second realm on a thread paid {:?} to compile the prelude against \
+         the first realm's {:?}; the template is not being shared",
+        later.prelude_compile,
+        first.prelude_compile
+    );
+    assert!(
+        later.prelude_run > Duration::ZERO,
+        "the prelude did not run in the second realm"
+    );
+    assert!(
+        later.total() < first.total(),
+        "sharing the compiled prelude made the later realm no cheaper: {:?} \
+         against {:?}",
+        later.total(),
+        first.total()
     );
 }
 

--- a/scripts/check_boa_release.sh
+++ b/scripts/check_boa_release.sh
@@ -23,7 +23,18 @@ ua='User-Agent: h5i-boa-release-check'
 # Once the pin is gone, its job is done: boa arriving from crates.io is the
 # state this script was pushing toward, not something to fail about.
 if ! grep -q 'boa-dev/boa' "$here/crates/h5i-browser-light/Cargo.toml"; then
-  echo "boa is a plain crates.io dependency; the workaround this check guarded is gone."
+  echo "the icu clash this check guarded is gone: boa is a plain version requirement."
+  # There is a second, unrelated reason boa is not stock, and saying only the
+  # sentence above would leave a reader thinking it is. The workspace patches
+  # boa to a fork carrying `Script::bind_to_realm` (§B15.12a), which is a
+  # feature upstream does not have rather than a version that cannot resolve.
+  # No release can clear it and crates.io cannot answer the question, so this
+  # script has nothing to test: the exit condition is the pull request landing
+  # upstream, and it is named here so the pin is not mistaken for this one.
+  if grep -q 'h5i-dev/boa' "$here/Cargo.toml"; then
+    echo "note: the workspace still patches boa to the bind_to_realm fork; that pin"
+    echo "      goes away when the API lands upstream, not when a release ships."
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
The script realm was most of what a small page cost, and the prelude's parse and compile were most of the realm: 67 ms of 83, paid again by every page, for 273 KiB of JavaScript that is identical on every one of them. They are now paid once per thread. A later realm costs ~15 ms instead of ~83, and a ten-section scripted page 26 ms instead of 72. `examples/perf.rs` prints the phases first-realm against later-realm, so the claim is measured within one run rather than argued across two builds.

What makes it safe is that instructions are shared and state is not. §B15.12a refuses reusing the *realm* across navigations, because a page could then set attacker-controlled state, navigate, and have the next document see it; that refusal stands and this is careful not to be it. Every page still gets its own realm, global object, prototypes and module map, and the shared code's inline caches are cleared on each bind. It is asserted from both sides: `a_realm_shares_the_preludes_code_and_none_of_its_state` from the page's, and `what_one_realm_does_to_the_shared_code_is_not_visible_to_the_next` from Boa's.

This needs an API Boa does not have, so the workspace patches `boa_engine` and `boa_gc` to a fork at `h5i-dev/boa` carrying one commit of difference: `Script::bind_to_realm`, which returns a script sharing this one's compiled code but running in another realm. **That branch has to keep existing for this branch to build**, and if it is ever rewritten the `rev` in `Cargo.toml` and `Cargo.lock` moves with it. Both crates are patched because this crate depends on `boa_gc` directly, and patching only the engine resolves a second copy whose cancellation token is then a different type with the same name. The distinction from §B22's stylo ruling is that this is not a vendored in-tree copy: it lives outside the tree, is pinned to one commit, is written as an upstream pull request, and goes away when that lands.

§B15.12a had refused this twice and both reasons were wrong, which is the part of this worth reading. The first was that a parsed script is not portable because `Script::parse` interns identifiers into the context's own interner: true of the parse, and irrelevant to the artifact, since a compiled `CodeBlock` holds no `Sym` at all. The second, added on Boa 0.22, was that reusing a code block would carry one page's object shapes into the next page's property lookups: also wrong, because a `CacheEntry` holds a `WeakShape` matched by address, so an object in a second realm can never hit an entry left by the first. Clearing the caches is still right, for the duller reason that the megamorphic flag is permanent and would otherwise accumulate. Both refusals named a structure in Boa and neither was read, so the section now asks that a refusal recorded with a mechanism cite the code the way §B8.9's rejections cite their measurements.

The first realm on a thread still paid the whole compile, and a one-shot `h5i browser open` never has a second, so §B15.12b moves that too: the compile now happens while the navigation's own request is in flight. `Broker::send_while` hands the renderer's idle window to a caller with something to do, and `BrokerClient` writes the request, runs the work, then blocks on the answer. The broker is a separate process, so the window is real. It is a reordering and not parallelism, because Boa's heap is thread-local and `Gc` is not `Send`. The default implementation drops the work rather than running it, since a broker fetching on the calling thread has no window and running the closure first would be a serial addition to the path this shortens.

It is speculative, which is the whole difficulty: the decision comes before the document exists, so it cannot ask whether the page has script, and a page with none builds no realm and would have paid for nothing. `worth_warming` asks the two things it can know. Measured over the corpus first, 64 pages: 92% run script, the scriptless ones fetch *slower* than the scripted ones, and the compile could grow from 67 ms to 172 ms before one page regressed. Every page there was remote, so loopback and the non-network schemes are excluded in code rather than assumed to behave like the rest. `policy::is_loopback` is deliberately not widened to match, though it misses a fully-qualified `localhost.`: it decides what the allowlist admits, and that is a decision to take on its own terms rather than as a side effect of making pages faster.

The end-to-end measurement was wrong once, in a way worth recording. It reported 171 ms saved, which is more than the compile being hidden and therefore could not be the change: `before` and `after` ran back to back on the same URL and the second inherited warm DNS, a resumable TLS session and a warm CDN. With the order alternating, eight pages spanning 0.9 to 39 seconds could not resolve a 67 ms effect at all, median −6 ms. Three pages under 1.5 s over 59 paired runs could: after faster in 44/59, sign test p = 0.0001, median +106 ms, 95% bootstrap CI [+53, +139] against a prediction of +63 to +82. The interval excludes zero and contains the prediction. Both instruments are kept in `perf/`, with the traps encoded rather than left to be found again.

And the overlap shipped a crash, which is the more useful half. Warming before a realm exists inverts the order in which two thread-locals are first touched, the template's and Boa's GC heap, and the template then drops `Gc` handles into a heap already torn down. The symptom is not a wrong answer: every operation succeeds and the process aborts as the thread ends, with `tcache_thread_shutdown(): unaligned tcache chunk detected`. Every test passed on the commit before, because building a realm touches Boa's heap first and the order happened to be safe, and 59 of 60 benchmark runs passed too, because the renderer exits by a path that runs no destructors. The fix is `ManuallyDrop`, so the thread-local has no destructor and the order cannot matter, and the rule it leaves behind is that anything holding a `Gc` in a thread-local must not be dropped. It surfaced only because a test was written for the link the wall clock could not measure, that warming actually empties the realm's compile.

WPT gate unchanged at 293,875 subtests, every directory identical to the baseline. 673 library tests plus 35 integration, `clippy --workspace --all-targets -D warnings` clean on both trees, and the fork clean under `cargo fmt --check` and its own clippy.
