### PR TITLE
docs: the benchmark numbers that changed without their fingerprints

### DIFF
--- a/docs/build-content.py
+++ b/docs/build-content.py
@@ -36,10 +36,10 @@ PUBLISHED = "2026-08-21"
 # without its date. Changing a page's content and forgetting the date is a
 # build error, not a silent regression.
 PAGE_HISTORY = {
-    "": ("2026-08-30", "24e93f00330e7551"),
-    "features/": ("2026-08-30", "100d40146599c9c8"),
+    "": ("2026-08-30", "c4860b676fa4d18f"),
+    "features/": ("2026-08-30", "a3b80ffa88d8bfed"),
     "manual/": ("2026-08-30", "2ca50cadaec9ca6b"),
-    "pitch/": ("2026-08-30", "80aea0bb0ca84a85"),
+    "pitch/": ("2026-08-30", "72d9632cdd5a19db"),
     "demo/": ("2026-08-30", "44a05038318650f0"),
     "guides/": ("2026-08-30", "c644fbeca404844d"),
     "blog/": ("2026-08-30", "397a557a63ce7431"),


### PR DESCRIPTION
The WPT commit revised the browser benchmark claims on the three hand-written pages, ~5x/~80% less peak memory to ~3x/~86%, across the meta descriptions, the JSON-LD ListItem and the visible copy. It left PAGE_HISTORY pinned to the fingerprints of the old numbers, which is exactly the case verify_dates() exists to catch, so `doc fresh` failed.

Fingerprints updated to what is shipping. The dates stay 2026-08-30 because the content change landed today, so <lastmod> and dateModified still describe the page a crawler would fetch.