### PR TITLE
Fix exploitable bugs in the websec workbench

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ env:
   # crates.io publish, because the engine depends on boa by git revision and
   # crates.io refuses that (see scripts/check_boa_release.sh).
   BINARY_NAME: h5i
+  # The workbench plugin, shipped beside the binary rather than inside it: see
+  # `docs/design/design-websec.md` W21.
+  PLUGIN_NAME: h5i-websec
 
 permissions:
   contents: write
@@ -162,11 +165,17 @@ jobs:
       # and boa alongside git2, so a target that cannot compile the engine cannot
       # produce a release binary at all. That is the reading the asset guard
       # below already takes.
+      # Both binaries. `h5i-websec` is the workbench plugin: a small clap
+      # wrapper that runs `h5i browser` verbs in a subprocess and links no
+      # engine, so it costs seconds to build and a few hundred kilobytes to
+      # ship. Without it in the release, `h5i plugin install websec --from …`
+      # has no file to point at unless you have the source and a toolchain.
       - name: Build
         env:
           H5I_SKIP_WEB_BUILD: "1"
         run: |
-          cargo build --release --locked --target ${{ matrix.target }}
+          cargo build --release --locked --target ${{ matrix.target }} \
+            -p ${{ env.BINARY_NAME }} -p ${{ env.PLUGIN_NAME }}
 
       # ── Package ───────────────────────────────────────────────────────────
 
@@ -192,6 +201,7 @@ jobs:
             sha256sum "$archive" > "$archive.sha256"
           }
           package "${{ env.BINARY_NAME }}"
+          package "${{ env.PLUGIN_NAME }}"
 
       - name: Package (Windows)
         if: matrix.archive_ext == 'zip'
@@ -209,6 +219,7 @@ jobs:
             "$hash  $archive" | Out-File -FilePath "$archive.sha256" -Encoding ASCII
           }
           Package "${{ env.BINARY_NAME }}"
+          Package "${{ env.PLUGIN_NAME }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6
@@ -241,14 +252,14 @@ jobs:
         run: ls -lh artifacts/
 
       # Fail loudly rather than publishing a short set: four targets, each with
-      # an archive and a checksum. A build job that silently stopped uploading
-      # would otherwise produce a release missing a platform, which nobody
-      # notices until someone's install breaks.
+      # two archives and their checksums. A build job that silently stopped
+      # uploading would otherwise produce a release missing a platform, which
+      # nobody notices until someone's install breaks.
       - name: Every expected asset is present, and nothing else
         run: |
-          # Four targets x one binary x (archive + checksum). The engine used to
-          # be a second archive per target, which is where 16 came from.
-          expected=8
+          # Four targets x two binaries (`h5i` and the `h5i-websec` plugin) x
+          # (archive + checksum).
+          expected=16
           found=$(find artifacts -maxdepth 1 -type f \
             \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \) | wc -l)
           extra=$(find artifacts -mindepth 1 -maxdepth 1 \
@@ -305,6 +316,20 @@ jobs:
             second archive (`h5i-browser-light`); `h5i browser` execs itself to
             become it now, and `h5i __engine` reaches its own CLI for the cases
             that want it directly.
+
+            ### The websec workbench
+
+            `h5i-websec` is a separate archive, and installing it is a
+            deliberate act:
+
+            ```bash
+            curl -L https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/h5i-websec-${{ github.ref_name }}-<TARGET>.tar.gz | tar -xz
+            h5i plugin install websec --from ./h5i-websec
+            ```
+
+            It holds no privilege of its own: every verb runs the `h5i browser`
+            verbs a person would type, through the same policy, budget and
+            receipts.
 
             Every request it makes is checked against an allowlist — every
             request and every redirect hop — and written to the log before any

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4771,6 +4771,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,12 @@ resolver = "3"
 thiserror = "2.0.18"
 git2 = "0.20.4"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# `preserve_order` because a JSON body edit rewrites the body it edits, and a
+# request whose keys came back alphabetised is not the request that was
+# recorded: an API that signs its body sees a different one and answers 401,
+# which a workbench reads as a finding. Insertion order costs an `IndexMap`
+# and buys `resend --set json.…` sending what it replayed.
+serde_json = { version = "1.0", features = ["preserve_order"] }
 toml = { version = "0.8", features = ["parse", "display"] }
 sha2 = "0.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,8 @@ resolver = "3"
 thiserror = "2.0.18"
 git2 = "0.20.4"
 serde = { version = "1.0", features = ["derive"] }
-# `preserve_order` because a JSON body edit rewrites the body it edits, and a
-# request whose keys came back alphabetised is not the request that was
-# recorded: an API that signs its body sees a different one and answers 401,
-# which a workbench reads as a finding. Insertion order costs an `IndexMap`
-# and buys `resend --set json.…` sending what it replayed.
+# `preserve_order`: a `json.` edit rewrites the body, and a replay whose keys
+# came back sorted is not the request that was recorded.
 serde_json = { version = "1.0", features = ["preserve_order"] }
 toml = { version = "0.8", features = ["parse", "display"] }
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -144,10 +144,12 @@ h5i box view <name> --term     # draw it in this terminal instead (needs kitty)
 h5i lets the agent inspect, edit, replay, and compare browser requests and responses, match conditions, and run 
 multi-step test flows without a MITM proxy, CA certificate, or separate repeater.
 
-Install the optional `websec` plugin, then browse the application normally:
+Install the optional `websec` plugin, then browse the application normally. The
+plugin is a separate archive on the release page, so installing it is a
+deliberate act:
 
 ```bash
-h5i plugin install websec
+h5i plugin install websec --from ./h5i-websec
 h5i browser open https://target.example --capture --allow target.example
 
 h5i websec requests                                  # captured HTTP messages

--- a/crates/h5i-browser/src/broker.rs
+++ b/crates/h5i-browser/src/broker.rs
@@ -125,8 +125,21 @@ pub struct LogSummary {
     pub total: usize,
     /// Requests the policy refused.
     pub denied: usize,
-    /// The cursor to pass back as `since`.
+    /// The highest sequence recorded, over both phases.
     pub highest: Option<u64>,
+    /// The cursor to pass back as `since`.
+    ///
+    /// Not [`Self::highest`], and the difference is an evidence gap. A request
+    /// and its response are two rows sharing one sequence number, and the
+    /// request half is written *before* the wire. An agent that polled while a
+    /// fetch was in flight took the in-flight request's number as its cursor,
+    /// and the next read asked for `seq > that` — so the response half, which
+    /// carries the status, the size and the error, was never handed to anyone.
+    ///
+    /// This is the highest sequence below which nothing is still in flight, so
+    /// the worst a poll can do is show a request row twice. Which is the right
+    /// side of that trade for a log whose whole claim is that it is complete.
+    pub cursor: Option<u64>,
 }
 
 /// A stored request, sent again with changes.
@@ -420,7 +433,32 @@ pub trait Broker: Send + Sync {
     /// [`Self::records_since`] exists.
     fn log_summary(&self) -> LogSummary {
         let records = self.records();
+        // The lowest sequence whose pair is not finished. Everything below it
+        // is complete and safe to move a cursor past; it and everything after
+        // are not, because a response row lands later and would fall behind a
+        // cursor that had already gone past its number.
+        let mut answered: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for record in &records {
+            if record.phase == crate::receipt::Phase::Response {
+                answered.insert(record.seq);
+            }
+        }
+        let in_flight = records
+            .iter()
+            .filter(|r| r.phase == crate::receipt::Phase::Request)
+            .map(|r| r.seq)
+            .filter(|seq| !answered.contains(seq))
+            .min();
+        let highest = records.iter().map(|r| r.seq).max();
+        let cursor = match in_flight {
+            // Nothing outstanding: the whole log has been handed over.
+            None => highest,
+            // Stop below the first request still waiting for its answer.
+            Some(0) => None,
+            Some(seq) => Some(seq - 1),
+        };
         LogSummary {
+            cursor,
             total: records.len(),
             denied: records
                 .iter()
@@ -430,7 +468,7 @@ pub trait Broker: Send + Sync {
             // before the append and a socket's reader thread appends
             // concurrently with the page's own fetches, so append order and
             // sequence order can differ.
-            highest: records.iter().map(|r| r.seq).max(),
+            highest,
         }
     }
 

--- a/crates/h5i-browser/src/broker.rs
+++ b/crates/h5i-browser/src/broker.rs
@@ -129,16 +129,10 @@ pub struct LogSummary {
     pub highest: Option<u64>,
     /// The cursor to pass back as `since`.
     ///
-    /// Not [`Self::highest`], and the difference is an evidence gap. A request
-    /// and its response are two rows sharing one sequence number, and the
-    /// request half is written *before* the wire. An agent that polled while a
-    /// fetch was in flight took the in-flight request's number as its cursor,
-    /// and the next read asked for `seq > that` — so the response half, which
-    /// carries the status, the size and the error, was never handed to anyone.
-    ///
-    /// This is the highest sequence below which nothing is still in flight, so
-    /// the worst a poll can do is show a request row twice. Which is the right
-    /// side of that trade for a log whose whole claim is that it is complete.
+    /// Not [`Self::highest`]: a request and its response share a sequence
+    /// number and the request half is written *before* the wire, so a poll
+    /// during a fetch took that number and never saw the response half. This
+    /// stops below anything in flight, so the worst it does is repeat a row.
     pub cursor: Option<u64>,
 }
 
@@ -434,9 +428,7 @@ pub trait Broker: Send + Sync {
     fn log_summary(&self) -> LogSummary {
         let records = self.records();
         // The lowest sequence whose pair is not finished. Everything below it
-        // is complete and safe to move a cursor past; it and everything after
-        // are not, because a response row lands later and would fall behind a
-        // cursor that had already gone past its number.
+        // is complete and safe to move a cursor past.
         let mut answered: std::collections::HashSet<u64> = std::collections::HashSet::new();
         for record in &records {
             if record.phase == crate::receipt::Phase::Response {
@@ -451,7 +443,6 @@ pub trait Broker: Send + Sync {
             .min();
         let highest = records.iter().map(|r| r.seq).max();
         let cursor = match in_flight {
-            // Nothing outstanding: the whole log has been handed over.
             None => highest,
             // Stop below the first request still waiting for its answer.
             Some(0) => None,

--- a/crates/h5i-browser/src/capture.rs
+++ b/crates/h5i-browser/src/capture.rs
@@ -177,9 +177,17 @@ pub struct Health {
 pub struct Capture {
     dir: PathBuf,
     bodies: PathBuf,
-    /// Bytes this session has put in `bodies`, which is what
-    /// [`MAX_STORE_BYTES`] bounds.
+    /// Bytes of *body* this session holds. What a reader means by "how much
+    /// evidence is in here", and half of what [`MAX_STORE_BYTES`] bounds.
     used: AtomicU64,
+    /// Bytes of message file beside them: the headers, both directions.
+    ///
+    /// The other half of the allowance, and it was outside it entirely. A
+    /// message file is not small — the raw sender accepts a response head as
+    /// large as the whole response cap — so a loop against a server that
+    /// chooses what it answers with grew this directory without limit while the
+    /// quota read as empty.
+    overhead: AtomicU64,
     /// Hashes already stored, used for deduplication and byte accounting.
     seen: Mutex<HashSet<String>>,
     /// How many messages this store failed to write. Reported rather than
@@ -196,7 +204,8 @@ impl Capture {
         std::fs::create_dir_all(&bodies).map_err(|e| H5iError::with_path(e, &bodies))?;
         owner_only_dir(dir);
         owner_only_dir(&bodies);
-        // Include existing bodies in the restored session's quota.
+        // Include what is already here in the restored session's quota: the
+        // bodies, and the message files beside them.
         let mut used = 0u64;
         let mut seen = HashSet::new();
         if let Ok(entries) = std::fs::read_dir(&bodies) {
@@ -211,10 +220,21 @@ impl Capture {
                 }
             }
         }
+        let mut overhead = 0u64;
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if let Ok(meta) = entry.metadata()
+                    && meta.is_file()
+                {
+                    overhead = overhead.saturating_add(meta.len());
+                }
+            }
+        }
         Ok(Self {
             dir: dir.to_path_buf(),
             bodies,
             used: AtomicU64::new(used),
+            overhead: AtomicU64::new(overhead),
             seen: Mutex::new(seen),
             errors: AtomicU64::new(0),
             messages: AtomicU64::new(0),
@@ -234,6 +254,12 @@ impl Capture {
     /// How many bytes of body this store holds.
     pub fn used(&self) -> u64 {
         self.used.load(Ordering::Relaxed)
+    }
+
+    /// Everything this store has put on disk: bodies and message files. What
+    /// [`MAX_STORE_BYTES`] is a bound on.
+    fn held(&self) -> u64 {
+        self.used().saturating_add(self.overhead.load(Ordering::Relaxed))
     }
 
     /// What this store has done, for whoever is asking whether to trust it.
@@ -364,7 +390,7 @@ impl Capture {
             // The allowance is checked under the same lock that claims the
             // hash, so two threads storing two different bodies at once cannot
             // both decide there is room for the last of it.
-            let used = self.used.load(Ordering::Relaxed);
+            let used = self.held();
             if used.saturating_add(kept.len() as u64) > MAX_STORE_BYTES {
                 // Refused rather than evicted. Eviction wants a pin, so that a
                 // body a finding rests on is not the one thrown away to make
@@ -397,11 +423,29 @@ impl Capture {
     }
 
     /// Write one message file. Best-effort, and counted when it fails.
+    ///
+    /// Against the same allowance a body is written against. A message file
+    /// holds every header of one message, and the raw sender will read a
+    /// response head as large as the whole response cap, so leaving these
+    /// outside the quota left the directory unbounded in the one case the quota
+    /// exists for: a loop against a server that chooses what it answers with.
     fn write<T: Serialize>(&self, seq: u64, phase: &str, message: &T) {
         let path = self.dir.join(format!("{seq}.{phase}.json"));
         let wrote = serde_json::to_vec(message)
             .map_err(H5iError::from)
-            .and_then(|bytes| write_owner_only(&path, &bytes));
+            .and_then(|bytes| {
+                let used = self.held();
+                if used.saturating_add(bytes.len() as u64) > MAX_STORE_BYTES {
+                    // Refused rather than evicted, like a body. Counted, so
+                    // `capture` health reports the gap rather than hiding it.
+                    return Err(H5iError::Metadata(format!(
+                        "the message store is full ({used} of {MAX_STORE_BYTES} bytes)"
+                    )));
+                }
+                write_owner_only(&path, &bytes)?;
+                self.overhead.fetch_add(bytes.len() as u64, Ordering::Relaxed);
+                Ok(())
+            });
         match wrote {
             Ok(()) => self.messages.fetch_add(1, Ordering::Relaxed),
             Err(_) => self.errors.fetch_add(1, Ordering::Relaxed),
@@ -518,6 +562,46 @@ mod tests {
             std::fs::read(&elsewhere).expect("still there"),
             b"do not touch",
             "and what it pointed at is untouched"
+        );
+    }
+
+    /// A message file holds every header of one message and used to be written
+    /// outside the quota entirely, so `used` could read as empty while the
+    /// directory grew. The raw sender accepts a response head as large as the
+    /// whole response cap, which is what makes that reachable on purpose.
+    #[test]
+    fn a_message_file_is_counted_against_the_store_the_way_a_body_is() {
+        let (_dir, capture) = store();
+        assert_eq!(capture.used(), 0);
+
+        capture.request(
+            1,
+            "GET",
+            "https://app.test/a",
+            vec![("x-big".to_string(), "v".repeat(50_000))],
+            b"",
+            None,
+        );
+
+        assert_eq!(capture.used(), 0, "a GET has no body, so no body is held");
+        assert!(
+            capture.held() > 50_000,
+            "but its headers are on disk and inside the allowance: {}",
+            capture.held()
+        );
+        assert_eq!(capture.errors(), 0);
+    }
+
+    /// And the allowance is over both, so a store filled by message files
+    /// refuses the next body rather than reporting room it does not have.
+    #[test]
+    fn message_files_fill_the_same_allowance_a_body_does() {
+        let (_dir, capture) = store();
+        capture.overhead.store(MAX_STORE_BYTES, Ordering::Relaxed);
+        let body = capture.store_body(Received::Bytes(b"evidence"), Some("text/plain"));
+        assert!(
+            matches!(body, Body::Skipped { reason: Skip::StoreFull, .. }),
+            "{body:?}"
         );
     }
 

--- a/crates/h5i-browser/src/capture.rs
+++ b/crates/h5i-browser/src/capture.rs
@@ -20,6 +20,22 @@ pub const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
 /// Maximum total body storage per session.
 pub const MAX_STORE_BYTES: u64 = 512 * 1024 * 1024;
 
+/// The file a body hash names inside a store, or `None` when it is not a hash.
+///
+/// The hash reaches every caller from a JSON file, and a JSON file in a session
+/// directory is not a trusted input: a session that runs inside a box has its
+/// store on a filesystem the boxed code can write to, so a `..` in that field
+/// would name a path outside the store, on the host. Hex and length are the
+/// whole check, because a name that is 64 hex characters cannot traverse
+/// anywhere. Public so that h5i's own reader shares the rule rather than
+/// reimplementing it, which is how the two came apart the first time.
+pub fn body_file(store: &Path, sha256: &str) -> Option<PathBuf> {
+    if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(store.join("bodies").join(sha256))
+}
+
 /// Skip large media unlikely to aid inspection. Images remain capturable for
 /// upload analysis.
 fn is_skipped_type(content_type: Option<&str>) -> bool {
@@ -289,18 +305,12 @@ impl Capture {
     }
 
     /// The file a hash names, refusing anything that is not one.
-    ///
-    /// The hash reaches this from a JSON file, and a JSON file in a session
-    /// directory is not a trusted input: a `..` in that field would otherwise
-    /// name a path outside the store. Hex and length are the whole check because
-    /// a name that is 64 hex characters cannot traverse anywhere.
     fn body_path(&self, sha256: &str) -> Result<PathBuf, H5iError> {
-        if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
-            return Err(H5iError::Internal(format!(
+        body_file(&self.dir, sha256).ok_or_else(|| {
+            H5iError::Internal(format!(
                 "{sha256:?} is not a body hash, so there is nothing in the store to read"
-            )));
-        }
-        Ok(self.bodies.join(sha256))
+            ))
+        })
     }
 
     /// Put a body in the store, and say what became of it.

--- a/crates/h5i-browser/src/capture.rs
+++ b/crates/h5i-browser/src/capture.rs
@@ -429,6 +429,13 @@ fn hex(bytes: &[u8]) -> String {
 /// The same reasoning as the request log's, one step further along. This holds
 /// session cookies and `Authorization` headers in full, and a boxed session's
 /// directory can be under a `/tmp` the `agent` profile shares with the host.
+///
+/// Which is also why the mode is not left to `OpenOptions`. `mode` applies when
+/// the file is *created* and says nothing about one that is already there, so
+/// anything that could put a 0666 file at one of these names first got the
+/// credentials written into it — and a name that was a symlink got them written
+/// wherever it pointed, over whatever was there. `O_NOFOLLOW` closes the second,
+/// and narrowing the handle after it opens closes the first.
 fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), H5iError> {
     use std::io::Write as _;
     let mut options = std::fs::OpenOptions::new();
@@ -437,8 +444,17 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), H5iError> {
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
+        options.custom_flags(libc::O_NOFOLLOW);
     }
     let mut file = options.open(path).map_err(|e| H5iError::with_path(e, path))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // On the handle, not the path: nothing can swap the name for another
+        // file between the open and this.
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(H5iError::Io)?;
+    }
     file.write_all(bytes).map_err(H5iError::Io)?;
     file.flush().map_err(H5iError::Io)?;
     Ok(())
@@ -464,6 +480,45 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let capture = Capture::open(&dir.path().join("messages")).expect("store opens");
         (dir, capture)
+    }
+
+    /// `OpenOptions::mode` applies to a file it creates and to no other, so a
+    /// message file that was already there kept whatever mode it had — and this
+    /// store holds `Cookie` and `Authorization` in full, in a directory that
+    /// can sit under a shared `/tmp`.
+    #[cfg(unix)]
+    #[test]
+    fn a_file_that_was_already_there_is_narrowed_rather_than_written_wide() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("waiting.json");
+        std::fs::write(&path, b"{}").expect("a file to be there first");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666))
+            .expect("wide open");
+
+        write_owner_only(&path, b"{\"secret\":true}").expect("writes");
+
+        let mode = std::fs::metadata(&path).expect("stat").permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "{mode:o}");
+    }
+
+    /// And a name that is a symlink is not a place to write a credential: it is
+    /// somebody else naming the file this store is about to truncate.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_is_refused_rather_than_followed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let elsewhere = dir.path().join("elsewhere");
+        std::fs::write(&elsewhere, b"do not touch").expect("a target");
+        let path = dir.path().join("42.response.json");
+        std::os::unix::fs::symlink(&elsewhere, &path).expect("a symlink in the way");
+
+        assert!(write_owner_only(&path, b"{}").is_err(), "a symlink is refused");
+        assert_eq!(
+            std::fs::read(&elsewhere).expect("still there"),
+            b"do not touch",
+            "and what it pointed at is untouched"
+        );
     }
 
     #[test]

--- a/crates/h5i-browser/src/capture.rs
+++ b/crates/h5i-browser/src/capture.rs
@@ -22,13 +22,9 @@ pub const MAX_STORE_BYTES: u64 = 512 * 1024 * 1024;
 
 /// The file a body hash names inside a store, or `None` when it is not a hash.
 ///
-/// The hash reaches every caller from a JSON file, and a JSON file in a session
-/// directory is not a trusted input: a session that runs inside a box has its
-/// store on a filesystem the boxed code can write to, so a `..` in that field
-/// would name a path outside the store, on the host. Hex and length are the
-/// whole check, because a name that is 64 hex characters cannot traverse
-/// anywhere. Public so that h5i's own reader shares the rule rather than
-/// reimplementing it, which is how the two came apart the first time.
+/// A boxed session's store is on a filesystem the boxed code can write to, so a
+/// `..` in that field would name a path outside it. Hex and length are the
+/// whole check. Public so h5i's own reader shares the rule rather than drifting.
 pub fn body_file(store: &Path, sha256: &str) -> Option<PathBuf> {
     if sha256.len() != 64 || !sha256.bytes().all(|b| b.is_ascii_hexdigit()) {
         return None;
@@ -177,16 +173,13 @@ pub struct Health {
 pub struct Capture {
     dir: PathBuf,
     bodies: PathBuf,
-    /// Bytes of *body* this session holds. What a reader means by "how much
-    /// evidence is in here", and half of what [`MAX_STORE_BYTES`] bounds.
+    /// Bytes of *body* held: what a reader means by "how much evidence is in
+    /// here", and half of what [`MAX_STORE_BYTES`] bounds.
     used: AtomicU64,
-    /// Bytes of message file beside them: the headers, both directions.
+    /// Bytes of message file beside them, the other half of the allowance.
     ///
-    /// The other half of the allowance, and it was outside it entirely. A
-    /// message file is not small — the raw sender accepts a response head as
-    /// large as the whole response cap — so a loop against a server that
-    /// chooses what it answers with grew this directory without limit while the
-    /// quota read as empty.
+    /// These were outside it entirely, and they are not small: the raw sender
+    /// accepts a response head as large as the whole response cap.
     overhead: AtomicU64,
     /// Hashes already stored, used for deduplication and byte accounting.
     seen: Mutex<HashSet<String>>,
@@ -204,8 +197,7 @@ impl Capture {
         std::fs::create_dir_all(&bodies).map_err(|e| H5iError::with_path(e, &bodies))?;
         owner_only_dir(dir);
         owner_only_dir(&bodies);
-        // Include what is already here in the restored session's quota: the
-        // bodies, and the message files beside them.
+        // What is already here counts against the restored session's quota.
         let mut used = 0u64;
         let mut seen = HashSet::new();
         if let Ok(entries) = std::fs::read_dir(&bodies) {
@@ -424,11 +416,8 @@ impl Capture {
 
     /// Write one message file. Best-effort, and counted when it fails.
     ///
-    /// Against the same allowance a body is written against. A message file
-    /// holds every header of one message, and the raw sender will read a
-    /// response head as large as the whole response cap, so leaving these
-    /// outside the quota left the directory unbounded in the one case the quota
-    /// exists for: a loop against a server that chooses what it answers with.
+    /// Against the same allowance a body is: these hold every header, and
+    /// leaving them outside the quota left the directory unbounded.
     fn write<T: Serialize>(&self, seq: u64, phase: &str, message: &T) {
         let path = self.dir.join(format!("{seq}.{phase}.json"));
         let wrote = serde_json::to_vec(message)
@@ -436,8 +425,7 @@ impl Capture {
             .and_then(|bytes| {
                 let used = self.held();
                 if used.saturating_add(bytes.len() as u64) > MAX_STORE_BYTES {
-                    // Refused rather than evicted, like a body. Counted, so
-                    // `capture` health reports the gap rather than hiding it.
+                    // Refused rather than evicted, like a body, and counted.
                     return Err(H5iError::Metadata(format!(
                         "the message store is full ({used} of {MAX_STORE_BYTES} bytes)"
                     )));
@@ -470,16 +458,10 @@ fn hex(bytes: &[u8]) -> String {
 
 /// Write a file readable only by its owner.
 ///
-/// The same reasoning as the request log's, one step further along. This holds
-/// session cookies and `Authorization` headers in full, and a boxed session's
-/// directory can be under a `/tmp` the `agent` profile shares with the host.
-///
-/// Which is also why the mode is not left to `OpenOptions`. `mode` applies when
-/// the file is *created* and says nothing about one that is already there, so
-/// anything that could put a 0666 file at one of these names first got the
-/// credentials written into it — and a name that was a symlink got them written
-/// wherever it pointed, over whatever was there. `O_NOFOLLOW` closes the second,
-/// and narrowing the handle after it opens closes the first.
+/// This holds session cookies and `Authorization` in full, in a directory that
+/// can sit under a shared `/tmp`. `OpenOptions::mode` applies only on create,
+/// so a pre-made 0666 file got the credentials written into it and a symlink
+/// got them written wherever it pointed.
 fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), H5iError> {
     use std::io::Write as _;
     let mut options = std::fs::OpenOptions::new();
@@ -494,8 +476,7 @@ fn write_owner_only(path: &Path, bytes: &[u8]) -> Result<(), H5iError> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        // On the handle, not the path: nothing can swap the name for another
-        // file between the open and this.
+        // On the handle, not the path.
         file.set_permissions(std::fs::Permissions::from_mode(0o600))
             .map_err(H5iError::Io)?;
     }
@@ -526,10 +507,8 @@ mod tests {
         (dir, capture)
     }
 
-    /// `OpenOptions::mode` applies to a file it creates and to no other, so a
-    /// message file that was already there kept whatever mode it had — and this
-    /// store holds `Cookie` and `Authorization` in full, in a directory that
-    /// can sit under a shared `/tmp`.
+    /// `mode` applies only to a file it creates, so one already there kept
+    /// whatever mode it had — with `Cookie` and `Authorization` written into it.
     #[cfg(unix)]
     #[test]
     fn a_file_that_was_already_there_is_narrowed_rather_than_written_wide() {
@@ -546,8 +525,7 @@ mod tests {
         assert_eq!(mode & 0o777, 0o600, "{mode:o}");
     }
 
-    /// And a name that is a symlink is not a place to write a credential: it is
-    /// somebody else naming the file this store is about to truncate.
+    /// And a symlink is somebody else naming the file this is about to truncate.
     #[cfg(unix)]
     #[test]
     fn a_symlink_is_refused_rather_than_followed() {
@@ -565,10 +543,8 @@ mod tests {
         );
     }
 
-    /// A message file holds every header of one message and used to be written
-    /// outside the quota entirely, so `used` could read as empty while the
-    /// directory grew. The raw sender accepts a response head as large as the
-    /// whole response cap, which is what makes that reachable on purpose.
+    /// Message files were written outside the quota entirely, so `used` read
+    /// as empty while the directory grew.
     #[test]
     fn a_message_file_is_counted_against_the_store_the_way_a_body_is() {
         let (_dir, capture) = store();
@@ -592,8 +568,7 @@ mod tests {
         assert_eq!(capture.errors(), 0);
     }
 
-    /// And the allowance is over both, so a store filled by message files
-    /// refuses the next body rather than reporting room it does not have.
+    /// And the allowance is over both.
     #[test]
     fn message_files_fill_the_same_allowance_a_body_does() {
         let (_dir, capture) = store();

--- a/crates/h5i-browser/src/cli.rs
+++ b/crates/h5i-browser/src/cli.rs
@@ -2583,20 +2583,15 @@ fn local_base(path: &Path) -> Result<Url, H5iError> {
     })
 }
 
-/// Most a `--set-file` payload may be.
-///
-/// Generous, because testing what a server does with a large upload is a real
-/// test. A bound at all, because the whole file is read into memory, base64'd
-/// and carried through a JSON control message, so a mistyped path costs several
-/// times the file in the CLI and again in the engine.
+/// Most a `--set-file` payload may be. Generous, because a large upload is a
+/// real test; bounded, because the file is read whole and base64'd through a
+/// control message.
 const MAX_PAYLOAD_BYTES: u64 = 64 * 1024 * 1024;
 
 /// One `--set-file` payload, read whole and bounded.
 ///
-/// The shape check is the one that matters: `/dev/zero` and `/dev/urandom` are
-/// named like files and are not, and `fs::read` on either grows a `Vec` until
-/// the machine gives out. A fifo is worse, since it blocks on a writer that may
-/// never come and the session simply stops answering.
+/// The shape check is the one that matters: `fs::read` on `/dev/zero` grows a
+/// `Vec` until the machine gives out, and a fifo blocks forever.
 fn read_a_payload(target: &str, path: &str) -> Result<Vec<u8>, H5iError> {
     let meta = std::fs::metadata(path).map_err(|e| {
         H5iError::Metadata(format!("`--set-file {target}`: {path} could not be read: {e}"))

--- a/crates/h5i-browser/src/cli.rs
+++ b/crates/h5i-browser/src/cli.rs
@@ -682,7 +682,7 @@ enum SessionVerb {
         /// Only responses with this status.
         #[arg(long, value_name = "CODE")]
         status: Option<u16>,
-        /// Only `navigation`, `subresource`, `frame` or `redirect`.
+        /// Only `navigation`, `subresource`, `frame`, `redirect` or `replay`.
         #[arg(long, value_name = "KIND")]
         initiator: Option<String>,
         /// Only what policy refused.

--- a/crates/h5i-browser/src/cli.rs
+++ b/crates/h5i-browser/src/cli.rs
@@ -1677,9 +1677,7 @@ fn session(verb: SessionVerb) -> Result<(), H5iError> {
                         "`--set-file {spec}` is `target=path`, and this has no `=`"
                     ))
                 })?;
-                let bytes = std::fs::read(path).map_err(|e| {
-                    H5iError::Metadata(format!("`--set-file {target}`: {path} could not be read: {e}"))
-                })?;
+                let bytes = read_a_payload(target, path)?;
                 use base64::Engine as _;
                 from_files.push((
                     target.to_string(),
@@ -2582,6 +2580,43 @@ fn local_base(path: &Path) -> Result<Url, H5iError> {
             "{} cannot be expressed as a file:// base",
             absolute.display()
         ))
+    })
+}
+
+/// Most a `--set-file` payload may be.
+///
+/// Generous, because testing what a server does with a large upload is a real
+/// test. A bound at all, because the whole file is read into memory, base64'd
+/// and carried through a JSON control message, so a mistyped path costs several
+/// times the file in the CLI and again in the engine.
+const MAX_PAYLOAD_BYTES: u64 = 64 * 1024 * 1024;
+
+/// One `--set-file` payload, read whole and bounded.
+///
+/// The shape check is the one that matters: `/dev/zero` and `/dev/urandom` are
+/// named like files and are not, and `fs::read` on either grows a `Vec` until
+/// the machine gives out. A fifo is worse, since it blocks on a writer that may
+/// never come and the session simply stops answering.
+fn read_a_payload(target: &str, path: &str) -> Result<Vec<u8>, H5iError> {
+    let meta = std::fs::metadata(path).map_err(|e| {
+        H5iError::Metadata(format!("`--set-file {target}`: {path} could not be read: {e}"))
+    })?;
+    if !meta.is_file() {
+        return Err(H5iError::Metadata(format!(
+            "`--set-file {target}`: {path} is not a regular file, so it has no bytes to \
+             send — a device or a pipe is read until it stops, and these do not stop"
+        )));
+    }
+    if meta.len() > MAX_PAYLOAD_BYTES {
+        return Err(H5iError::Metadata(format!(
+            "`--set-file {target}`: {path} is {} bytes, past the {MAX_PAYLOAD_BYTES} byte \
+             limit on one payload. It is read whole, encoded and carried through a control \
+             message, so this would cost several times that in memory",
+            meta.len()
+        )));
+    }
+    std::fs::read(path).map_err(|e| {
+        H5iError::Metadata(format!("`--set-file {target}`: {path} could not be read: {e}"))
     })
 }
 

--- a/crates/h5i-browser/src/cors.rs
+++ b/crates/h5i-browser/src/cors.rs
@@ -425,14 +425,9 @@ pub fn check_preflight(
 
     let (headers_any, allowed) = listed(allow_headers);
     for wanted in &ask.headers {
-        // `*` covers every header a page asked for except one. Fetch carves
-        // `Authorization` out of the wildcard by name, and every browser
-        // implements the carve-out, for the reason the rest of this module
-        // exists: a server answering `*` has said "any header", which is not
-        // the same as agreeing to receive somebody's bearer token. Without the
-        // carve-out a page on one allowlisted origin could hand another origin
-        // a credential that origin never asked for, and the wildcard is the
-        // answer a server gives when it has not thought about the question.
+        // Fetch carves `Authorization` out of the wildcard by name, and every
+        // browser implements it: a server answering `*` has said "any header",
+        // not "I agree to receive somebody's bearer token".
         let covered_by_wildcard =
             headers_any && !ask.credentials && wanted != "authorization";
         if covered_by_wildcard || allowed.iter().any(|a| a == wanted) {
@@ -736,12 +731,8 @@ mod tests {
         assert!(refused.is_err(), "a wildcard must not cover credentials");
     }
 
-    /// `Access-Control-Allow-Headers: *` covers every header a page asked for
-    /// except one. Fetch carves `Authorization` out of the wildcard by name and
-    /// every browser implements the carve-out, because a server answering `*`
-    /// has said "any header", not "I agree to receive somebody's bearer token".
-    /// Without it, a page on one allowlisted origin hands another origin a
-    /// credential that origin never asked for by name.
+    /// Fetch carves `Authorization` out of `Allow-Headers: *`, because a server
+    /// answering `*` has said "any header", not "send me a bearer token".
     #[test]
     fn a_wildcard_preflight_does_not_cover_authorization() {
         let asking_for = |header: &str| Preflight {

--- a/crates/h5i-browser/src/cors.rs
+++ b/crates/h5i-browser/src/cors.rs
@@ -424,15 +424,32 @@ pub fn check_preflight(
     }
 
     let (headers_any, allowed) = listed(allow_headers);
-    if !(headers_any && !ask.credentials) {
-        for wanted in &ask.headers {
-            if !allowed.iter().any(|a| a == wanted) {
-                return Err(format!(
-                    "the preflight does not allow the `{wanted}` header. The server would \
-                     have to list it in `Access-Control-Allow-Headers`."
-                ));
-            }
+    for wanted in &ask.headers {
+        // `*` covers every header a page asked for except one. Fetch carves
+        // `Authorization` out of the wildcard by name, and every browser
+        // implements the carve-out, for the reason the rest of this module
+        // exists: a server answering `*` has said "any header", which is not
+        // the same as agreeing to receive somebody's bearer token. Without the
+        // carve-out a page on one allowlisted origin could hand another origin
+        // a credential that origin never asked for, and the wildcard is the
+        // answer a server gives when it has not thought about the question.
+        let covered_by_wildcard =
+            headers_any && !ask.credentials && wanted != "authorization";
+        if covered_by_wildcard || allowed.iter().any(|a| a == wanted) {
+            continue;
         }
+        if wanted == "authorization" && headers_any {
+            return Err(
+                "the preflight allows `*`, and `*` does not cover `Authorization`: a \
+                 server must name that header in `Access-Control-Allow-Headers` before a \
+                 page may send it to another origin."
+                    .to_string(),
+            );
+        }
+        return Err(format!(
+            "the preflight does not allow the `{wanted}` header. The server would \
+             have to list it in `Access-Control-Allow-Headers`."
+        ));
     }
     Ok(())
 }
@@ -717,6 +734,56 @@ mod tests {
             Some("*"),
         );
         assert!(refused.is_err(), "a wildcard must not cover credentials");
+    }
+
+    /// `Access-Control-Allow-Headers: *` covers every header a page asked for
+    /// except one. Fetch carves `Authorization` out of the wildcard by name and
+    /// every browser implements the carve-out, because a server answering `*`
+    /// has said "any header", not "I agree to receive somebody's bearer token".
+    /// Without it, a page on one allowlisted origin hands another origin a
+    /// credential that origin never asked for by name.
+    #[test]
+    fn a_wildcard_preflight_does_not_cover_authorization() {
+        let asking_for = |header: &str| Preflight {
+            origin: "https://a.example".into(),
+            method: "GET".into(),
+            headers: vec![header.into()],
+            credentials: false,
+        };
+        // Any other header the wildcard does cover.
+        assert!(
+            check_preflight(
+                &asking_for("x-token"),
+                Some("*"),
+                None,
+                Some("*"),
+                Some("*")
+            )
+            .is_ok(),
+            "`*` covers an ordinary header"
+        );
+        let refused = check_preflight(
+            &asking_for("authorization"),
+            Some("*"),
+            None,
+            Some("*"),
+            Some("*"),
+        )
+        .expect_err("`*` does not cover Authorization");
+        assert!(refused.contains("does not cover"), "{refused}");
+
+        // Named explicitly, it goes through: that is the server agreeing.
+        assert!(
+            check_preflight(
+                &asking_for("authorization"),
+                Some("*"),
+                None,
+                Some("*"),
+                Some("authorization, x-token")
+            )
+            .is_ok(),
+            "a server that names it has agreed to it"
+        );
     }
 
     #[test]

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -287,13 +287,10 @@ fn parse_target(spec: &str) -> Result<Target, EditError> {
     }
 }
 
-/// Whether a header name is one a request can carry.
+/// Whether a header name is one a request can carry: RFC 9110's token.
 ///
-/// RFC 9110's token, which is what every HTTP client and server agrees a field
-/// name is. Checked here rather than left to the wire because a name with a
-/// space or a colon in it does not reach the server as a header at all: the
-/// client refuses to build the request, and the caller is told "builder error",
-/// which names neither the header nor the character.
+/// Checked here because the wire's refusal is "builder error", which names
+/// neither the header nor the character.
 fn header_name_is_sendable(name: &str) -> bool {
     !name.is_empty()
         && name.bytes().all(|b| {
@@ -306,13 +303,10 @@ fn header_name_is_sendable(name: &str) -> bool {
         })
 }
 
-/// The character in a header value that a request cannot carry, if there is one.
+/// The character in a header value a request cannot carry, if there is one.
 ///
-/// CR, LF and NUL, and nothing else: a header value is otherwise anything, and
-/// a workbench that narrowed it further would refuse payloads that are the
-/// whole point. These three end the field, and a client that let one through
-/// would be splitting the message — which is a thing worth testing and is what
-/// `--raw-request` is for, byte for byte and with the framing it broke named.
+/// CR, LF and NUL only — anything narrower would refuse the payloads this is
+/// for. Splitting a message deliberately is what `--raw-request` is for.
 fn header_value_refuses(value: &str) -> Option<char> {
     value.chars().find(|c| matches!(c, '\r' | '\n' | '\0'))
 }
@@ -382,10 +376,8 @@ fn refuse_a_resolved_traversal(
 ) -> Result<(), EditError> {
     // Whatever was named — a path or a whole URL — only its path can hold a
     // dot segment.
-    // The authority ends at the first separator, and a backslash is one of
-    // those: `https://app.test\..\..\x` has a path even though it holds no
-    // `/`, and looking only for a slash would hand back "/" and find nothing to
-    // refuse in a URL the parser resolves down to `/x`.
+    // The authority ends at the first separator, and `\` is one:
+    // `https://app.test\..\..\x` has a path despite holding no `/`.
     let asked = match asked.split_once("://") {
         Some((_, rest)) => match rest.find(['/', '\\']) {
             Some(at) => &rest[at..],
@@ -394,12 +386,9 @@ fn refuse_a_resolved_traversal(
         None => asked,
     };
     let asked_path = asked.split(['?', '#']).next().unwrap_or(asked);
-    // A backslash is a path separator too, for exactly the schemes this engine
-    // speaks: the URL standard reads `\` as `/` in a special URL, so
-    // `/cgi-bin/..\..\etc/passwd` is resolved to `/etc/passwd` before any
-    // request exists. Refused for the same reason a dot segment is, and named
-    // separately because the traversal is not the only rewrite: `/a\b` goes out
-    // as `/a/b`, which is a different request from the one that was typed.
+    // The URL standard reads `\` as `/` in an http(s) URL, so
+    // `/cgi-bin/..\..\etc/passwd` resolves to `/etc/passwd` before a request
+    // exists — and even `/a\b` goes out as `/a/b`.
     if asked_path.contains('\\') {
         return Err(EditError::new(
             target,
@@ -524,12 +513,9 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
         }
 
         Target::Query(name) => {
-            // The query is edited as the pieces it was written as, not decoded
-            // into pairs and re-encoded. Re-encoding rewrote parameters nobody
-            // named: `?debug` came back as `debug=`, and `x[]=1` as
-            // `x%5B%5D=1`. Both are a different request, and "the edits named
-            // on the command line and nothing else changed" is the whole claim
-            // this verb makes.
+            // Edited as the pieces it was written as. Decoding and re-encoding
+            // rewrote parameters nobody named: `?debug` came back as `debug=`,
+            // `x[]=1` as `x%5B%5D=1`.
             let raw = request.url.query().unwrap_or_default().to_string();
             let pieces: Vec<&str> = if raw.is_empty() {
                 Vec::new()
@@ -613,17 +599,14 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
         }
 
         Target::Cookie(name) => {
-            // A cookie is a header once it is written, so the same three
-            // characters end it. Checked before anything is rebuilt, so a
-            // refused edit leaves the request alone.
+            // A cookie is a header once written, so the same three characters
+            // end it. Checked before anything is rebuilt.
             if !removing {
                 refuse_an_unsendable_header(&target, "Cookie", &text(&value))?;
                 refuse_a_reframed_cookie(&target, name, &text(&value))?;
             }
-            // Edited as the pieces the header was written as. Parsing it into
-            // pairs dropped every piece that had no `=`, so a header carrying a
-            // bare token lost it on any edit at all: a cookie the caller never
-            // named, gone from a request they were told only changed one.
+            // As the pieces it was written as: parsing into pairs dropped
+            // every piece with no `=`, so a bare token was lost on any edit.
             let current = request.header("cookie").unwrap_or_default().to_string();
             let pieces: Vec<&str> = if current.is_empty() {
                 Vec::new()
@@ -644,8 +627,8 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
                         continue;
                     }
                     if !replaced {
-                        // The piece's own leading space, so the header reads as
-                        // it did rather than as this code would have written it.
+                        // The piece's own leading space, so the header reads
+                        // as it did.
                         let lead = &piece[..piece.len() - piece.trim_start().len()];
                         next.push(format!("{lead}{name}={}", text(&value)));
                         replaced = true;
@@ -677,11 +660,8 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
             // ordinary starting point for an API call the page never makes, and
             // refusing it sent callers to `body.raw` to hand-write the JSON that
             // this edit exists to maintain.
-            // Built here and committed at the end, rather than written into
-            // the request and then edited. Starting the body off as `{}` before
-            // the edit could fail left a refused edit having changed the
-            // request: an empty body became `{}` with a `Content-Type` beside
-            // it, under an error saying nothing had happened.
+            // Built here and committed at the end: starting the body off as
+            // `{}` left a refused edit having already changed the request.
             let building = request.body.is_empty() && create;
             let kind = request.content_type().unwrap_or("").to_string();
             let mut document: serde_json::Value = if building {
@@ -731,10 +711,8 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
         }
 
         Target::Form(name) => {
-            // Edited as the pieces the body was written as, for the reason
-            // `query.` is: re-serialising rewrote fields nobody named, and a
-            // body that differs in a field the caller did not touch is a
-            // different request under the same name.
+            // As the pieces it was written as, for the reason `query.` is:
+            // re-serialising rewrote fields nobody named.
             let pieces: Vec<&[u8]> = if request.body.is_empty() {
                 Vec::new()
             } else {
@@ -895,10 +873,8 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
     }
 }
 
-/// The decoded name of one `k=v` piece of a query string.
-///
-/// A piece with no `=` is a name with no value, which is a shape servers do
-/// read: `?debug` and `?debug=` are not the same request everywhere.
+/// The decoded name of one `k=v` piece of a query string. A piece with no `=`
+/// is a name with no value: `?debug` and `?debug=` are not the same request.
 fn query_name(piece: &str) -> String {
     let raw = piece.split_once('=').map(|(k, _)| k).unwrap_or(piece);
     decode_query(raw)
@@ -933,11 +909,9 @@ fn cookie_name_and_value(piece: &str) -> (String, String) {
 
 /// Refuse a cookie edit that would write more than one cookie.
 ///
-/// `;` separates the pairs and `=` separates a pair, so either one inside a
-/// name or a `;` inside a value makes the header carry something other than the
-/// single cookie the edit named. Refused rather than escaped, because escaping
-/// would send a value that is not the one asked for: to write the header
-/// exactly, `header.Cookie=` takes the whole thing.
+/// `;` separates pairs and `=` separates a pair, so either inside a name — or a
+/// `;` in a value — writes something other than the cookie named. Refused
+/// rather than escaped; `header.Cookie=` takes the whole header.
 fn refuse_a_reframed_cookie(
     target: &impl fmt::Display,
     name: &str,
@@ -952,10 +926,8 @@ fn refuse_a_reframed_cookie(
              whole header with `header.Cookie=` when that is the request you mean",
         ));
     }
-    // A `Cookie` header allows whitespace around each pair, and every reader
-    // strips it, so a value that begins or ends with a space is not a value a
-    // cookie can carry: the header would go out saying one thing and be read as
-    // another. Inside the value it is ordinary and stays.
+    // Every reader strips whitespace around a pair, so a value that begins or
+    // ends with one goes out saying something it is not read as. Inside, it stays.
     if value != value.trim() || name != name.trim() {
         return Err(EditError::new(
             target,
@@ -1096,9 +1068,7 @@ fn json_remove(document: &mut serde_json::Value, path: &str) -> Result<(), Strin
     }
     match at {
         serde_json::Value::Object(map) => {
-            // `shift_remove`, not `remove`: with `preserve_order` the plain one
-            // is a swap, and removing one field would move the last field to
-            // where it used to be.
+            // `shift_remove`: with `preserve_order` the plain one is a swap.
             map.shift_remove(*last);
             Ok(())
         }
@@ -1478,9 +1448,7 @@ mod tests {
         }
     }
 
-    /// The URL standard reads `\` as `/` in an http or https URL, so a
-    /// traversal spelled with backslashes resolves just as far and used to slip
-    /// past the check above: it splits on `/`, and `..\..\etc` holds none.
+    /// The check above splits on `/`, and `..\..\etc` holds none — so
     /// `path=/cgi-bin/..\..\etc/passwd` went out as `/etc/passwd`.
     #[test]
     fn a_backslash_is_a_separator_too_and_is_refused_with_it() {
@@ -1502,11 +1470,8 @@ mod tests {
         }
     }
 
-    /// A header value holding CR or LF does not reach the server as a header:
-    /// the client refuses to build the request and the caller was told
-    /// "builder error", which names neither the header nor the character.
-    /// Refused where the edit is written, and pointed at the path that can
-    /// actually send it.
+    /// A CR or LF in a header value came back as "builder error", which names
+    /// neither the header nor the character.
     #[test]
     fn a_header_that_could_not_be_sent_is_refused_by_name() {
         for spelling in [
@@ -1531,11 +1496,9 @@ mod tests {
         assert!(error.to_string().contains("not a header name"), "{error}");
     }
 
-    /// "The edits named on the command line and nothing else changed" is what
-    /// replay claims. Decoding the query into pairs and re-encoding it broke
-    /// that for every parameter the caller did not name: `?debug` went out as
-    /// `debug=` and `x[]=1` as `x%5B%5D=1`, and in a workbench the difference
-    /// between two requests is the entire measurement.
+    /// Replay claims nothing else changed. Re-encoding the query broke that
+    /// for every parameter the caller did not name: `?debug` went out as
+    /// `debug=`, `x[]=1` as `x%5B%5D=1`.
     #[test]
     fn editing_one_query_parameter_leaves_the_others_byte_for_byte() {
         let mut request = Editable {
@@ -1570,9 +1533,8 @@ mod tests {
         assert_eq!(request.url.query(), Some("debug&role=admin"));
     }
 
-    /// The same rule as the query's, for the same reason: a form body that
-    /// differs in a field the caller never named is a different request going
-    /// out under the name of the one that was recorded.
+    /// The query's rule, for the same reason: a body differing in a field the
+    /// caller never named is a different request.
     #[test]
     fn editing_one_form_field_leaves_the_others_byte_for_byte() {
         let mut request = Editable {
@@ -1592,11 +1554,8 @@ mod tests {
         );
     }
 
-    /// A `Cookie` header can carry a bare token, and parsing the header into
-    /// pairs threw every one of them away: editing any cookie deleted a cookie
-    /// the caller never named, out of a request they were told only changed
-    /// one. Which is a logout, or a feature flag turning off, arriving as part
-    /// of the measurement.
+    /// Parsing into pairs threw away every bare token, so editing one cookie
+    /// deleted another the caller never named — a logout inside a measurement.
     #[test]
     fn a_bare_cookie_survives_an_edit_to_a_different_one() {
         let mut request = Editable {
@@ -1615,8 +1574,7 @@ mod tests {
         );
     }
 
-    /// And an edit that would write two cookies where it names one is refused,
-    /// rather than escaped into a value nobody asked for.
+    /// And an edit naming one cookie but writing two is refused, not escaped.
     #[test]
     fn a_cookie_edit_that_would_write_two_is_refused() {
         let mut request = request();
@@ -1626,12 +1584,9 @@ mod tests {
         assert_eq!(request.header("cookie"), Some("session=abc; theme=dark"));
     }
 
-    /// A JSON edit rewrites the body it edits, so the order the fields come
-    /// back in is the order they go out in. `serde_json`'s default map sorts
-    /// them, so `{"user":…,"role":…,"nonce":…}` was replayed as
-    /// `{"nonce":…,"role":…,"user":…}` — a different body under the name of the
-    /// recorded one, which an API that signs its body answers 401 to. That 401
-    /// is then read as the finding.
+    /// A JSON edit rewrites the body, and `serde_json`'s default map sorts the
+    /// keys — so a signed body was replayed as a different one, and the 401
+    /// that came back read as the finding.
     #[test]
     fn a_json_edit_keeps_the_fields_in_the_order_they_were_in() {
         let mut request = Editable {
@@ -1647,8 +1602,7 @@ mod tests {
         );
     }
 
-    /// And removing one field shifts the rest along rather than swapping the
-    /// last one into its place.
+    /// And a removal shifts the rest along rather than swapping in the last.
     #[test]
     fn removing_a_json_field_leaves_the_others_in_order() {
         let mut request = Editable {
@@ -1669,11 +1623,8 @@ mod tests {
         );
     }
 
-    /// The rule every refusal in this module is written to: an edit that
-    /// errors changed nothing. A caller who reads the error and tries a
-    /// different spelling is otherwise editing a request that has already been
-    /// half-edited, and the request that eventually goes out is one nobody
-    /// composed.
+    /// The rule every refusal here is written to: an edit that errors changed
+    /// nothing, or the next attempt edits a half-edited request.
     #[test]
     fn an_edit_that_is_refused_leaves_the_request_exactly_as_it_was() {
         let targets = [
@@ -1717,10 +1668,8 @@ mod tests {
         }
     }
 
-    /// The query, form and cookie editors work on the pieces the request was
-    /// written as, which means slicing strings a target or a caller chose.
-    /// Multi-byte characters, lone separators and empty pieces are where that
-    /// goes wrong, and an edit that panics takes the whole session with it.
+    /// The editors slice strings a target or caller chose. Multi-byte
+    /// characters, lone separators and empty pieces are where that goes wrong.
     #[test]
     fn no_arrangement_of_these_edits_panics() {
         let targets = [
@@ -1765,13 +1714,8 @@ mod tests {
                                     let applied = apply(&mut request, &[edit], create);
                                     cases += 1;
                                     // An edit that succeeded put the value
-                                    // where it said it did. This is the half a
-                                    // panic hunt misses: writing the pieces
-                                    // back by hand is how an encoding bug gets
-                                    // in, and a request that quietly carries a
-                                    // different value than the one asked for is
-                                    // the failure this whole module is written
-                                    // against.
+                                    // where it said it did — the half a panic
+                                    // hunt misses.
                                     if applied.is_ok() {
                                         if let Some(name) = target.strip_prefix("query.") {
                                             assert!(
@@ -1816,9 +1760,8 @@ mod tests {
         assert!(cases > 10_000, "the sweep actually ran: {cases}");
     }
 
-    /// A `Cookie` header allows whitespace around each pair and every reader
-    /// strips it, so `cookie.s= ` went out as `s= ` and arrived as `s=`. Found
-    /// by the sweep below, which is what a round-trip property is for.
+    /// Every reader strips whitespace around a pair, so `cookie.s= ` went out
+    /// as `s= ` and arrived as `s=`. Found by the sweep below.
     #[test]
     fn a_cookie_value_the_header_cannot_carry_is_refused() {
         for spec in ["cookie.s= ", "cookie.s=  a", "cookie.s=a "] {

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -321,15 +321,35 @@ fn refuse_a_resolved_traversal(
 ) -> Result<(), EditError> {
     // Whatever was named — a path or a whole URL — only its path can hold a
     // dot segment.
+    // The authority ends at the first separator, and a backslash is one of
+    // those: `https://app.test\..\..\x` has a path even though it holds no
+    // `/`, and looking only for a slash would hand back "/" and find nothing to
+    // refuse in a URL the parser resolves down to `/x`.
     let asked = match asked.split_once("://") {
-        Some((_, rest)) => match rest.find('/') {
+        Some((_, rest)) => match rest.find(['/', '\\']) {
             Some(at) => &rest[at..],
             None => "/",
         },
         None => asked,
     };
     let asked_path = asked.split(['?', '#']).next().unwrap_or(asked);
-    if !asked_path.split('/').any(is_a_dot_segment) {
+    // A backslash is a path separator too, for exactly the schemes this engine
+    // speaks: the URL standard reads `\` as `/` in a special URL, so
+    // `/cgi-bin/..\..\etc/passwd` is resolved to `/etc/passwd` before any
+    // request exists. Refused for the same reason a dot segment is, and named
+    // separately because the traversal is not the only rewrite: `/a\b` goes out
+    // as `/a/b`, which is a different request from the one that was typed.
+    if asked_path.contains('\\') {
+        return Err(EditError::new(
+            target,
+            format!(
+                "{asked_path:?} contains a backslash, and the URL standard reads that as a \
+                 path separator in an http or https URL: this would have gone out as \
+                 {resolved:?}. Percent-encode it as %5C to send the character itself."
+            ),
+        ));
+    }
+    if !asked_path.split(['/', '\\']).any(is_a_dot_segment) {
         return Ok(());
     }
     Err(EditError::new(
@@ -1232,6 +1252,30 @@ mod tests {
                 error.to_string().contains("dot segment"),
                 "{spelling}: {error}"
             );
+            assert_eq!(
+                request.url.as_str(),
+                "https://app.test/api/users?user_id=123&page=2",
+                "a refused edit leaves the request alone"
+            );
+        }
+    }
+
+    /// The URL standard reads `\` as `/` in an http or https URL, so a
+    /// traversal spelled with backslashes resolves just as far and used to slip
+    /// past the check above: it splits on `/`, and `..\..\etc` holds none.
+    /// `path=/cgi-bin/..\..\etc/passwd` went out as `/etc/passwd`.
+    #[test]
+    fn a_backslash_is_a_separator_too_and_is_refused_with_it() {
+        for spelling in [
+            "path=/cgi-bin/..\\..\\etc/passwd",
+            "path=/a\\b",
+            "url=https://app.test/cgi-bin/..\\..\\etc/passwd",
+            "url=https://app.test\\..\\..\\x",
+        ] {
+            let mut request = request();
+            let error = apply(&mut request, &[set(spelling)], false)
+                .expect_err("a backslash the parser rewrites is refused");
+            assert!(error.to_string().contains("backslash"), "{spelling}: {error}");
             assert_eq!(
                 request.url.as_str(),
                 "https://app.test/api/users?user_id=123&page=2",

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -677,15 +677,17 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
             // ordinary starting point for an API call the page never makes, and
             // refusing it sent callers to `body.raw` to hand-write the JSON that
             // this edit exists to maintain.
-            if request.body.is_empty() && create {
-                request.body = b"{}".to_vec();
-                if request.content_type().is_none() {
-                    request.set_header("Content-Type", "application/json");
-                }
-            }
+            // Built here and committed at the end, rather than written into
+            // the request and then edited. Starting the body off as `{}` before
+            // the edit could fail left a refused edit having changed the
+            // request: an empty body became `{}` with a `Content-Type` beside
+            // it, under an error saying nothing had happened.
+            let building = request.body.is_empty() && create;
             let kind = request.content_type().unwrap_or("").to_string();
-            let mut document: serde_json::Value = serde_json::from_slice(&request.body)
-                .map_err(|e| {
+            let mut document: serde_json::Value = if building {
+                serde_json::Value::Object(serde_json::Map::new())
+            } else {
+                serde_json::from_slice(&request.body).map_err(|e| {
                     EditError::new(
                         &target,
                         format!(
@@ -694,7 +696,8 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
                             if kind.is_empty() { "unset" } else { &kind }
                         ),
                     )
-                })?;
+                })?
+            };
             let was = json_at(&document, path).map(render_json);
             if was.is_none() && !create && !removing {
                 return Err(EditError::new(
@@ -716,6 +719,9 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
             }
             request.body = serde_json::to_vec(&document)
                 .map_err(|e| EditError::new(&target, format!("could not rebuild the body: {e}")))?;
+            if building && request.content_type().is_none() {
+                request.set_header("Content-Type", "application/json");
+            }
             Ok(Applied {
                 target,
                 value: (!removing).then(|| text(&value)),
@@ -1648,6 +1654,54 @@ mod tests {
             String::from_utf8_lossy(&request.body),
             r#"{"a":1,"c":3,"d":4}"#
         );
+    }
+
+    /// The rule every refusal in this module is written to: an edit that
+    /// errors changed nothing. A caller who reads the error and tries a
+    /// different spelling is otherwise editing a request that has already been
+    /// half-edited, and the request that eventually goes out is one nobody
+    /// composed.
+    #[test]
+    fn an_edit_that_is_refused_leaves_the_request_exactly_as_it_was() {
+        let targets = [
+            "method", "url", "path", "query.a", "query.", "header.X", "header.X A",
+            "cookie.s", "cookie.s;x", "json.a", "json.a.b", "json.", "form.f",
+            "multipart.f", "multipart.f.filename", "multipart.f.content_type",
+            "body.raw", "body.other", "nonsense", "", ".", "..", "query.a.b",
+        ];
+        let values = [
+            "", "1", "..", "/a/../b", "\\\\..\\\\", "https://app.test/../x", "not a url",
+            "a\r\nb", "a; b=c", "{\"a\":1}", "%2e%2e", "@", "=", "a=b",
+        ];
+        let bodies: [&[u8]; 4] = [b"", b"{\"a\":{\"b\":1}}", b"a=1&b=2", b"\xff\xd8not text"];
+
+        for body in bodies {
+            for target in targets {
+                for value in values {
+                    for create in [false, true] {
+                        for removing in [false, true] {
+                            let mut request = request();
+                            request.body = body.to_vec();
+                            let before = request.clone();
+                            let edit = if removing {
+                                parse_unset(target)
+                            } else {
+                                parse_set(&format!("{target}={value}"))
+                            };
+                            let Ok(edit) = edit else { continue };
+                            if apply(&mut request, &[edit], create).is_err() {
+                                assert_eq!(
+                                    request, before,
+                                    "`{target}` = `{value}` (create={create}, \
+                                     removing={removing}) was refused and still \
+                                     changed the request"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -708,24 +708,47 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
         }
 
         Target::Form(name) => {
-            let mut pairs: Vec<(String, String)> =
-                form_urlencoded::parse(&request.body).into_owned().collect();
-            let was = pairs.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone());
-            if was.is_none() && !create && !removing {
-                return Err(missing(&target, "form field", &pairs));
-            }
-            if removing {
-                pairs.retain(|(k, _)| k != name);
-            } else if let Some(slot) = pairs.iter_mut().find(|(k, _)| k == name) {
-                slot.1 = text(&value);
+            // Edited as the pieces the body was written as, for the reason
+            // `query.` is: re-serialising rewrote fields nobody named, and a
+            // body that differs in a field the caller did not touch is a
+            // different request under the same name.
+            let pieces: Vec<&[u8]> = if request.body.is_empty() {
+                Vec::new()
             } else {
-                pairs.push((name.clone(), text(&value)));
+                request.body.split(|b| *b == b'&').collect()
+            };
+            let named: Vec<(String, String)> = pieces
+                .iter()
+                .map(|piece| form_name_and_value(piece))
+                .collect();
+            let was = named.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone());
+            if was.is_none() && !create && !removing {
+                return Err(missing(&target, "form field", &named));
             }
-            let mut serializer = form_urlencoded::Serializer::new(String::new());
-            for (k, v) in &pairs {
-                serializer.append_pair(k, v);
+            let encoded = format!(
+                "{}={}",
+                encode_query(name),
+                encode_query(&text(&value))
+            );
+            let mut replaced = false;
+            let mut next: Vec<Vec<u8>> = Vec::with_capacity(pieces.len() + 1);
+            for (piece, (k, _)) in pieces.iter().zip(&named) {
+                if k == name {
+                    if removing {
+                        continue;
+                    }
+                    if !replaced {
+                        next.push(encoded.clone().into_bytes());
+                        replaced = true;
+                        continue;
+                    }
+                }
+                next.push(piece.to_vec());
             }
-            request.body = serializer.finish().into_bytes();
+            if !replaced && !removing {
+                next.push(encoded.into_bytes());
+            }
+            request.body = next.join(&b'&');
             if request.content_type().is_none() {
                 request.set_header("Content-Type", "application/x-www-form-urlencoded");
             }
@@ -872,6 +895,23 @@ fn decode_query(raw: &str) -> String {
 
 fn encode_query(value: &str) -> String {
     form_urlencoded::byte_serialize(value.as_bytes()).collect()
+}
+
+/// One `k=v` piece of a form body, decoded.
+fn form_name_and_value(piece: &[u8]) -> (String, String) {
+    let at = piece.iter().position(|b| *b == b'=');
+    let (raw_name, raw_value) = match at {
+        Some(at) => (&piece[..at], &piece[at + 1..]),
+        None => (piece, &[][..]),
+    };
+    (decode_form(raw_name), decode_form(raw_value))
+}
+
+fn decode_form(raw: &[u8]) -> String {
+    form_urlencoded::parse(raw)
+        .next()
+        .map(|(k, _)| k.into_owned())
+        .unwrap_or_default()
 }
 
 /// The error for a target that is not there, carrying what is.
@@ -1454,6 +1494,28 @@ mod tests {
         apply(&mut request, &[parse_unset("query.id").expect("parses")], false)
             .expect("removes");
         assert_eq!(request.url.query(), Some("debug&role=admin"));
+    }
+
+    /// The same rule as the query's, for the same reason: a form body that
+    /// differs in a field the caller never named is a different request going
+    /// out under the name of the one that was recorded.
+    #[test]
+    fn editing_one_form_field_leaves_the_others_byte_for_byte() {
+        let mut request = Editable {
+            method: "POST".to_string(),
+            url: Url::parse("https://app.test/login").expect("a url"),
+            headers: vec![(
+                "Content-Type".to_string(),
+                "application/x-www-form-urlencoded".to_string(),
+            )],
+            body: b"remember&next=%2Fadmin&tags[]=a&user=alice".to_vec(),
+        };
+        let applied = apply(&mut request, &[set("form.user=admin")], false).expect("applies");
+        assert_eq!(applied[0].was.as_deref(), Some("alice"));
+        assert_eq!(
+            String::from_utf8_lossy(&request.body),
+            "remember&next=%2Fadmin&tags[]=a&user=admin"
+        );
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -952,6 +952,19 @@ fn refuse_a_reframed_cookie(
              whole header with `header.Cookie=` when that is the request you mean",
         ));
     }
+    // A `Cookie` header allows whitespace around each pair, and every reader
+    // strips it, so a value that begins or ends with a space is not a value a
+    // cookie can carry: the header would go out saying one thing and be read as
+    // another. Inside the value it is ordinary and stays.
+    if value != value.trim() || name != name.trim() {
+        return Err(EditError::new(
+            target,
+            "a `Cookie` header allows whitespace around each pair and every reader strips \
+             it, so a name or value that begins or ends with a space would not arrive as \
+             the one asked for. Set the whole header with `header.Cookie=` to send those \
+             bytes exactly",
+        ));
+    }
     Ok(())
 }
 
@@ -1702,6 +1715,123 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// The query, form and cookie editors work on the pieces the request was
+    /// written as, which means slicing strings a target or a caller chose.
+    /// Multi-byte characters, lone separators and empty pieces are where that
+    /// goes wrong, and an edit that panics takes the whole session with it.
+    #[test]
+    fn no_arrangement_of_these_edits_panics() {
+        let targets = [
+            "query.a", "query.é", "query.", "form.f", "form.é", "cookie.s", "cookie.é",
+            "json.a", "body.raw", "header.X", "method", "path", "url",
+        ];
+        let values = [
+            "", "=", "&", ";", " ", "é", "🙂", "a=b&c", "a; b", "\u{a0}x", "%", "%zz",
+            "\u{feff}", "..", "/a/../b",
+        ];
+        // Bodies and URLs built out of the same sharp pieces.
+        let queries = ["", "?a", "?a=1", "?é=1&a", "?=1", "?&&", "?a=%", "?🙂=1"];
+        let bodies: [&[u8]; 6] = [
+            b"",
+            b"a=1&b",
+            b"=1",
+            b"&&",
+            "é=1&🙂=2".as_bytes(),
+            b"\xff\xfe not text",
+        ];
+        let cookies = ["", "s=1", " s = 1 ; t", ";;", "é=1", "s"];
+
+        let mut cases = 0usize;
+        for query in queries {
+            for body in bodies {
+                for cookie in cookies {
+                    for target in targets {
+                        for value in values {
+                            for create in [false, true] {
+                                let mut request = Editable {
+                                    method: "POST".to_string(),
+                                    url: Url::parse(&format!("https://app.test/p{query}"))
+                                        .expect("a url"),
+                                    headers: vec![(
+                                        "Cookie".to_string(),
+                                        cookie.to_string(),
+                                    )],
+                                    body: body.to_vec(),
+                                };
+                                let spec = format!("{target}={value}");
+                                if let Ok(edit) = parse_set(&spec) {
+                                    let applied = apply(&mut request, &[edit], create);
+                                    cases += 1;
+                                    // An edit that succeeded put the value
+                                    // where it said it did. This is the half a
+                                    // panic hunt misses: writing the pieces
+                                    // back by hand is how an encoding bug gets
+                                    // in, and a request that quietly carries a
+                                    // different value than the one asked for is
+                                    // the failure this whole module is written
+                                    // against.
+                                    if applied.is_ok() {
+                                        if let Some(name) = target.strip_prefix("query.") {
+                                            assert!(
+                                                request
+                                                    .url
+                                                    .query_pairs()
+                                                    .any(|(k, v)| k == name && v == value),
+                                                "`{spec}` did not read back: {:?}",
+                                                request.url.query()
+                                            );
+                                        }
+                                        if let Some(name) = target.strip_prefix("form.") {
+                                            assert!(
+                                                form_urlencoded::parse(&request.body)
+                                                    .any(|(k, v)| k == name && v == value),
+                                                "`{spec}` did not read back: {:?}",
+                                                String::from_utf8_lossy(&request.body)
+                                            );
+                                        }
+                                        if let Some(name) = target.strip_prefix("cookie.") {
+                                            let header =
+                                                request.header("cookie").unwrap_or_default();
+                                            assert!(
+                                                header.split(';').any(|piece| {
+                                                    cookie_name_and_value(piece)
+                                                        == (name.to_string(), value.to_string())
+                                                }),
+                                                "`{spec}` did not read back: {header:?}"
+                                            );
+                                        }
+                                    }
+                                }
+                                if let Ok(edit) = parse_unset(target) {
+                                    let _ = apply(&mut request, &[edit], create);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert!(cases > 10_000, "the sweep actually ran: {cases}");
+    }
+
+    /// A `Cookie` header allows whitespace around each pair and every reader
+    /// strips it, so `cookie.s= ` went out as `s= ` and arrived as `s=`. Found
+    /// by the sweep below, which is what a round-trip property is for.
+    #[test]
+    fn a_cookie_value_the_header_cannot_carry_is_refused() {
+        for spec in ["cookie.s= ", "cookie.s=  a", "cookie.s=a "] {
+            let mut request = request();
+            let error = apply(&mut request, &[set(spec)], true)
+                .expect_err("a value the header cannot carry is refused");
+            assert!(error.to_string().contains("header.Cookie="), "{spec}: {error}");
+            assert_eq!(request.header("cookie"), Some("session=abc; theme=dark"));
+        }
+        // Whitespace inside the value is ordinary and survives.
+        let mut request = request();
+        apply(&mut request, &[set("cookie.theme=a b")], false).expect("applies");
+        assert_eq!(request.header("cookie"), Some("session=abc; theme=a b"));
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -1077,7 +1077,10 @@ fn json_remove(document: &mut serde_json::Value, path: &str) -> Result<(), Strin
     }
     match at {
         serde_json::Value::Object(map) => {
-            map.remove(*last);
+            // `shift_remove`, not `remove`: with `preserve_order` the plain one
+            // is a swap, and removing one field would move the last field to
+            // where it used to be.
+            map.shift_remove(*last);
             Ok(())
         }
         serde_json::Value::Array(items) => {
@@ -1602,6 +1605,49 @@ mod tests {
             .expect_err("a `;` in a cookie value writes a second cookie");
         assert!(error.to_string().contains("header.Cookie="), "{error}");
         assert_eq!(request.header("cookie"), Some("session=abc; theme=dark"));
+    }
+
+    /// A JSON edit rewrites the body it edits, so the order the fields come
+    /// back in is the order they go out in. `serde_json`'s default map sorts
+    /// them, so `{"user":…,"role":…,"nonce":…}` was replayed as
+    /// `{"nonce":…,"role":…,"user":…}` — a different body under the name of the
+    /// recorded one, which an API that signs its body answers 401 to. That 401
+    /// is then read as the finding.
+    #[test]
+    fn a_json_edit_keeps_the_fields_in_the_order_they_were_in() {
+        let mut request = Editable {
+            method: "POST".to_string(),
+            url: Url::parse("https://app.test/api").expect("a url"),
+            headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+            body: br#"{"user":"alice","role":"user","nonce":"z9"}"#.to_vec(),
+        };
+        apply(&mut request, &[set("json.role=\"admin\"")], false).expect("applies");
+        assert_eq!(
+            String::from_utf8_lossy(&request.body),
+            r#"{"user":"alice","role":"admin","nonce":"z9"}"#
+        );
+    }
+
+    /// And removing one field shifts the rest along rather than swapping the
+    /// last one into its place.
+    #[test]
+    fn removing_a_json_field_leaves_the_others_in_order() {
+        let mut request = Editable {
+            method: "POST".to_string(),
+            url: Url::parse("https://app.test/api").expect("a url"),
+            headers: vec![("Content-Type".to_string(), "application/json".to_string())],
+            body: br#"{"a":1,"b":2,"c":3,"d":4}"#.to_vec(),
+        };
+        apply(
+            &mut request,
+            &[parse_unset("json.b").expect("parses")],
+            false,
+        )
+        .expect("removes");
+        assert_eq!(
+            String::from_utf8_lossy(&request.body),
+            r#"{"a":1,"c":3,"d":4}"#
+        );
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -614,37 +614,54 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
 
         Target::Cookie(name) => {
             // A cookie is a header once it is written, so the same three
-            // characters end it. Checked before the pair list is rebuilt, so a
-            // refused edit leaves the jar's own header alone.
+            // characters end it. Checked before anything is rebuilt, so a
+            // refused edit leaves the request alone.
             if !removing {
                 refuse_an_unsendable_header(&target, "Cookie", &text(&value))?;
+                refuse_a_reframed_cookie(&target, name, &text(&value))?;
             }
+            // Edited as the pieces the header was written as. Parsing it into
+            // pairs dropped every piece that had no `=`, so a header carrying a
+            // bare token lost it on any edit at all: a cookie the caller never
+            // named, gone from a request they were told only changed one.
             let current = request.header("cookie").unwrap_or_default().to_string();
-            let mut pairs: Vec<(String, String)> = current
-                .split(';')
-                .filter_map(|pair| pair.split_once('='))
-                .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
-                .collect();
-            let was = pairs.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone());
-            if was.is_none() && !create && !removing {
-                return Err(missing(&target, "cookie", &pairs));
-            }
-            if removing {
-                pairs.retain(|(k, _)| k != name);
-            } else if let Some(slot) = pairs.iter_mut().find(|(k, _)| k == name) {
-                slot.1 = text(&value);
+            let pieces: Vec<&str> = if current.is_empty() {
+                Vec::new()
             } else {
-                pairs.push((name.clone(), text(&value)));
+                current.split(';').collect()
+            };
+            let named: Vec<(String, String)> =
+                pieces.iter().map(|piece| cookie_name_and_value(piece)).collect();
+            let was = named.iter().find(|(k, _)| k == name).map(|(_, v)| v.clone());
+            if was.is_none() && !create && !removing {
+                return Err(missing(&target, "cookie", &named));
             }
-            if pairs.is_empty() {
+            let mut replaced = false;
+            let mut next: Vec<String> = Vec::with_capacity(pieces.len() + 1);
+            for (piece, (k, _)) in pieces.iter().zip(&named) {
+                if k == name {
+                    if removing {
+                        continue;
+                    }
+                    if !replaced {
+                        // The piece's own leading space, so the header reads as
+                        // it did rather than as this code would have written it.
+                        let lead = &piece[..piece.len() - piece.trim_start().len()];
+                        next.push(format!("{lead}{name}={}", text(&value)));
+                        replaced = true;
+                        continue;
+                    }
+                }
+                next.push((*piece).to_string());
+            }
+            if !replaced && !removing {
+                let lead = if next.is_empty() { "" } else { " " };
+                next.push(format!("{lead}{name}={}", text(&value)));
+            }
+            if next.is_empty() {
                 request.remove_header("cookie");
             } else {
-                let joined = pairs
-                    .iter()
-                    .map(|(k, v)| format!("{k}={v}"))
-                    .collect::<Vec<_>>()
-                    .join("; ");
-                request.set_header("Cookie", &joined);
+                request.set_header("Cookie", &next.join(";"));
             }
             Ok(Applied {
                 target,
@@ -895,6 +912,41 @@ fn decode_query(raw: &str) -> String {
 
 fn encode_query(value: &str) -> String {
     form_urlencoded::byte_serialize(value.as_bytes()).collect()
+}
+
+/// One piece of a `Cookie` header, as name and value.
+///
+/// A piece with no `=` is a bare token, which servers do read and which this
+/// therefore has to keep: it is a cookie with an empty value, not an absence.
+fn cookie_name_and_value(piece: &str) -> (String, String) {
+    match piece.split_once('=') {
+        Some((name, value)) => (name.trim().to_string(), value.trim().to_string()),
+        None => (piece.trim().to_string(), String::new()),
+    }
+}
+
+/// Refuse a cookie edit that would write more than one cookie.
+///
+/// `;` separates the pairs and `=` separates a pair, so either one inside a
+/// name or a `;` inside a value makes the header carry something other than the
+/// single cookie the edit named. Refused rather than escaped, because escaping
+/// would send a value that is not the one asked for: to write the header
+/// exactly, `header.Cookie=` takes the whole thing.
+fn refuse_a_reframed_cookie(
+    target: &impl fmt::Display,
+    name: &str,
+    value: &str,
+) -> Result<(), EditError> {
+    let bad_name = name.contains(';') || name.contains('=');
+    if bad_name || value.contains(';') {
+        return Err(EditError::new(
+            target,
+            "`;` separates one cookie from the next and `=` separates a name from its \
+             value, so this edit would write more than the one cookie it names. Set the \
+             whole header with `header.Cookie=` when that is the request you mean",
+        ));
+    }
+    Ok(())
 }
 
 /// One `k=v` piece of a form body, decoded.
@@ -1516,6 +1568,40 @@ mod tests {
             String::from_utf8_lossy(&request.body),
             "remember&next=%2Fadmin&tags[]=a&user=admin"
         );
+    }
+
+    /// A `Cookie` header can carry a bare token, and parsing the header into
+    /// pairs threw every one of them away: editing any cookie deleted a cookie
+    /// the caller never named, out of a request they were told only changed
+    /// one. Which is a logout, or a feature flag turning off, arriving as part
+    /// of the measurement.
+    #[test]
+    fn a_bare_cookie_survives_an_edit_to_a_different_one() {
+        let mut request = Editable {
+            method: "GET".to_string(),
+            url: Url::parse("https://app.test/a").expect("a url"),
+            headers: vec![(
+                "Cookie".to_string(),
+                "session=abc; beta; theme=dark".to_string(),
+            )],
+            body: Vec::new(),
+        };
+        apply(&mut request, &[set("cookie.theme=light")], false).expect("applies");
+        assert_eq!(
+            request.header("cookie"),
+            Some("session=abc; beta; theme=light")
+        );
+    }
+
+    /// And an edit that would write two cookies where it names one is refused,
+    /// rather than escaped into a value nobody asked for.
+    #[test]
+    fn a_cookie_edit_that_would_write_two_is_refused() {
+        let mut request = request();
+        let error = apply(&mut request, &[set("cookie.session=a; admin=1")], false)
+            .expect_err("a `;` in a cookie value writes a second cookie");
+        assert!(error.to_string().contains("header.Cookie="), "{error}");
+        assert_eq!(request.header("cookie"), Some("session=abc; theme=dark"));
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -524,22 +524,33 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
         }
 
         Target::Query(name) => {
-            let pairs: Vec<(String, String)> = request
-                .url
-                .query_pairs()
-                .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            // The query is edited as the pieces it was written as, not decoded
+            // into pairs and re-encoded. Re-encoding rewrote parameters nobody
+            // named: `?debug` came back as `debug=`, and `x[]=1` as
+            // `x%5B%5D=1`. Both are a different request, and "the edits named
+            // on the command line and nothing else changed" is the whole claim
+            // this verb makes.
+            let raw = request.url.query().unwrap_or_default().to_string();
+            let pieces: Vec<&str> = if raw.is_empty() {
+                Vec::new()
+            } else {
+                raw.split('&').collect()
+            };
+            let named: Vec<(String, String)> = pieces
+                .iter()
+                .map(|piece| (query_name(piece), query_value(piece)))
                 .collect();
-            let was = pairs
+            let was = named
                 .iter()
                 .find(|(k, _)| k == name)
                 .map(|(_, v)| v.clone());
             if was.is_none() && !create && !removing {
-                return Err(missing(&target, "query parameter", &pairs));
+                return Err(missing(&target, "query parameter", &named));
             }
             let mut replaced = false;
-            let mut next: Vec<(String, String)> = Vec::with_capacity(pairs.len() + 1);
-            for (k, v) in pairs {
-                if &k == name {
+            let mut next: Vec<String> = Vec::with_capacity(pieces.len() + 1);
+            for (piece, (k, _)) in pieces.iter().zip(&named) {
+                if k == name {
                     if removing {
                         continue;
                     }
@@ -547,24 +558,24 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
                     // list, and collapsing it would change the request in a way
                     // nobody asked for.
                     if !replaced {
-                        next.push((k, text(&value)));
+                        next.push(format!("{}={}", encode_query(k), encode_query(&text(&value))));
                         replaced = true;
                         continue;
                     }
                 }
-                next.push((k, v));
+                next.push((*piece).to_string());
             }
             if !replaced && !removing {
-                next.push((name.clone(), text(&value)));
+                next.push(format!(
+                    "{}={}",
+                    encode_query(name),
+                    encode_query(&text(&value))
+                ));
             }
             if next.is_empty() {
                 request.url.set_query(None);
             } else {
-                let mut serializer = form_urlencoded::Serializer::new(String::new());
-                for (k, v) in &next {
-                    serializer.append_pair(k, v);
-                }
-                request.url.set_query(Some(&serializer.finish()));
+                request.url.set_query(Some(&next.join("&")));
             }
             Ok(Applied {
                 target,
@@ -836,6 +847,31 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
             })
         }
     }
+}
+
+/// The decoded name of one `k=v` piece of a query string.
+///
+/// A piece with no `=` is a name with no value, which is a shape servers do
+/// read: `?debug` and `?debug=` are not the same request everywhere.
+fn query_name(piece: &str) -> String {
+    let raw = piece.split_once('=').map(|(k, _)| k).unwrap_or(piece);
+    decode_query(raw)
+}
+
+/// The decoded value of one piece, empty when it has none.
+fn query_value(piece: &str) -> String {
+    piece.split_once('=').map(|(_, v)| decode_query(v)).unwrap_or_default()
+}
+
+fn decode_query(raw: &str) -> String {
+    form_urlencoded::parse(raw.as_bytes())
+        .next()
+        .map(|(k, _)| k.into_owned())
+        .unwrap_or_default()
+}
+
+fn encode_query(value: &str) -> String {
+    form_urlencoded::byte_serialize(value.as_bytes()).collect()
 }
 
 /// The error for a target that is not there, carrying what is.
@@ -1379,6 +1415,45 @@ mod tests {
         let error = apply(&mut request, &[set("header.X A=1")], true)
             .expect_err("a name with a space in it is not a header name");
         assert!(error.to_string().contains("not a header name"), "{error}");
+    }
+
+    /// "The edits named on the command line and nothing else changed" is what
+    /// replay claims. Decoding the query into pairs and re-encoding it broke
+    /// that for every parameter the caller did not name: `?debug` went out as
+    /// `debug=` and `x[]=1` as `x%5B%5D=1`, and in a workbench the difference
+    /// between two requests is the entire measurement.
+    #[test]
+    fn editing_one_query_parameter_leaves_the_others_byte_for_byte() {
+        let mut request = Editable {
+            method: "GET".to_string(),
+            url: Url::parse("https://app.test/a?debug&next=%2Fadmin&q=a+b&x[]=1&keep=A")
+                .expect("a url"),
+            headers: Vec::new(),
+            body: Vec::new(),
+        };
+        let applied = apply(&mut request, &[set("query.keep=B")], false).expect("applies");
+        assert_eq!(applied[0].was.as_deref(), Some("A"));
+        assert_eq!(
+            request.url.query(),
+            Some("debug&next=%2Fadmin&q=a+b&x[]=1&keep=B")
+        );
+    }
+
+    /// A parameter that is not there is still added, and a removal still takes
+    /// every copy.
+    #[test]
+    fn a_query_parameter_is_added_and_removed_without_touching_the_rest() {
+        let mut request = Editable {
+            method: "GET".to_string(),
+            url: Url::parse("https://app.test/a?debug&id=1&id=2").expect("a url"),
+            headers: Vec::new(),
+            body: Vec::new(),
+        };
+        apply(&mut request, &[set("query.role=admin")], true).expect("adds");
+        assert_eq!(request.url.query(), Some("debug&id=1&id=2&role=admin"));
+        apply(&mut request, &[parse_unset("query.id").expect("parses")], false)
+            .expect("removes");
+        assert_eq!(request.url.query(), Some("debug&role=admin"));
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/edits.rs
+++ b/crates/h5i-browser/src/edits.rs
@@ -287,6 +287,67 @@ fn parse_target(spec: &str) -> Result<Target, EditError> {
     }
 }
 
+/// Whether a header name is one a request can carry.
+///
+/// RFC 9110's token, which is what every HTTP client and server agrees a field
+/// name is. Checked here rather than left to the wire because a name with a
+/// space or a colon in it does not reach the server as a header at all: the
+/// client refuses to build the request, and the caller is told "builder error",
+/// which names neither the header nor the character.
+fn header_name_is_sendable(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'.'
+                        | b'^' | b'_' | b'`' | b'|' | b'~'
+                )
+        })
+}
+
+/// The character in a header value that a request cannot carry, if there is one.
+///
+/// CR, LF and NUL, and nothing else: a header value is otherwise anything, and
+/// a workbench that narrowed it further would refuse payloads that are the
+/// whole point. These three end the field, and a client that let one through
+/// would be splitting the message — which is a thing worth testing and is what
+/// `--raw-request` is for, byte for byte and with the framing it broke named.
+fn header_value_refuses(value: &str) -> Option<char> {
+    value.chars().find(|c| matches!(c, '\r' | '\n' | '\0'))
+}
+
+/// The refusal both header edits share.
+fn refuse_an_unsendable_header(
+    target: &impl fmt::Display,
+    name: &str,
+    value: &str,
+) -> Result<(), EditError> {
+    if !header_name_is_sendable(name) {
+        return Err(EditError::new(
+            target,
+            format!(
+                "{name:?} is not a header name: a field name is a token, so it holds no \
+                 space, colon or control character. A request whose framing is deliberately \
+                 wrong goes out with `--raw-request`, which writes the bytes given and \
+                 reports what it broke"
+            ),
+        ));
+    }
+    if let Some(bad) = header_value_refuses(value) {
+        return Err(EditError::new(
+            target,
+            format!(
+                "this value contains {bad:?}, which ends a header field rather than sitting \
+                 in one: the request would not be the one it looks like. To send a message \
+                 whose framing is deliberately wrong, use `--raw-request`, which writes the \
+                 bytes given and reports which invariants it had to break"
+            ),
+        ));
+    }
+    Ok(())
+}
+
 /// Is this path segment a dot segment, in any of the spellings a URL parser
 /// treats as one?
 ///
@@ -530,6 +591,7 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
                     created: false,
                 });
             }
+            refuse_an_unsendable_header(&target, name, &text(&value))?;
             let was = request.set_header(name, &text(&value));
             Ok(Applied {
                 target,
@@ -540,6 +602,12 @@ fn apply_one(request: &mut Editable, edit: &Edit, create: bool) -> Result<Applie
         }
 
         Target::Cookie(name) => {
+            // A cookie is a header once it is written, so the same three
+            // characters end it. Checked before the pair list is rebuilt, so a
+            // refused edit leaves the jar's own header alone.
+            if !removing {
+                refuse_an_unsendable_header(&target, "Cookie", &text(&value))?;
+            }
             let current = request.header("cookie").unwrap_or_default().to_string();
             let mut pairs: Vec<(String, String)> = current
                 .split(';')
@@ -1282,6 +1350,35 @@ mod tests {
                 "a refused edit leaves the request alone"
             );
         }
+    }
+
+    /// A header value holding CR or LF does not reach the server as a header:
+    /// the client refuses to build the request and the caller was told
+    /// "builder error", which names neither the header nor the character.
+    /// Refused where the edit is written, and pointed at the path that can
+    /// actually send it.
+    #[test]
+    fn a_header_that_could_not_be_sent_is_refused_by_name() {
+        for spelling in [
+            "header.X-A=one\r\nX-Injected: yes",
+            "header.X-A=one\nX-Injected: yes",
+            "cookie.sid=a\r\nX-Injected: yes",
+        ] {
+            let mut request = request();
+            let error = apply(&mut request, &[set(spelling)], true)
+                .expect_err("a header that cannot be sent is refused");
+            assert!(error.to_string().contains("--raw-request"), "{spelling}: {error}");
+            assert_eq!(
+                request.header("cookie"),
+                Some("session=abc; theme=dark"),
+                "a refused edit leaves the request alone"
+            );
+        }
+        // A name that is not a token goes the same way, and says which.
+        let mut request = request();
+        let error = apply(&mut request, &[set("header.X A=1")], true)
+            .expect_err("a name with a space in it is not a header name");
+        assert!(error.to_string().contains("not a header name"), "{error}");
     }
 
     /// And an ordinary path still goes through, dots in a filename included.

--- a/crates/h5i-browser/src/ipc.rs
+++ b/crates/h5i-browser/src/ipc.rs
@@ -1554,12 +1554,9 @@ mod tests {
         assert_eq!(client.log_summary().denied, 1);
     }
 
-    /// A request and its response are two rows sharing one sequence number, and
-    /// the request half is written before the wire. Handing back the highest
-    /// number seen meant an agent that polled while a fetch was in flight took
-    /// that number as its cursor, asked for `seq >` it next time, and never
-    /// received the response half — so the status, the size and the error of
-    /// that request were lost to it permanently.
+    /// A request and its response share a sequence number, and the request row
+    /// is written before the wire — so a poll during a fetch took that number
+    /// as its cursor and never saw the response half.
     #[test]
     fn the_cursor_never_moves_past_a_request_still_waiting_for_its_answer() {
         use crate::receipt::Sink as _;

--- a/crates/h5i-browser/src/ipc.rs
+++ b/crates/h5i-browser/src/ipc.rs
@@ -518,6 +518,7 @@ impl Broker for BrokerClient {
                 total: 0,
                 denied: 0,
                 highest: None,
+                cursor: None,
             },
         }
     }
@@ -1551,6 +1552,45 @@ mod tests {
         let url = Url::parse("https://denied.test/").expect("url");
         client.send(&Fetch::get(&url, Initiator::Navigation));
         assert_eq!(client.log_summary().denied, 1);
+    }
+
+    /// A request and its response are two rows sharing one sequence number, and
+    /// the request half is written before the wire. Handing back the highest
+    /// number seen meant an agent that polled while a fetch was in flight took
+    /// that number as its cursor, asked for `seq >` it next time, and never
+    /// received the response half — so the status, the size and the error of
+    /// that request were lost to it permanently.
+    #[test]
+    fn the_cursor_never_moves_past_a_request_still_waiting_for_its_answer() {
+        use crate::receipt::Sink as _;
+        let (client, broker, _served) = paired();
+        let row = |seq: u64| {
+            RequestRecord::request(seq, Initiator::Navigation, "GET", "https://docs.test/")
+        };
+        // Three finished pairs, then one request whose answer has not landed.
+        for seq in 0..3u64 {
+            broker.log().append(&row(seq)).expect("appended");
+            broker.log().append(&row(seq).response()).expect("appended");
+        }
+        broker.log().append(&row(3)).expect("appended");
+
+        let summary = client.log_summary();
+        assert_eq!(summary.highest, Some(3), "the log has seen 3");
+        assert_eq!(
+            summary.cursor,
+            Some(2),
+            "but a reader may only be told it is caught up to 2"
+        );
+
+        // Which is exactly what makes the answer reachable when it lands.
+        broker.log().append(&row(3).response()).expect("appended");
+        let tail = client.records_since(summary.cursor);
+        assert!(
+            tail.iter()
+                .any(|r| r.seq == 3 && r.phase == crate::receipt::Phase::Response),
+            "the response has to be in the next window: {tail:?}"
+        );
+        assert_eq!(client.log_summary().cursor, Some(3), "and now it is past");
     }
 
     #[test]

--- a/crates/h5i-browser/src/multipart.rs
+++ b/crates/h5i-browser/src/multipart.rs
@@ -108,11 +108,9 @@ pub fn parse(body: &[u8], boundary: &str) -> Option<Vec<Part>> {
         // The CRLF before the next boundary belongs to the framing, not to the
         // data. Dropping it is what makes a round trip byte-identical.
         //
-        // Only when there is data for it to sit behind. A body whose boundary
-        // follows its header terminator with nothing between them is malformed,
-        // and a page can post one: the line break being stepped over is then
-        // the terminator's own, `end` lands two bytes before the data starts,
-        // and the slice below runs backwards and panics.
+        // Only when there is data for it to sit behind. A boundary following
+        // the header terminator directly makes `end` land before the data
+        // starts, and the slice below then runs backwards.
         let data_at = headers_end + gap;
         let mut end = next;
         if end > data_at + 1 && body[..end].ends_with(b"\r\n") {
@@ -147,15 +145,9 @@ pub fn parse(body: &[u8], boundary: &str) -> Option<Vec<Part>> {
 
 /// One `Content-Disposition` parameter, quoted or bare.
 ///
-/// Both spellings, because both arrive. A browser quotes; a page building its
-/// own body through `fetch` writes whatever its author typed, and servers read
-/// either. Reading only `name="x"` gave a bare `name=x` an empty name, and the
-/// rebuild then wrote `name=""` over it — so editing one field of an upload
-/// renamed every other field in the request to nothing.
-///
-/// The parameter is matched at a boundary (start of the header, or after a
-/// `;`), so `filename=` is not found inside `x-filename=` and `name=` is not
-/// found inside `filename=`.
+/// Both spellings arrive, and reading only `name="x"` gave a bare `name=x` an
+/// empty name — which the rebuild then wrote back as `name=""`. Matched at a
+/// parameter boundary, so `name=` is not found inside `filename=`.
 fn parameter(header: &str, key: &str) -> Option<String> {
     let mut rest = header;
     loop {
@@ -230,20 +222,16 @@ mod tests {
         body
     }
 
-    /// Every body this parser sees is a body somebody else wrote: a page's own
-    /// `fetch` put it in the store, and an edit takes it apart again. It may
-    /// answer `None`, it may answer with odd parts; it may not die.
+    /// Every body here was written by somebody else. It may answer `None` or
+    /// with odd parts; it may not die.
     #[test]
     fn no_arrangement_of_these_bytes_makes_the_parser_panic() {
-        // A small alphabet of exactly the bytes the framing is made of, which
-        // is where the sharp edges are: boundaries, terminators, half of a
-        // CRLF, a header colon.
+        // Exactly the bytes the framing is made of, where the edges are.
         let alphabet: &[&[u8]] = &[
             b"------abc", b"--", b"\r\n", b"\n", b"\r", b"a", b":", b" ",
             b"Content-Disposition: form-data; name=\"a\"", b"filename=\"f\"", b"",
         ];
-        // A cheap deterministic generator: every arrangement of six pieces
-        // would be 11^6, so walk a fixed stride through that space instead.
+        // A fixed stride through the space, rather than all 11^6 of it.
         let mut seed: u64 = 0x243f_6a88_85a3_08d3;
         for _ in 0..200_000 {
             let mut body = Vec::new();
@@ -258,11 +246,9 @@ mod tests {
         }
     }
 
-    /// A part whose boundary follows the header terminator with nothing
-    /// between them is malformed, and a page can post one through `fetch`. The
-    /// CRLF the parser stepped over was then the terminator's own, so the data
-    /// slice ran backwards and the process died on the next edit of that
-    /// stored request.
+    /// A page can post a part whose boundary follows the header terminator
+    /// directly. The CRLF stepped over was then the terminator's own, so the
+    /// data slice ran backwards.
     #[test]
     fn a_part_with_no_data_at_all_is_parsed_rather_than_panicked_on() {
         let mut body = Vec::new();
@@ -287,11 +273,8 @@ mod tests {
         assert!(parts[0].data.is_empty());
     }
 
-    /// `Content-Disposition` parameters may be quoted or bare, and a page that
-    /// builds its own multipart body through `fetch` writes whichever it likes.
-    /// Reading only the quoted form gave the part an empty name, and rebuilding
-    /// then wrote `name=""` — so an edit to one field silently renamed every
-    /// other field in the request to nothing.
+    /// Reading only the quoted form gave the part an empty name, and the
+    /// rebuild wrote `name=""` — so editing one field renamed all the others.
     #[test]
     fn an_unquoted_disposition_parameter_is_read_like_a_quoted_one() {
         let mut body = Vec::new();
@@ -313,9 +296,8 @@ mod tests {
         assert_eq!(round, parts);
     }
 
-    /// `name=` occurs inside `filename=`, and a plain substring search found it
-    /// there: a part that wrote its filename first came back with the
-    /// filename as its field name. Parameter order is the sender's choice.
+    /// `name=` occurs inside `filename=`, so a part that wrote its filename
+    /// first came back with the filename as its field name.
     #[test]
     fn a_filename_written_first_is_not_read_as_the_field_name() {
         let mut body = Vec::new();

--- a/crates/h5i-browser/src/multipart.rs
+++ b/crates/h5i-browser/src/multipart.rs
@@ -115,9 +115,9 @@ pub fn parse(body: &[u8], boundary: &str) -> Option<Vec<Part>> {
         // and the slice below runs backwards and panics.
         let data_at = headers_end + gap;
         let mut end = next;
-        if end >= data_at + 2 && body[..end].ends_with(b"\r\n") {
+        if end > data_at + 1 && body[..end].ends_with(b"\r\n") {
             end -= 2;
-        } else if end >= data_at + 1 && body[..end].ends_with(b"\n") {
+        } else if end > data_at && body[..end].ends_with(b"\n") {
             end -= 1;
         }
 

--- a/crates/h5i-browser/src/multipart.rs
+++ b/crates/h5i-browser/src/multipart.rs
@@ -107,15 +107,22 @@ pub fn parse(body: &[u8], boundary: &str) -> Option<Vec<Part>> {
         let next = find(body, sep, headers_end + gap)?;
         // The CRLF before the next boundary belongs to the framing, not to the
         // data. Dropping it is what makes a round trip byte-identical.
+        //
+        // Only when there is data for it to sit behind. A body whose boundary
+        // follows its header terminator with nothing between them is malformed,
+        // and a page can post one: the line break being stepped over is then
+        // the terminator's own, `end` lands two bytes before the data starts,
+        // and the slice below runs backwards and panics.
+        let data_at = headers_end + gap;
         let mut end = next;
-        if body[..end].ends_with(b"\r\n") {
+        if end >= data_at + 2 && body[..end].ends_with(b"\r\n") {
             end -= 2;
-        } else if body[..end].ends_with(b"\n") {
+        } else if end >= data_at + 1 && body[..end].ends_with(b"\n") {
             end -= 1;
         }
 
         let mut part = Part {
-            data: body[headers_end + gap..end].to_vec(),
+            data: body[data_at..end].to_vec(),
             ..Default::default()
         };
         for line in head.lines().filter(|l| !l.trim().is_empty()) {
@@ -199,6 +206,35 @@ mod tests {
         body.extend_from_slice(b"\x89PNG\r\n\x1a\n binary");
         body.extend_from_slice(b"\r\n------abc--\r\n");
         body
+    }
+
+    /// A part whose boundary follows the header terminator with nothing
+    /// between them is malformed, and a page can post one through `fetch`. The
+    /// CRLF the parser stepped over was then the terminator's own, so the data
+    /// slice ran backwards and the process died on the next edit of that
+    /// stored request.
+    #[test]
+    fn a_part_with_no_data_at_all_is_parsed_rather_than_panicked_on() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"------abc\r\n");
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"a\"\r\n\r\n");
+        body.extend_from_slice(b"------abc--\r\n");
+        let parts = parse(&body, "----abc").expect("parses");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].name, "a");
+        assert!(parts[0].data.is_empty(), "{:?}", parts[0].data);
+    }
+
+    /// The well-formed spelling of the same thing keeps working.
+    #[test]
+    fn an_empty_part_written_properly_is_still_empty() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"------abc\r\n");
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"a\"\r\n\r\n");
+        body.extend_from_slice(b"\r\n------abc--\r\n");
+        let parts = parse(&body, "----abc").expect("parses");
+        assert_eq!(parts.len(), 1);
+        assert!(parts[0].data.is_empty());
     }
 
     #[test]

--- a/crates/h5i-browser/src/multipart.rs
+++ b/crates/h5i-browser/src/multipart.rs
@@ -131,8 +131,8 @@ pub fn parse(body: &[u8], boundary: &str) -> Option<Vec<Part>> {
             };
             let (name, value) = (name.trim(), value.trim());
             if name.eq_ignore_ascii_case("content-disposition") {
-                part.name = quoted(value, "name").unwrap_or_default();
-                part.filename = quoted(value, "filename");
+                part.name = parameter(value, "name").unwrap_or_default();
+                part.filename = parameter(value, "filename");
             } else if name.eq_ignore_ascii_case("content-type") {
                 part.content_type = Some(value.to_string());
             } else {
@@ -145,13 +145,35 @@ pub fn parse(body: &[u8], boundary: &str) -> Option<Vec<Part>> {
     Some(parts)
 }
 
-/// `name="value"` out of a `Content-Disposition`.
-fn quoted(header: &str, key: &str) -> Option<String> {
-    let needle = format!("{key}=\"");
-    let at = header.find(&needle)? + needle.len();
-    let rest = &header[at..];
-    let end = rest.find('"')?;
-    Some(rest[..end].to_string())
+/// One `Content-Disposition` parameter, quoted or bare.
+///
+/// Both spellings, because both arrive. A browser quotes; a page building its
+/// own body through `fetch` writes whatever its author typed, and servers read
+/// either. Reading only `name="x"` gave a bare `name=x` an empty name, and the
+/// rebuild then wrote `name=""` over it — so editing one field of an upload
+/// renamed every other field in the request to nothing.
+///
+/// The parameter is matched at a boundary (start of the header, or after a
+/// `;`), so `filename=` is not found inside `x-filename=` and `name=` is not
+/// found inside `filename=`.
+fn parameter(header: &str, key: &str) -> Option<String> {
+    let mut rest = header;
+    loop {
+        let at = rest.find(key)?;
+        let before = rest[..at].trim_end();
+        let starts_here = before.is_empty() || before.ends_with(';');
+        let after = &rest[at + key.len()..];
+        if starts_here && after.starts_with('=') {
+            let value = &after[1..];
+            return Some(match value.strip_prefix('"') {
+                // Quoted: to the closing quote.
+                Some(quoted) => quoted.split('"').next().unwrap_or_default().to_string(),
+                // Bare: to the next `;`, trimmed.
+                None => value.split(';').next().unwrap_or_default().trim().to_string(),
+            });
+        }
+        rest = &rest[at + key.len()..];
+    }
 }
 
 fn find(haystack: &[u8], needle: &[u8], from: usize) -> Option<usize> {
@@ -263,6 +285,49 @@ mod tests {
         let parts = parse(&body, "----abc").expect("parses");
         assert_eq!(parts.len(), 1);
         assert!(parts[0].data.is_empty());
+    }
+
+    /// `Content-Disposition` parameters may be quoted or bare, and a page that
+    /// builds its own multipart body through `fetch` writes whichever it likes.
+    /// Reading only the quoted form gave the part an empty name, and rebuilding
+    /// then wrote `name=""` — so an edit to one field silently renamed every
+    /// other field in the request to nothing.
+    #[test]
+    fn an_unquoted_disposition_parameter_is_read_like_a_quoted_one() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"------abc\r\n");
+        body.extend_from_slice(b"Content-Disposition: form-data; name=avatar; filename=cat.png\r\n");
+        body.extend_from_slice(b"Content-Type: image/png\r\n\r\n");
+        body.extend_from_slice(b"PNGDATA");
+        body.extend_from_slice(b"\r\n------abc--\r\n");
+
+        let parts = parse(&body, "----abc").expect("parses");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].name, "avatar");
+        assert_eq!(parts[0].filename.as_deref(), Some("cat.png"));
+        assert_eq!(parts[0].data, b"PNGDATA");
+
+        // And it survives a rebuild, which is what an edit does to it.
+        let again = serialize(&parts, "----xyz");
+        let round = parse(&again, "----xyz").expect("parses again");
+        assert_eq!(round, parts);
+    }
+
+    /// `name=` occurs inside `filename=`, and a plain substring search found it
+    /// there: a part that wrote its filename first came back with the
+    /// filename as its field name. Parameter order is the sender's choice.
+    #[test]
+    fn a_filename_written_first_is_not_read_as_the_field_name() {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"------abc\r\n");
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; filename=\"cat.png\"; name=\"avatar\"\r\n\r\n",
+        );
+        body.extend_from_slice(b"PNGDATA");
+        body.extend_from_slice(b"\r\n------abc--\r\n");
+        let parts = parse(&body, "----abc").expect("parses");
+        assert_eq!(parts[0].name, "avatar");
+        assert_eq!(parts[0].filename.as_deref(), Some("cat.png"));
     }
 
     #[test]

--- a/crates/h5i-browser/src/multipart.rs
+++ b/crates/h5i-browser/src/multipart.rs
@@ -208,6 +208,34 @@ mod tests {
         body
     }
 
+    /// Every body this parser sees is a body somebody else wrote: a page's own
+    /// `fetch` put it in the store, and an edit takes it apart again. It may
+    /// answer `None`, it may answer with odd parts; it may not die.
+    #[test]
+    fn no_arrangement_of_these_bytes_makes_the_parser_panic() {
+        // A small alphabet of exactly the bytes the framing is made of, which
+        // is where the sharp edges are: boundaries, terminators, half of a
+        // CRLF, a header colon.
+        let alphabet: &[&[u8]] = &[
+            b"------abc", b"--", b"\r\n", b"\n", b"\r", b"a", b":", b" ",
+            b"Content-Disposition: form-data; name=\"a\"", b"filename=\"f\"", b"",
+        ];
+        // A cheap deterministic generator: every arrangement of six pieces
+        // would be 11^6, so walk a fixed stride through that space instead.
+        let mut seed: u64 = 0x243f_6a88_85a3_08d3;
+        for _ in 0..200_000 {
+            let mut body = Vec::new();
+            for _ in 0..6 {
+                seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                body.extend_from_slice(alphabet[(seed >> 33) as usize % alphabet.len()]);
+            }
+            // Both the boundary it declares and one it does not.
+            let _ = parse(&body, "----abc");
+            let _ = parse(&body, "--");
+            let _ = parse(&body, "");
+        }
+    }
+
     /// A part whose boundary follows the header terminator with nothing
     /// between them is malformed, and a page can post one through `fetch`. The
     /// CRLF the parser stepped over was then the terminator's own, so the data

--- a/crates/h5i-browser/src/net.rs
+++ b/crates/h5i-browser/src/net.rs
@@ -49,9 +49,8 @@ fn accept_for(initiator: Initiator) -> &'static str {
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
         }
         Initiator::Subresource => "*/*",
-        // A replay carries the stored request's own `Accept` and this default
-        // stands aside for it; it is here for a composed request that named
-        // none, where "whatever the server has" is the honest ask.
+        // A replay carries its own `Accept`; this is for a composed request
+        // that named none.
         Initiator::Replay => "*/*",
     }
 }
@@ -688,18 +687,11 @@ impl LocalBroker {
 
     /// The header set this request will actually go out with.
     ///
-    /// Not `built.headers()` alone. A client-level default — this engine sets
-    /// one, the `User-Agent` — lives on the `Client` and is merged into the
-    /// request at *execute* time, after `build()`, so reading the built
-    /// request's headers records everything except it. The store then held a
-    /// request that was not the one sent, which matters twice: the whole point
-    /// of the store is that it says what went out, and `message --raw` is the
-    /// documented way to produce a file for `resend --raw-request`, which
-    /// writes those bytes verbatim. That round trip was sending a request with
-    /// no `User-Agent` at all, and a UA-gated endpoint answers a different
-    /// question.
-    ///
-    /// Merged the way `reqwest` merges it: the request's own value wins.
+    /// Not `built.headers()` alone: `reqwest` merges the client's defaults —
+    /// here, the `User-Agent` — at *execute* time, so the store held a request
+    /// that was not the one sent. `message --raw` feeds `--raw-request`, and
+    /// that round trip was going out with no `User-Agent` at all. Merged the
+    /// way `reqwest` does: the request's own value wins.
     fn headers_as_sent(&self, built: &reqwest::blocking::Request) -> Vec<(String, String)> {
         let mut headers: Vec<(String, String)> = built
             .headers()
@@ -3238,14 +3230,9 @@ mod capture_wire_tests {
         }
     }
 
-    /// The store's whole claim is that it says what went out. A client-level
-    /// default header — this engine sets one, the `User-Agent` — is merged into
-    /// the request at *execute* time, after `build()`, so reading the built
-    /// request's headers recorded everything except it. Which also broke the
-    /// documented round trip: `message --raw` produces the file
-    /// `resend --raw-request` writes verbatim, and that file carried no
-    /// `User-Agent` at all, so a UA-gated endpoint answered a different
-    /// question and the difference read as a finding.
+    /// `reqwest` merges client defaults at *execute* time, so reading the
+    /// built request recorded everything but the `User-Agent`. That also broke
+    /// the `message --raw` → `--raw-request` round trip, which went out bare.
     #[test]
     fn the_store_records_the_header_set_that_went_on_the_wire() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/h5i-browser/src/net.rs
+++ b/crates/h5i-browser/src/net.rs
@@ -49,6 +49,10 @@ fn accept_for(initiator: Initiator) -> &'static str {
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
         }
         Initiator::Subresource => "*/*",
+        // A replay carries the stored request's own `Accept` and this default
+        // stands aside for it; it is here for a composed request that named
+        // none, where "whatever the server has" is the honest ask.
+        Initiator::Replay => "*/*",
     }
 }
 
@@ -1976,7 +1980,7 @@ impl crate::broker::Broker for LocalBroker {
 
         let denied = |broker: &Self, seq: u64, reason: &str| -> FetchOutcome {
             let record =
-                RequestRecord::request(seq, Initiator::Navigation, &req.method, &display)
+                RequestRecord::request(seq, Initiator::Replay, &req.method, &display)
                     .denied(reason);
             if let Err(e) = broker.record_pair(&record) {
                 return FetchOutcome::failed(url.clone(), format!("receipt sink refused: {e}"));
@@ -2013,7 +2017,7 @@ impl crate::broker::Broker for LocalBroker {
 
         // 5. Record the decision before sending. Fail closed if this fails.
         let mut record =
-            RequestRecord::request(seq, Initiator::Navigation, &req.method, &display);
+            RequestRecord::request(seq, Initiator::Replay, &req.method, &display);
         record.headers_overridden = req.broke.clone();
         if let Err(e) = self.append(&record) {
             return FetchOutcome::failed(
@@ -2342,7 +2346,7 @@ impl LocalBroker {
             // named, exactly like a navigation, and not a page reaching for a
             // subresource. That is what decides the policy question and what
             // keeps the same-origin rules out of it: there is no document here.
-            initiator: Initiator::Navigation,
+            initiator: Initiator::Replay,
             method: editable.method.clone(),
             body: editable.body.clone(),
             content_type,

--- a/crates/h5i-browser/src/net.rs
+++ b/crates/h5i-browser/src/net.rs
@@ -686,6 +686,43 @@ impl LocalBroker {
         )
     }
 
+    /// The header set this request will actually go out with.
+    ///
+    /// Not `built.headers()` alone. A client-level default — this engine sets
+    /// one, the `User-Agent` — lives on the `Client` and is merged into the
+    /// request at *execute* time, after `build()`, so reading the built
+    /// request's headers records everything except it. The store then held a
+    /// request that was not the one sent, which matters twice: the whole point
+    /// of the store is that it says what went out, and `message --raw` is the
+    /// documented way to produce a file for `resend --raw-request`, which
+    /// writes those bytes verbatim. That round trip was sending a request with
+    /// no `User-Agent` at all, and a UA-gated endpoint answers a different
+    /// question.
+    ///
+    /// Merged the way `reqwest` merges it: the request's own value wins.
+    fn headers_as_sent(&self, built: &reqwest::blocking::Request) -> Vec<(String, String)> {
+        let mut headers: Vec<(String, String)> = built
+            .headers()
+            .iter()
+            .filter_map(|(name, value)| {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (name.as_str().to_string(), v.to_string()))
+            })
+            .collect();
+        if !headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("user-agent"))
+        {
+            headers.push((
+                "user-agent".to_string(),
+                self.presented.user_agent.clone(),
+            ));
+        }
+        headers
+    }
+
     /// Resolve a URL's host, check every address it answers with, and pin the
     /// result for the connection that follows. `Ok(())` when there is nothing to
     /// do (a proxy in the path, or a URL with no host) so the caller has one
@@ -1091,16 +1128,7 @@ impl LocalBroker {
                         seq,
                         built.method().as_str(),
                         built.url().as_str(),
-                        built
-                            .headers()
-                            .iter()
-                            .filter_map(|(name, value)| {
-                                value
-                                    .to_str()
-                                    .ok()
-                                    .map(|v| (name.as_str().to_string(), v.to_string()))
-                            })
-                            .collect(),
+                        self.headers_as_sent(&built),
                         &body,
                         content_type,
                     );
@@ -3208,6 +3236,52 @@ mod capture_wire_tests {
                 "`{header}` went out more than once on the replay:\n{replay}"
             );
         }
+    }
+
+    /// The store's whole claim is that it says what went out. A client-level
+    /// default header — this engine sets one, the `User-Agent` — is merged into
+    /// the request at *execute* time, after `build()`, so reading the built
+    /// request's headers recorded everything except it. Which also broke the
+    /// documented round trip: `message --raw` produces the file
+    /// `resend --raw-request` writes verbatim, and that file carried no
+    /// `User-Agent` at all, so a UA-gated endpoint answered a different
+    /// question and the difference read as a finding.
+    #[test]
+    fn the_store_records_the_header_set_that_went_on_the_wire() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let capture = Arc::new(Capture::open(&dir.path().join("messages")).expect("store"));
+        let broker = LocalBroker::with_limits(
+            Policy::new(),
+            Arc::new(MemorySink::new()),
+            None,
+            crate::budget::Limits::default(),
+            Some(capture.clone()),
+        )
+        .expect("broker");
+
+        let (port, seen) = super::caller_header_tests::head_recorder(1, None);
+        let url = Url::parse(&format!("http://127.0.0.1:{port}/api")).unwrap();
+        assert!(broker.fetch(&url, Initiator::Navigation).is_ok());
+
+        let on_the_wire = seen.lock().unwrap()[0].to_ascii_lowercase();
+        let stored = capture.read_request(0).expect("a stored request");
+        for (name, _) in &stored.headers {
+            assert!(
+                on_the_wire.contains(&format!("\n{}:", name.to_ascii_lowercase()))
+                    || name.eq_ignore_ascii_case("host"),
+                "the store holds `{name}`, which never went out:\n{on_the_wire}"
+            );
+        }
+        // And the one that used to be missing is there.
+        assert!(
+            stored
+                .headers
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("user-agent")),
+            "the store must hold the `User-Agent` the wire carried: {:?}",
+            stored.headers
+        );
+        assert!(on_the_wire.contains("user-agent:"), "{on_the_wire}");
     }
 
     /// An edit that would change nothing is a mistake, and saying so is the

--- a/crates/h5i-browser/src/rawsock.rs
+++ b/crates/h5i-browser/src/rawsock.rs
@@ -259,7 +259,16 @@ pub(crate) fn read_http_response(wire: &mut Wire, cap: usize) -> Result<RawRespo
     let (body, leftover) = if te_chunked {
         read_chunked(wire, &mut rest, &mut chunk, cap)?
     } else if let Some(len) = content_length {
-        read_exact_len(wire, rest, &mut chunk, len.min(cap))?
+        // Refused past the cap rather than cut short, which is what every
+        // other body reader in this engine does. Truncating had a second cost
+        // that belongs to this path alone: the bytes past the cap became
+        // `leftover`, and `leftover` is how a raw send reports that the socket
+        // answered twice. Any page larger than the cap therefore read as a
+        // successful desync — the one signal this path exists to produce.
+        if len > cap {
+            return Err(format!("response exceeds the {cap} byte cap"));
+        }
+        read_exact_len(wire, rest, &mut chunk, len)?
     } else {
         // Without framing, read until the connection closes or the cap is
         // reached. Nothing can follow a response that ends at the close.
@@ -299,7 +308,10 @@ fn read_to_close(
     chunk: &mut [u8],
     cap: usize,
 ) -> Result<Vec<u8>, String> {
-    while have.len() < cap {
+    // One byte past the cap, so that "exactly the cap" and "more than the cap"
+    // are different answers. Silently truncating here handed back a body that
+    // is not the one the server sent, under a status that says it is.
+    while have.len() <= cap {
         match wire.read(chunk) {
             Ok(0) => break,
             Ok(n) => have.extend_from_slice(&chunk[..n]),
@@ -307,7 +319,9 @@ fn read_to_close(
             Err(e) => return Err(format!("reading the response body failed: {e}")),
         }
     }
-    have.truncate(cap);
+    if have.len() > cap {
+        return Err(format!("response exceeds the {cap} byte cap"));
+    }
     Ok(have)
 }
 
@@ -495,6 +509,33 @@ mod tests {
         );
     }
 
+    /// `leftover` is this path's desync signal: bytes on the socket after the
+    /// response its own framing ended. A body larger than the cap used to be
+    /// cut at the cap with the remainder handed back under that name, so an
+    /// ordinary large page reported as a successful request smuggle.
+    #[test]
+    fn a_body_past_the_cap_is_refused_rather_than_reported_as_a_second_response() {
+        let big = "x".repeat(4096);
+        let said = format!("HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\n{big}");
+        let outcome = try_reading_from_a_server_that_says_with_cap(&said, 1024);
+        match outcome {
+            Err(why) => assert!(why.contains("cap"), "{why}"),
+            Ok(response) => panic!(
+                "kept {} bytes and called {} of them a second response",
+                response.body.len(),
+                response.leftover.len()
+            ),
+        }
+    }
+
+    /// And the same for a response with no framing at all, which used to be
+    /// truncated to the cap and handed back under a 200.
+    #[test]
+    fn an_unframed_body_past_the_cap_is_refused_rather_than_cut_short() {
+        let said = format!("HTTP/1.1 200 OK\r\n\r\n{}", "x".repeat(4096));
+        assert!(try_reading_from_a_server_that_says_with_cap(&said, 1024).is_err());
+    }
+
     /// One connection, one write, whatever bytes the test names.
     fn read_from_a_server_that_says(bytes: &str) -> RawResponse {
         use std::io::Write;
@@ -521,6 +562,13 @@ mod tests {
 
     /// The same server, for the cases where the refusal is the answer.
     fn try_reading_from_a_server_that_says(bytes: &str) -> Result<RawResponse, String> {
+        try_reading_from_a_server_that_says_with_cap(bytes, 1 << 20)
+    }
+
+    fn try_reading_from_a_server_that_says_with_cap(
+        bytes: &str,
+        cap: usize,
+    ) -> Result<RawResponse, String> {
         use std::io::Write;
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
         let port = listener.local_addr().expect("addr").port();
@@ -535,7 +583,7 @@ mod tests {
         let sock = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect");
         sock.set_read_timeout(Some(std::time::Duration::from_secs(5))).expect("timeout");
         let mut wire = Wire::plain(sock);
-        let response = read_http_response(&mut wire, 1 << 20);
+        let response = read_http_response(&mut wire, cap);
         let _ = server.join();
         response
     }

--- a/crates/h5i-browser/src/rawsock.rs
+++ b/crates/h5i-browser/src/rawsock.rs
@@ -411,13 +411,28 @@ fn parse_head(head: &[u8]) -> (Option<u16>, Vec<(String, String)>) {
         .next()
         .and_then(|line| line.split_whitespace().nth(1))
         .and_then(|code| code.parse::<u16>().ok());
-    let headers = lines
-        .filter(|line| !line.is_empty())
-        .filter_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            Some((name.trim().to_string(), value.trim().to_string()))
-        })
-        .collect();
+    let mut headers: Vec<(String, String)> = Vec::new();
+    for line in lines.filter(|line| !line.is_empty()) {
+        // A line beginning with a space or a tab is an obs-fold: the
+        // continuation of the header above it, which RFC 9110 §5.2 says a
+        // recipient reads as one field with the fold replaced by a space.
+        // Reading it as a header of its own is how a reflected value becomes a
+        // header — `X-Echo: <input>\r\n Set-Cookie: sid=evil` arrived here as a
+        // real `Set-Cookie`, and `send_raw` writes those into the session jar.
+        // No compliant client would have seen it, so neither does this: the
+        // exact bytes are in the message store either way, which is where a
+        // reader goes to see that the fold was there at all.
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if let Some((_, value)) = headers.last_mut() {
+                value.push(' ');
+                value.push_str(line.trim());
+            }
+            continue;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            headers.push((name.trim().to_string(), value.trim().to_string()));
+        }
+    }
     (status, headers)
 }
 
@@ -450,6 +465,30 @@ mod tests {
             .iter()
             .any(|(n, v)| n == "Content-Type" && v == "text/plain"));
         assert!(headers.iter().any(|(n, v)| n == "Content-Length" && v == "3"));
+    }
+
+    /// A line beginning with a space is an obs-fold: the continuation of the
+    /// header above it, not a header of its own. Reading it as one turned
+    /// `X-Echo: <reflected>\r\n Set-Cookie: sid=evil` into a `Set-Cookie` this
+    /// engine then wrote into the session jar — a cookie the origin never set,
+    /// and one no compliant client would have seen.
+    #[test]
+    fn a_folded_header_line_is_a_continuation_and_not_a_new_header() {
+        let head = b"HTTP/1.1 200 OK\r\nX-Echo: hello\r\n Set-Cookie: sid=evil\r\n\r\n";
+        let (status, headers) = parse_head(head);
+        assert_eq!(status, Some(200));
+        assert!(
+            !headers.iter().any(|(n, _)| n.eq_ignore_ascii_case("set-cookie")),
+            "a folded line is not a Set-Cookie: {headers:?}"
+        );
+        assert_eq!(
+            headers
+                .iter()
+                .find(|(n, _)| n == "X-Echo")
+                .map(|(_, v)| v.as_str()),
+            Some("hello Set-Cookie: sid=evil"),
+            "it is part of the value above it: {headers:?}"
+        );
     }
 
     #[test]

--- a/crates/h5i-browser/src/rawsock.rs
+++ b/crates/h5i-browser/src/rawsock.rs
@@ -339,6 +339,16 @@ fn read_chunked(
         let size_hex = size_text.split(';').next().unwrap_or("").trim();
         let size = usize::from_str_radix(size_hex, 16)
             .map_err(|_| format!("`{size_hex}` is not a chunk size"))?;
+        // A chunk cannot be bigger than the whole response is allowed to be,
+        // and a size that says otherwise is not a body to read: it is
+        // arithmetic to break. `cursor + size + 2` wraps in a release build, so
+        // a size near `usize::MAX` makes the fill loop below decide it already
+        // has enough and then slice a range that runs backwards, which panics.
+        // Refused where the number is read, so every sum after this point is
+        // bounded by the cap.
+        if size > cap {
+            return Err(format!("chunked response exceeded the {cap} byte cap"));
+        }
         cursor = line_end + 2;
         if size == 0 {
             break; // the last chunk; trailers, if any, are ignored
@@ -470,6 +480,21 @@ mod tests {
         );
     }
 
+    /// A chunk size is a number a server chooses, and one near `usize::MAX`
+    /// used to reach `&have[cursor..cursor + size]` with the sum wrapped past
+    /// zero: a range running backwards, which panics. A hostile target could
+    /// therefore end the session by answering a raw send.
+    #[test]
+    fn a_chunk_size_that_would_overflow_is_refused_rather_than_sliced() {
+        let hostile = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nffffffffffffffee\r\n";
+        let outcome = try_reading_from_a_server_that_says(hostile);
+        assert!(
+            outcome.is_err(),
+            "a chunk larger than the cap has to be refused, got {:?}",
+            outcome.map(|r| r.body)
+        );
+    }
+
     /// One connection, one write, whatever bytes the test names.
     fn read_from_a_server_that_says(bytes: &str) -> RawResponse {
         use std::io::Write;
@@ -490,6 +515,27 @@ mod tests {
         sock.set_read_timeout(Some(std::time::Duration::from_secs(5))).expect("timeout");
         let mut wire = Wire::plain(sock);
         let response = read_http_response(&mut wire, 1 << 20).expect("a response");
+        let _ = server.join();
+        response
+    }
+
+    /// The same server, for the cases where the refusal is the answer.
+    fn try_reading_from_a_server_that_says(bytes: &str) -> Result<RawResponse, String> {
+        use std::io::Write;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let said = bytes.to_string();
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _ = stream.write_all(said.as_bytes());
+                let _ = stream.flush();
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+        });
+        let sock = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        sock.set_read_timeout(Some(std::time::Duration::from_secs(5))).expect("timeout");
+        let mut wire = Wire::plain(sock);
+        let response = read_http_response(&mut wire, 1 << 20);
         let _ = server.join();
         response
     }

--- a/crates/h5i-browser/src/rawsock.rs
+++ b/crates/h5i-browser/src/rawsock.rs
@@ -259,12 +259,9 @@ pub(crate) fn read_http_response(wire: &mut Wire, cap: usize) -> Result<RawRespo
     let (body, leftover) = if te_chunked {
         read_chunked(wire, &mut rest, &mut chunk, cap)?
     } else if let Some(len) = content_length {
-        // Refused past the cap rather than cut short, which is what every
-        // other body reader in this engine does. Truncating had a second cost
-        // that belongs to this path alone: the bytes past the cap became
-        // `leftover`, and `leftover` is how a raw send reports that the socket
-        // answered twice. Any page larger than the cap therefore read as a
-        // successful desync — the one signal this path exists to produce.
+        // Refused past the cap, as every other body reader here does.
+        // Truncating made the overflow `leftover`, which is how this path
+        // reports a second response — so a large page read as a desync.
         if len > cap {
             return Err(format!("response exceeds the {cap} byte cap"));
         }
@@ -308,9 +305,8 @@ fn read_to_close(
     chunk: &mut [u8],
     cap: usize,
 ) -> Result<Vec<u8>, String> {
-    // One byte past the cap, so that "exactly the cap" and "more than the cap"
-    // are different answers. Silently truncating here handed back a body that
-    // is not the one the server sent, under a status that says it is.
+    // One byte past the cap, so "exactly" and "more than" differ. Truncating
+    // handed back a body that is not the one the server sent.
     while have.len() <= cap {
         match wire.read(chunk) {
             Ok(0) => break,
@@ -353,13 +349,8 @@ fn read_chunked(
         let size_hex = size_text.split(';').next().unwrap_or("").trim();
         let size = usize::from_str_radix(size_hex, 16)
             .map_err(|_| format!("`{size_hex}` is not a chunk size"))?;
-        // A chunk cannot be bigger than the whole response is allowed to be,
-        // and a size that says otherwise is not a body to read: it is
-        // arithmetic to break. `cursor + size + 2` wraps in a release build, so
-        // a size near `usize::MAX` makes the fill loop below decide it already
-        // has enough and then slice a range that runs backwards, which panics.
-        // Refused where the number is read, so every sum after this point is
-        // bounded by the cap.
+        // A size past the cap is not a body to read, it is arithmetic to
+        // break: `cursor + size + 2` wraps and the slice below runs backwards.
         if size > cap {
             return Err(format!("chunked response exceeded the {cap} byte cap"));
         }
@@ -413,15 +404,11 @@ fn parse_head(head: &[u8]) -> (Option<u16>, Vec<(String, String)>) {
         .and_then(|code| code.parse::<u16>().ok());
     let mut headers: Vec<(String, String)> = Vec::new();
     for line in lines.filter(|line| !line.is_empty()) {
-        // A line beginning with a space or a tab is an obs-fold: the
-        // continuation of the header above it, which RFC 9110 §5.2 says a
-        // recipient reads as one field with the fold replaced by a space.
-        // Reading it as a header of its own is how a reflected value becomes a
-        // header — `X-Echo: <input>\r\n Set-Cookie: sid=evil` arrived here as a
-        // real `Set-Cookie`, and `send_raw` writes those into the session jar.
-        // No compliant client would have seen it, so neither does this: the
-        // exact bytes are in the message store either way, which is where a
-        // reader goes to see that the fold was there at all.
+        // An obs-fold: the continuation of the header above it, which RFC 9110
+        // §5.2 reads as one field. Taken as a header of its own,
+        // `X-Echo: <input>\r\n Set-Cookie: sid=evil` became a real
+        // `Set-Cookie` that `send_raw` wrote into the jar. The store keeps the
+        // exact bytes either way.
         if line.starts_with(' ') || line.starts_with('\t') {
             if let Some((_, value)) = headers.last_mut() {
                 value.push(' ');
@@ -467,11 +454,9 @@ mod tests {
         assert!(headers.iter().any(|(n, v)| n == "Content-Length" && v == "3"));
     }
 
-    /// A line beginning with a space is an obs-fold: the continuation of the
-    /// header above it, not a header of its own. Reading it as one turned
-    /// `X-Echo: <reflected>\r\n Set-Cookie: sid=evil` into a `Set-Cookie` this
-    /// engine then wrote into the session jar — a cookie the origin never set,
-    /// and one no compliant client would have seen.
+    /// An obs-fold is a continuation, not a header. Read as one,
+    /// `X-Echo: <reflected>\r\n Set-Cookie: sid=evil` became a cookie in the
+    /// jar that the origin never set.
     #[test]
     fn a_folded_header_line_is_a_continuation_and_not_a_new_header() {
         let head = b"HTTP/1.1 200 OK\r\nX-Echo: hello\r\n Set-Cookie: sid=evil\r\n\r\n";
@@ -533,10 +518,8 @@ mod tests {
         );
     }
 
-    /// A chunk size is a number a server chooses, and one near `usize::MAX`
-    /// used to reach `&have[cursor..cursor + size]` with the sum wrapped past
-    /// zero: a range running backwards, which panics. A hostile target could
-    /// therefore end the session by answering a raw send.
+    /// A chunk size near `usize::MAX` reached `&have[cursor..cursor + size]`
+    /// with the sum wrapped past zero: a backwards range, which panics.
     #[test]
     fn a_chunk_size_that_would_overflow_is_refused_rather_than_sliced() {
         let hostile = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\nffffffffffffffee\r\n";
@@ -548,10 +531,9 @@ mod tests {
         );
     }
 
-    /// `leftover` is this path's desync signal: bytes on the socket after the
-    /// response its own framing ended. A body larger than the cap used to be
-    /// cut at the cap with the remainder handed back under that name, so an
-    /// ordinary large page reported as a successful request smuggle.
+    /// `leftover` is this path's desync signal. Cutting an oversized body at
+    /// the cap handed the remainder back under that name, so a large page
+    /// reported as a successful smuggle.
     #[test]
     fn a_body_past_the_cap_is_refused_rather_than_reported_as_a_second_response() {
         let big = "x".repeat(4096);
@@ -567,18 +549,15 @@ mod tests {
         }
     }
 
-    /// And the same for a response with no framing at all, which used to be
-    /// truncated to the cap and handed back under a 200.
+    /// And the same with no framing at all, truncated under a 200.
     #[test]
     fn an_unframed_body_past_the_cap_is_refused_rather_than_cut_short() {
         let said = format!("HTTP/1.1 200 OK\r\n\r\n{}", "x".repeat(4096));
         assert!(try_reading_from_a_server_that_says_with_cap(&said, 1024).is_err());
     }
 
-    /// Everything this reader parses is what a target chose to send: a status
-    /// line, a header block, a chunk size. It may refuse, it may time out; it
-    /// may not die, because a raw send is how this engine looks at a server
-    /// that is already behaving badly on purpose.
+    /// Everything here is what a target chose to send. It may refuse or time
+    /// out; it may not die — a raw send is aimed at servers behaving badly.
     #[test]
     fn no_arrangement_of_these_bytes_makes_the_reader_panic() {
         let alphabet: &[&str] = &[
@@ -588,10 +567,8 @@ mod tests {
             "HTTP/1.1 200 OK", "Content-Length: 5",
             "Content-Length: 99999999999999999999", "Content-Length: -1",
         ];
-        // Half the cases begin with a head that reaches the chunked reader and
-        // half with one that reaches the length reader, because a random prefix
-        // almost never forms either: the sharp arithmetic is past a valid head,
-        // and a fuzzer that cannot get there is a fuzzer that proves nothing.
+        // Seeded with real heads: the sharp arithmetic is past a valid one,
+        // and a random prefix almost never forms one.
         let heads: &[&str] = &[
             "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
             "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n",
@@ -637,12 +614,8 @@ mod tests {
         response
     }
 
-    /// A server that says its piece and hangs up at once.
-    ///
-    /// The helpers above hold the connection open so the reader has to stop on
-    /// the framing; this one is for the fuzz loop, where two thousand
-    /// two-hundred-millisecond sleeps is seven minutes of holding sockets open
-    /// to learn nothing the close does not also teach.
+    /// A server that says its piece and hangs up at once. The helpers above
+    /// hold the connection open, which the fuzz loop cannot afford.
     fn read_from_a_server_that_hangs_up(bytes: &str, cap: usize) -> Result<RawResponse, String> {
         use std::io::Write;
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/crates/h5i-browser/src/rawsock.rs
+++ b/crates/h5i-browser/src/rawsock.rs
@@ -536,6 +536,44 @@ mod tests {
         assert!(try_reading_from_a_server_that_says_with_cap(&said, 1024).is_err());
     }
 
+    /// Everything this reader parses is what a target chose to send: a status
+    /// line, a header block, a chunk size. It may refuse, it may time out; it
+    /// may not die, because a raw send is how this engine looks at a server
+    /// that is already behaving badly on purpose.
+    #[test]
+    fn no_arrangement_of_these_bytes_makes_the_reader_panic() {
+        let alphabet: &[&str] = &[
+            "\r\n", "\n", "\r", ":", " ", "0", "2", "hi", ";ext", "--", "",
+            "ffffffffffffffee", "ffffffffffffffff", "7fffffffffffffff", "fffffffffffffff0",
+            "8000000000000000", "-1", "1000", "zz", "Trailer: x",
+            "HTTP/1.1 200 OK", "Content-Length: 5",
+            "Content-Length: 99999999999999999999", "Content-Length: -1",
+        ];
+        // Half the cases begin with a head that reaches the chunked reader and
+        // half with one that reaches the length reader, because a random prefix
+        // almost never forms either: the sharp arithmetic is past a valid head,
+        // and a fuzzer that cannot get there is a fuzzer that proves nothing.
+        let heads: &[&str] = &[
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n",
+            "HTTP/1.1 200 OK\r\n\r\n",
+            "",
+        ];
+        let mut seed: u64 = 0x9e37_79b9_7f4a_7c15;
+        let mut next = |modulo: usize| {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            (seed >> 33) as usize % modulo
+        };
+        for _ in 0..3_000 {
+            let mut said = heads[next(heads.len())].to_string();
+            for _ in 0..6 {
+                said.push_str(alphabet[next(alphabet.len())]);
+            }
+            // Whatever it answers, including an error, is fine. A panic is not.
+            let _ = read_from_a_server_that_hangs_up(&said, 4096);
+        }
+    }
+
     /// One connection, one write, whatever bytes the test names.
     fn read_from_a_server_that_says(bytes: &str) -> RawResponse {
         use std::io::Write;
@@ -556,6 +594,31 @@ mod tests {
         sock.set_read_timeout(Some(std::time::Duration::from_secs(5))).expect("timeout");
         let mut wire = Wire::plain(sock);
         let response = read_http_response(&mut wire, 1 << 20).expect("a response");
+        let _ = server.join();
+        response
+    }
+
+    /// A server that says its piece and hangs up at once.
+    ///
+    /// The helpers above hold the connection open so the reader has to stop on
+    /// the framing; this one is for the fuzz loop, where two thousand
+    /// two-hundred-millisecond sleeps is seven minutes of holding sockets open
+    /// to learn nothing the close does not also teach.
+    fn read_from_a_server_that_hangs_up(bytes: &str, cap: usize) -> Result<RawResponse, String> {
+        use std::io::Write;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let said = bytes.to_string();
+        let server = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let _ = stream.write_all(said.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        let sock = std::net::TcpStream::connect(("127.0.0.1", port)).expect("connect");
+        sock.set_read_timeout(Some(std::time::Duration::from_secs(2))).expect("timeout");
+        let mut wire = Wire::plain(sock);
+        let response = read_http_response(&mut wire, cap);
         let _ = server.join();
         response
     }

--- a/crates/h5i-browser/src/receipt.rs
+++ b/crates/h5i-browser/src/receipt.rs
@@ -42,12 +42,9 @@ pub enum Initiator {
     Redirect,
     /// The agent sending a message again, through `resend`.
     ///
-    /// Its own name because the whole claim of this log is that it says *why* a
-    /// request happened, and a replay was recorded as a navigation: the log
-    /// said the browser went somewhere it never went, and the site map marked
-    /// an endpoint as navigated when an agent had only bent a parameter at it.
-    /// A reviewer separating "the application did this" from "the tester did
-    /// this" is asking exactly this field.
+    /// Its own name because a replay recorded as a navigation said the browser
+    /// went somewhere it never went. This is the field a reviewer reads to tell
+    /// what the application did from what the tester did.
     Replay,
 }
 

--- a/crates/h5i-browser/src/receipt.rs
+++ b/crates/h5i-browser/src/receipt.rs
@@ -40,6 +40,15 @@ pub enum Initiator {
     Frame,
     /// A hop the server asked for via `Location`.
     Redirect,
+    /// The agent sending a message again, through `resend`.
+    ///
+    /// Its own name because the whole claim of this log is that it says *why* a
+    /// request happened, and a replay was recorded as a navigation: the log
+    /// said the browser went somewhere it never went, and the site map marked
+    /// an endpoint as navigated when an agent had only bent a parameter at it.
+    /// A reviewer separating "the application did this" from "the tester did
+    /// this" is asking exactly this field.
+    Replay,
 }
 
 /// The engine's clock, RFC3339 with microseconds.

--- a/crates/h5i-browser/src/stream.rs
+++ b/crates/h5i-browser/src/stream.rs
@@ -1540,11 +1540,8 @@ fn control_verb_inner(
                 .get("raw_target")
                 .and_then(Value::as_str)
                 .map(str::to_string);
-            // A `raw_request` that did not survive the hop is refused, never
-            // dropped. Falling back to `None` sent an ordinary framed request
-            // instead — the exact opposite of what the flag asks for — and
-            // reported its answer as the raw send's, so a smuggling test that
-            // never happened read as a target that is not vulnerable.
+            // Refused, never dropped: falling back to `None` sent an ordinary
+            // framed request and reported its answer as the raw send's.
             let raw_request = match request.get("raw_request") {
                 None | Some(Value::Null) => None,
                 Some(value) => {
@@ -1675,11 +1672,8 @@ fn control_verb_inner(
             // The composed form carries its body base64 in the JSON: this hop
             // is a control channel, not the broker's own socket.
             //
-            // Every piece is refused rather than defaulted. This is the
-            // cross-session replay, so a body that did not decode used to be
-            // sent as an empty one and a method that did not arrive became a
-            // GET — Alice's POST going out as Bob's bodyless GET, under a reply
-            // that calls it a replay of Alice's POST.
+            // Every piece is refused rather than defaulted: a body that did not
+            // decode was sent as an empty one and a missing method became a GET.
             let composed = match given {
                 None => None,
                 Some(value) => {
@@ -5300,14 +5294,9 @@ mod tests {
         assert!(!changed);
     }
 
-    /// The control channel carries the composed request `--as` builds and the
-    /// bytes `--raw-request` reads. Every piece of both used to be defaulted
-    /// when it could not be read: a body that did not decode was sent as an
-    /// empty one, a missing method became a GET, and a `raw_request` that did
-    /// not decode fell through to the ordinary framed sender. All three send a
-    /// request the caller did not compose and then report its answer as
-    /// theirs, which for `--as` means Alice's POST going out as a bodyless GET
-    /// under a reply that calls it her POST.
+    /// Every piece of a composed request was defaulted when it could not be
+    /// read: an undecodable body went out empty, a missing method became a GET,
+    /// and an undecodable `raw_request` fell through to the framed sender.
     #[test]
     fn a_composed_request_that_cannot_be_read_is_refused_rather_than_defaulted() {
         let mut session = session_with(tall_page());

--- a/crates/h5i-browser/src/stream.rs
+++ b/crates/h5i-browser/src/stream.rs
@@ -2599,12 +2599,10 @@ fn control_verb_inner(
                     "requests": rows,
                     // The cursor to pass back as `since`. Named rather than
                     // left to be derived from the last row, which is absent
-                    // when the window is empty. The highest sequence, not the
-                    // last appended: numbers are taken before the append and a
-                    // socket's reader thread appends concurrently with the
-                    // page's own fetches, so `last()` would either re-show a
-                    // row or skip one permanently.
-                    "cursor": summary.highest,
+                    // when the window is empty, and stopping below anything
+                    // still in flight rather than at the highest number seen:
+                    // see [`crate::broker::LogSummary::cursor`].
+                    "cursor": summary.cursor,
                     "shown": rows.len(),
                     // Whether what came back is the window or a slice of it, so
                     // "two rows" is never read as "this session made two

--- a/crates/h5i-browser/src/stream.rs
+++ b/crates/h5i-browser/src/stream.rs
@@ -1540,13 +1540,35 @@ fn control_verb_inner(
                 .get("raw_target")
                 .and_then(Value::as_str)
                 .map(str::to_string);
-            let raw_request = request
-                .get("raw_request")
-                .and_then(Value::as_str)
-                .and_then(|b| {
-                    use base64::Engine as _;
-                    base64::engine::general_purpose::STANDARD.decode(b).ok()
-                });
+            // A `raw_request` that did not survive the hop is refused, never
+            // dropped. Falling back to `None` sent an ordinary framed request
+            // instead — the exact opposite of what the flag asks for — and
+            // reported its answer as the raw send's, so a smuggling test that
+            // never happened read as a target that is not vulnerable.
+            let raw_request = match request.get("raw_request") {
+                None | Some(Value::Null) => None,
+                Some(value) => {
+                    let decoded = value.as_str().and_then(|b| {
+                        use base64::Engine as _;
+                        base64::engine::general_purpose::STANDARD.decode(b).ok()
+                    });
+                    match decoded {
+                        Some(bytes) => Some(bytes),
+                        None => {
+                            return (
+                                json!({
+                                    "ok": false,
+                                    "code": "bad-raw",
+                                    "message": "the raw request's bytes did not survive the \
+                                                hop, and sending a framed request instead \
+                                                would answer a different question",
+                                }),
+                                false,
+                            );
+                        }
+                    }
+                }
+            };
             let plan = crate::broker::Sends {
                 count: request
                     .get("repeat")
@@ -1652,36 +1674,73 @@ fn control_verb_inner(
 
             // The composed form carries its body base64 in the JSON: this hop
             // is a control channel, not the broker's own socket.
-            let composed = given.map(|value| {
-                let text = |key: &str| {
-                    value.get(key).and_then(Value::as_str).unwrap_or_default().to_string()
-                };
-                let body = value
-                    .get("body_base64")
-                    .and_then(Value::as_str)
-                    .and_then(|b| {
-                        use base64::Engine as _;
-                        base64::engine::general_purpose::STANDARD.decode(b).ok()
-                    })
-                    .unwrap_or_default();
-                let headers = value
-                    .get("headers")
-                    .and_then(Value::as_array)
-                    .map(|items| {
-                        items
-                            .iter()
-                            .filter_map(|pair| {
-                                let pair = pair.as_array()?;
-                                Some((
-                                    pair.first()?.as_str()?.to_string(),
-                                    pair.get(1)?.as_str()?.to_string(),
-                                ))
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                (text("method"), text("url"), headers, body)
-            });
+            //
+            // Every piece is refused rather than defaulted. This is the
+            // cross-session replay, so a body that did not decode used to be
+            // sent as an empty one and a method that did not arrive became a
+            // GET — Alice's POST going out as Bob's bodyless GET, under a reply
+            // that calls it a replay of Alice's POST.
+            let composed = match given {
+                None => None,
+                Some(value) => {
+                    let text = |key: &str| {
+                        value.get(key).and_then(Value::as_str).unwrap_or_default().to_string()
+                    };
+                    let refuse = |what: &str| {
+                        (
+                            json!({
+                                "ok": false,
+                                "code": "bad-request",
+                                "message": format!(
+                                    "the request handed to `resend` {what}, and sending \
+                                     something else in its place would answer a different \
+                                     question"
+                                ),
+                            }),
+                            false,
+                        )
+                    };
+                    let body = match value.get("body_base64") {
+                        None | Some(Value::Null) => Vec::new(),
+                        Some(encoded) => {
+                            let decoded = encoded.as_str().and_then(|b| {
+                                use base64::Engine as _;
+                                base64::engine::general_purpose::STANDARD.decode(b).ok()
+                            });
+                            match decoded {
+                                Some(bytes) => bytes,
+                                None => return refuse("has a body that did not survive the hop"),
+                            }
+                        }
+                    };
+                    let mut headers: Vec<(String, String)> = Vec::new();
+                    match value.get("headers") {
+                        None | Some(Value::Null) => {}
+                        Some(Value::Array(items)) => {
+                            for pair in items {
+                                let read = pair.as_array().and_then(|pair| {
+                                    Some((
+                                        pair.first()?.as_str()?.to_string(),
+                                        pair.get(1)?.as_str()?.to_string(),
+                                    ))
+                                });
+                                match read {
+                                    Some(pair) => headers.push(pair),
+                                    None => {
+                                        return refuse("has a header that is not a name and a value")
+                                    }
+                                }
+                            }
+                        }
+                        Some(_) => return refuse("has headers that are not a list"),
+                    }
+                    let method = text("method");
+                    if method.trim().is_empty() {
+                        return refuse("names no method");
+                    }
+                    Some((method, text("url"), headers, body))
+                }
+            };
 
             let outcome = match composed {
                 Some((method, target, headers, body)) => match url::Url::parse(&target) {
@@ -5241,6 +5300,72 @@ mod tests {
              outline as one reading the CLI: {reply:?}"
         );
         assert!(!changed);
+    }
+
+    /// The control channel carries the composed request `--as` builds and the
+    /// bytes `--raw-request` reads. Every piece of both used to be defaulted
+    /// when it could not be read: a body that did not decode was sent as an
+    /// empty one, a missing method became a GET, and a `raw_request` that did
+    /// not decode fell through to the ordinary framed sender. All three send a
+    /// request the caller did not compose and then report its answer as
+    /// theirs, which for `--as` means Alice's POST going out as a bodyless GET
+    /// under a reply that calls it her POST.
+    #[test]
+    fn a_composed_request_that_cannot_be_read_is_refused_rather_than_defaulted() {
+        let mut session = session_with(tall_page());
+        let resend = |body: Value| {
+            let mut request = json!({"verb": "resend", "from": 0});
+            request["request"] = body;
+            request
+        };
+
+        let (reply, moved) = control_verb(
+            &mut session,
+            &resend(json!({
+                "method": "POST",
+                "url": "https://app.test/a",
+                "headers": [],
+                "body_base64": "not base64 !!",
+            })),
+        );
+        assert_eq!(reply["ok"], false, "{reply}");
+        assert_eq!(reply["code"], "bad-request");
+        assert!(
+            reply["message"].as_str().unwrap_or_default().contains("body"),
+            "{reply}"
+        );
+        assert!(!moved);
+
+        let (reply, _) = control_verb(
+            &mut session,
+            &resend(json!({"url": "https://app.test/a", "headers": [], "body_base64": ""})),
+        );
+        assert_eq!(reply["ok"], false, "a request with no method: {reply}");
+        assert!(
+            reply["message"].as_str().unwrap_or_default().contains("method"),
+            "{reply}"
+        );
+
+        let (reply, _) = control_verb(
+            &mut session,
+            &resend(json!({
+                "method": "GET",
+                "url": "https://app.test/a",
+                "headers": [["only-a-name"]],
+            })),
+        );
+        assert_eq!(reply["ok"], false, "a half-written header: {reply}");
+        assert!(
+            reply["message"].as_str().unwrap_or_default().contains("header"),
+            "{reply}"
+        );
+
+        let (reply, _) = control_verb(
+            &mut session,
+            &json!({"verb": "resend", "from": 0, "raw_request": "not base64 !!"}),
+        );
+        assert_eq!(reply["ok"], false, "{reply}");
+        assert_eq!(reply["code"], "bad-raw");
     }
 
     #[test]

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -1174,7 +1174,7 @@ const MAX_LOG_BYTES: u64 = 8 * 1024 * 1024;
 /// Opened `O_NOFOLLOW` first and `fstat`ed after, rather than stat-then-open:
 /// in a directory the box writes, those are two resolutions of a path and only
 /// the second one is read.
-fn read_log_capped(path: &Path) -> Option<String> {
+pub fn read_log_capped(path: &Path) -> Option<String> {
     use std::io::Read as _;
     let mut opts = fs::OpenOptions::new();
     opts.read(true);

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -476,6 +476,28 @@ pub fn dir(root: &Path, id: &str) -> PathBuf {
     root.join(SESSIONS).join(id)
 }
 
+/// Whether an id is one path component and nothing else.
+///
+/// An id reaches [`dir`] from two places that are not this module's to trust: a
+/// `--session` selector, or `$H5I_BROWSER_SESSION`, typed by whoever is driving;
+/// and the `id` field of a `session.json`, which for a boxed session sits on a
+/// filesystem the boxed code can write to. Either one carrying `..` names a
+/// directory outside the registry, and everything below a session directory —
+/// the cookie jar, the control channel, the message store with its
+/// `Authorization` headers in it — is addressed by joining onto it.
+///
+/// The shape [`new_id`] mints, plus what a restore or a test may reasonably
+/// have written: letters, digits, `.`, `_` and `-`, never a separator, never
+/// leading with a dot.
+pub fn id_is_one_component(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 96
+        && !id.starts_with('.')
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
 /// Mint an id no session has ever had, and create its directory.
 ///
 /// The directory is the claim: creating it with `create_new` is what makes two
@@ -537,6 +559,9 @@ pub fn write(root: &Path, session: &Session) -> Result<(), H5iError> {
 
 /// Read one record by id.
 pub fn read(root: &Path, id: &str) -> Result<Session, H5iError> {
+    if !id_is_one_component(id) {
+        return Err(unknown(root, id));
+    }
     let path = dir(root, id).join(RECORD);
     let body = fs::read_to_string(&path).map_err(|_| unknown(root, id))?;
     serde_json::from_str(&body)
@@ -1478,6 +1503,29 @@ fn process_alive(_pid: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
+    /// A session id is joined onto the registry to address the cookie jar, the
+    /// control channel and the message store, and it arrives from two places
+    /// this module does not own: a `--session` selector, and the `id` field of a
+    /// `session.json`, which for a boxed session sits where boxed code can
+    /// write to it.
+    #[test]
+    fn an_id_that_is_not_one_component_names_no_directory() {
+        for bad in ["..", "../../etc", "a/b", "a\\b", ".hidden", ""] {
+            assert!(!super::id_is_one_component(bad), "`{bad}` should not be an id");
+        }
+        for good in ["br_g9pftf", "br_1", "a.b-c_d"] {
+            assert!(super::id_is_one_component(good), "`{good}` should be an id");
+        }
+    }
+
+    /// And `read` answers "unknown session" rather than following it out of the
+    /// registry and reading whatever is there.
+    #[test]
+    fn reading_a_traversing_id_is_an_unknown_session() {
+        let root = tempfile::tempdir().unwrap();
+        assert!(super::read(root.path(), "../../../etc/passwd").is_err());
+    }
+
     /// The two logs an audit reads live inside the box's own `/tmp`, which the
     /// box writes. Reading them whole made `h5i box export` allocate whatever
     /// the box wrote, and following a link made it read whatever the box

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -648,6 +648,23 @@ pub fn find_by_name(root: &Path, name: &str) -> Option<Session> {
         .find(|s| s.state.is_live() && s.name.as_deref() == Some(name))
 }
 
+/// A session that has ended, by the name it was opened with. Newest first,
+/// which is what [`list`] already orders by.
+///
+/// Separate from [`find_by_name`] on purpose: a verb that acts on a session must
+/// only ever find a live one, and folding the two together would let a fetch or
+/// a click address a session that is no longer there. This is for the readers —
+/// `status` and `audit` — whose whole subject is often the run that just
+/// finished. `close` says "its record stays at …", and the name is what the
+/// caller has; making them find the opaque id first is making them look up
+/// something h5i already knows.
+pub fn find_ended_by_name(root: &Path, name: &str) -> Option<Session> {
+    list(root)
+        .unwrap_or_default()
+        .into_iter()
+        .find(|s| !s.state.is_live() && s.name.as_deref() == Some(name))
+}
+
 /// Turn what the caller said (or did not say) into a session a verb may act on.
 pub fn resolve(root: &Path, selector: Option<&str>) -> Result<Session, SessionGone> {
     let selector = selector
@@ -1503,6 +1520,29 @@ fn process_alive(_pid: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
+    /// A name only ever resolves to a live session, which is right for a verb
+    /// that acts and wrong for the readers: a closed session asked for by the
+    /// name it was opened with came back as "no such session", and `close`
+    /// itself says the record stays. The caller has the name, not the id.
+    #[test]
+    fn a_closed_session_is_still_findable_by_the_name_it_was_opened_with() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let mut session = named(root, "auth");
+
+        // While it is live, only the live lookup finds it.
+        assert!(find_by_name(root, "auth").is_some());
+        assert!(find_ended_by_name(root, "auth").is_none());
+
+        end(root, &mut session, State::Closed, "closed by the user");
+
+        // And once it has ended, the other way round.
+        assert!(find_by_name(root, "auth").is_none());
+        let found = find_ended_by_name(root, "auth").expect("the record stays");
+        assert_eq!(found.id, session.id);
+        assert!(find_ended_by_name(root, "never").is_none());
+    }
+
     /// A session id is joined onto the registry to address the cookie jar, the
     /// control channel and the message store, and it arrives from two places
     /// this module does not own: a `--session` selector, and the `id` field of a

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -1175,6 +1175,16 @@ const MAX_LOG_BYTES: u64 = 8 * 1024 * 1024;
 /// in a directory the box writes, those are two resolutions of a path and only
 /// the second one is read.
 pub fn read_log_capped(path: &Path) -> Option<String> {
+    read_log_capped_saying(path).map(|(text, _)| text)
+}
+
+/// The same read, and whether the cap cut it short.
+///
+/// A bound that says nothing turns a partial log into a complete-looking one:
+/// a run past [`MAX_LOG_BYTES`] would report as a session that simply stopped
+/// making requests, and for a crawl the requests past the cap are the ones
+/// worth seeing. Callers that render a log to a person take the flag.
+pub fn read_log_capped_saying(path: &Path) -> Option<(String, bool)> {
     use std::io::Read as _;
     let mut opts = fs::OpenOptions::new();
     opts.read(true);
@@ -1189,13 +1199,14 @@ pub fn read_log_capped(path: &Path) -> Option<String> {
     }
     let mut buf = Vec::new();
     file.take(MAX_LOG_BYTES).read_to_end(&mut buf).ok()?;
+    let cut = buf.len() as u64 >= MAX_LOG_BYTES;
     let text = String::from_utf8_lossy(&buf).into_owned();
     // These logs are JSONL and the cap can land mid-line. Ending on a whole
     // line means the parse below drops nothing it could have read.
-    match text.rfind('\n') {
-        Some(at) => Some(text[..=at].to_string()),
-        None => Some(text),
-    }
+    Some(match text.rfind('\n') {
+        Some(at) => (text[..=at].to_string(), cut),
+        None => (text, cut),
+    })
 }
 
 /// Assemble the whole record of a session: what the agent asked for, what the engine decided,
@@ -1541,6 +1552,32 @@ mod tests {
         let found = find_ended_by_name(root, "auth").expect("the record stays");
         assert_eq!(found.id, session.id);
         assert!(find_ended_by_name(root, "never").is_none());
+    }
+
+    /// The log read is bounded, and a bound that says nothing turns a partial
+    /// log into a complete-looking one: a run past the cap reads as a session
+    /// that simply stopped making requests, and for a crawl the requests past
+    /// the cap are the ones worth seeing.
+    #[test]
+    fn a_log_read_says_whether_the_cap_cut_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let small = tmp.path().join("small.jsonl");
+        std::fs::write(&small, b"{\"seq\":0}\n{\"seq\":1}\n").unwrap();
+        let (text, cut) = read_log_capped_saying(&small).expect("read");
+        assert!(!cut, "a log under the cap is whole");
+        assert_eq!(text.lines().count(), 2);
+
+        let big = tmp.path().join("big.jsonl");
+        let line = format!("{}\n", "{\"seq\":0,\"pad\":\"aaaaaaaaaaaaaaaa\"}");
+        let mut body = String::new();
+        while body.len() as u64 <= super::MAX_LOG_BYTES {
+            body.push_str(&line);
+        }
+        std::fs::write(&big, body.as_bytes()).unwrap();
+        let (text, cut) = read_log_capped_saying(&big).expect("read");
+        assert!(cut, "a log over the cap says so");
+        // And what comes back is still whole lines, so nothing half-parsed.
+        assert!(text.ends_with('\n'));
     }
 
     /// A session id is joined onto the registry to address the cookie jar, the

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -1076,6 +1076,11 @@ pub enum Availability {
     Empty,
     /// Not readable from here. Nothing can be concluded from its silence.
     Unavailable,
+    /// Read, and only the start of it: the byte cap cut the rest off.
+    ///
+    /// Its own state because the rows that *are* here look no different either
+    /// way, so a timeline that stops reads as a session that went quiet.
+    Partial,
 }
 
 impl Availability {
@@ -1084,6 +1089,7 @@ impl Availability {
             Availability::Read => "read",
             Availability::Empty => "empty",
             Availability::Unavailable => "unavailable",
+            Availability::Partial => "partial",
         }
     }
 
@@ -1092,6 +1098,14 @@ impl Availability {
             None => Availability::Unavailable,
             Some(t) if t.trim().is_empty() => Availability::Empty,
             Some(_) => Availability::Read,
+        }
+    }
+
+    /// The same, for a read that says whether the cap cut it.
+    fn of_capped(read: &Option<(String, bool)>) -> Availability {
+        match read {
+            Some((_, true)) => Availability::Partial,
+            other => Availability::of(&other.as_ref().map(|(text, _)| text.clone())),
         }
     }
 }
@@ -1199,8 +1213,10 @@ pub fn audit(root: &Path, session: &Session) -> Audit {
     use crate::browser_events as ev;
 
     let dir = dir(root, &session.id);
-    let read = |path: &Option<PathBuf>| -> Option<String> {
-        path.as_ref().and_then(|p| read_log_capped(p))
+    // The flag comes back with the text: a log the cap cut short is a timeline
+    // that stops early, and the rows that are here look no different for it.
+    let read = |path: &Option<PathBuf>| -> Option<(String, bool)> {
+        path.as_ref().and_then(|p| read_log_capped_saying(p))
     };
     let actions = read(&session.logs.actions);
     let requests = read(&session.logs.requests);
@@ -1247,12 +1263,12 @@ pub fn audit(root: &Path, session: &Session) -> Audit {
     // first and read by the second. The one ordering dependency here, and the
     // same one `BoxStream::poll` states in its own comment.
     let mut caused = std::collections::BTreeMap::new();
-    if let Some(text) = &actions {
+    if let Some((text, _)) = &actions {
         for draft in ev::ingest_light_actions_with(text, &mut caused) {
             rows.push(Row::engine(&session.started_at, &read_at, draft));
         }
     }
-    if let Some(text) = &requests {
+    if let Some((text, _)) = &requests {
         for draft in ev::ingest_request_log_with(text, &caused) {
             rows.push(Row::engine(&session.started_at, &read_at, draft));
         }
@@ -1311,8 +1327,8 @@ pub fn audit(root: &Path, session: &Session) -> Audit {
     Audit {
         session: session.clone(),
         sources: Sources {
-            actions: Availability::of(&actions),
-            requests: Availability::of(&requests),
+            actions: Availability::of_capped(&actions),
+            requests: Availability::of_capped(&requests),
             control: if handovers.is_empty() {
                 Availability::Empty
             } else {
@@ -1534,6 +1550,39 @@ mod tests {
         let found = find_ended_by_name(root, "auth").expect("the record stays");
         assert_eq!(found.id, session.id);
         assert!(find_ended_by_name(root, "never").is_none());
+    }
+
+    /// And the audit built on it says so, rather than rendering the head of a
+    /// log as the whole run. The rows that are there look no different either
+    /// way, so a timeline that stops reads as a session that went quiet.
+    #[test]
+    fn an_audit_over_a_capped_log_reports_the_source_as_partial() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let mut session = named(root, "long");
+        let dir = dir(root, &session.id);
+
+        // A request log past the cap, and an action log comfortably under it.
+        let mut requests = String::new();
+        while requests.len() as u64 <= super::MAX_LOG_BYTES {
+            requests.push_str(
+                "{\"seq\":0,\"at\":\"2026-09-04T00:00:00.000000Z\",\"phase\":\"request\",\
+                 \"initiator\":\"navigation\",\"method\":\"GET\",\
+                 \"url\":\"https://app.test/\",\"allowed\":true}\n",
+            );
+        }
+        std::fs::write(dir.join(RECEIPTS_FILE), requests.as_bytes()).unwrap();
+        std::fs::write(dir.join("browser-actions.jsonl"), b"").unwrap();
+        session.logs.requests = Some(dir.join(RECEIPTS_FILE));
+        session.logs.actions = Some(dir.join("browser-actions.jsonl"));
+
+        let audit = audit(root, &session);
+        assert_eq!(
+            audit.sources.requests,
+            Availability::Partial,
+            "a log the cap cut short is not one that was read whole"
+        );
+        assert_eq!(audit.sources.actions, Availability::Empty);
     }
 
     /// A bound that says nothing makes a run past the cap read as a session

--- a/crates/h5i-core/src/browser_session.rs
+++ b/crates/h5i-core/src/browser_session.rs
@@ -478,17 +478,10 @@ pub fn dir(root: &Path, id: &str) -> PathBuf {
 
 /// Whether an id is one path component and nothing else.
 ///
-/// An id reaches [`dir`] from two places that are not this module's to trust: a
-/// `--session` selector, or `$H5I_BROWSER_SESSION`, typed by whoever is driving;
-/// and the `id` field of a `session.json`, which for a boxed session sits on a
-/// filesystem the boxed code can write to. Either one carrying `..` names a
-/// directory outside the registry, and everything below a session directory —
-/// the cookie jar, the control channel, the message store with its
-/// `Authorization` headers in it — is addressed by joining onto it.
-///
-/// The shape [`new_id`] mints, plus what a restore or a test may reasonably
-/// have written: letters, digits, `.`, `_` and `-`, never a separator, never
-/// leading with a dot.
+/// An id reaches [`dir`] from a `--session` selector and from a `session.json`
+/// that, for a boxed session, boxed code can write. Everything under a session
+/// directory — jar, control channel, message store — is addressed by joining
+/// onto it, so a `..` here names a directory outside the registry.
 pub fn id_is_one_component(id: &str) -> bool {
     !id.is_empty()
         && id.len() <= 96
@@ -648,16 +641,11 @@ pub fn find_by_name(root: &Path, name: &str) -> Option<Session> {
         .find(|s| s.state.is_live() && s.name.as_deref() == Some(name))
 }
 
-/// A session that has ended, by the name it was opened with. Newest first,
-/// which is what [`list`] already orders by.
+/// A session that has ended, by the name it was opened with. Newest first.
 ///
-/// Separate from [`find_by_name`] on purpose: a verb that acts on a session must
-/// only ever find a live one, and folding the two together would let a fetch or
-/// a click address a session that is no longer there. This is for the readers —
-/// `status` and `audit` — whose whole subject is often the run that just
-/// finished. `close` says "its record stays at …", and the name is what the
-/// caller has; making them find the opaque id first is making them look up
-/// something h5i already knows.
+/// Separate from [`find_by_name`] on purpose: a verb that *acts* must only find
+/// a live session. This is for the readers, whose subject is usually the run
+/// that just finished — and `close` says the record stays.
 pub fn find_ended_by_name(root: &Path, name: &str) -> Option<Session> {
     list(root)
         .unwrap_or_default()
@@ -1178,12 +1166,8 @@ pub fn read_log_capped(path: &Path) -> Option<String> {
     read_log_capped_saying(path).map(|(text, _)| text)
 }
 
-/// The same read, and whether the cap cut it short.
-///
-/// A bound that says nothing turns a partial log into a complete-looking one:
-/// a run past [`MAX_LOG_BYTES`] would report as a session that simply stopped
-/// making requests, and for a crawl the requests past the cap are the ones
-/// worth seeing. Callers that render a log to a person take the flag.
+/// The same read, and whether the cap cut it short. A bound that says nothing
+/// makes a run past [`MAX_LOG_BYTES`] read as one that stopped making requests.
 pub fn read_log_capped_saying(path: &Path) -> Option<(String, bool)> {
     use std::io::Read as _;
     let mut opts = fs::OpenOptions::new();
@@ -1531,10 +1515,8 @@ fn process_alive(_pid: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    /// A name only ever resolves to a live session, which is right for a verb
-    /// that acts and wrong for the readers: a closed session asked for by the
-    /// name it was opened with came back as "no such session", and `close`
-    /// itself says the record stays. The caller has the name, not the id.
+    /// A name only resolves to a live session, so a closed one asked for by
+    /// name came back as "no such session" — though its record stays.
     #[test]
     fn a_closed_session_is_still_findable_by_the_name_it_was_opened_with() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1554,10 +1536,8 @@ mod tests {
         assert!(find_ended_by_name(root, "never").is_none());
     }
 
-    /// The log read is bounded, and a bound that says nothing turns a partial
-    /// log into a complete-looking one: a run past the cap reads as a session
-    /// that simply stopped making requests, and for a crawl the requests past
-    /// the cap are the ones worth seeing.
+    /// A bound that says nothing makes a run past the cap read as a session
+    /// that simply stopped making requests.
     #[test]
     fn a_log_read_says_whether_the_cap_cut_it() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1580,11 +1560,8 @@ mod tests {
         assert!(text.ends_with('\n'));
     }
 
-    /// A session id is joined onto the registry to address the cookie jar, the
-    /// control channel and the message store, and it arrives from two places
-    /// this module does not own: a `--session` selector, and the `id` field of a
-    /// `session.json`, which for a boxed session sits where boxed code can
-    /// write to it.
+    /// An id addresses the jar, the control channel and the message store, and
+    /// arrives from a selector and from a file boxed code can write.
     #[test]
     fn an_id_that_is_not_one_component_names_no_directory() {
         for bad in ["..", "../../etc", "a/b", "a\\b", ".hidden", ""] {
@@ -1595,8 +1572,7 @@ mod tests {
         }
     }
 
-    /// And `read` answers "unknown session" rather than following it out of the
-    /// registry and reading whatever is there.
+    /// And `read` answers "unknown session" rather than following it out.
     #[test]
     fn reading_a_traversing_id_is_an_unknown_session() {
         let root = tempfile::tempdir().unwrap();

--- a/crates/h5i-core/src/export.rs
+++ b/crates/h5i-core/src/export.rs
@@ -498,6 +498,22 @@ fn report(
                  timeline there is not evidence of a quiet session.\n"
             ));
         }
+        // A log that was read *in part* is a different fact from one that could
+        // not be read at all, and reporting it as neither would make a timeline
+        // that stops at the cap read as a session that went quiet.
+        let cut = sessions
+            .iter()
+            .filter(|x| {
+                x.sources.actions == crate::browser_session::Availability::Partial
+                    || x.sources.requests == crate::browser_session::Availability::Partial
+            })
+            .count();
+        if cut > 0 {
+            out.push_str(&format!(
+                "\n**{cut} session(s) had a log too large to read whole.** The timeline for \
+                 those covers the start of the run and not the end of it.\n"
+            ));
+        }
         out.push('\n');
     }
 

--- a/crates/h5i-websec/src/main.rs
+++ b/crates/h5i-websec/src/main.rs
@@ -73,7 +73,7 @@ enum Verb {
         /// Only responses with this status.
         #[arg(long, value_name = "CODE")]
         status: Option<u16>,
-        /// Only `navigation`, `subresource`, `frame` or `redirect`.
+        /// Only `navigation`, `subresource`, `frame`, `redirect` or `replay`.
         #[arg(long, value_name = "KIND")]
         initiator: Option<String>,
         /// Only what policy refused.

--- a/docs/design/design-websec.md
+++ b/docs/design/design-websec.md
@@ -617,7 +617,10 @@ file describes.
 ### What is built, 2026-09-03
 
 `h5i plugin install|list|remove`, and `h5i websec` dispatching to an installed
-`h5i-websec` (`src/cli/plugin.rs`, `crates/h5i-websec`). A name h5i knows but
+`h5i-websec` (`src/cli/plugin.rs`, `crates/h5i-websec`). The release ships
+`h5i-websec` as its own archive per target, so `--from` has a file to point at
+without a source tree; `install` still takes a path rather than fetching one,
+because a downloaded executable needs a provenance story this does not have. A name h5i knows but
 does not have answers with what the capability is and how to install it, rather
 than "unknown command". Installs are refused for names not on the known list,
 because a plugin directory anything can add a name to is a directory where
@@ -646,9 +649,10 @@ than precede it: the benchmark is what will say which of them are load-bearing.
 ### What a plugin is
 
 A separate executable, discovered by name the way `git` finds its subcommands.
-`h5i plugin install websec` fetches `h5i-websec` for this platform into a
-per-user plugin directory, and `h5i websec <verb>` execs it with the arguments
-forwarded and the environment that names the session. A build without the
+`h5i plugin install websec --from <path>` copies `h5i-websec` into a per-user
+plugin directory, and `h5i websec <verb>` execs it with the arguments forwarded
+and the environment that names the session. The release publishes the
+executable; fetching it by name is not built. A build without the
 plugin still knows the name: `h5i websec` prints what it is and how to install
 it, rather than an unknown-subcommand error, so the feature is discoverable
 without being present.

--- a/docs/design/design-websec.md
+++ b/docs/design/design-websec.md
@@ -53,8 +53,11 @@ h5i already funnels requests through one `Fetch` in
 and the outcome after it. Three things follow that a proxy cannot have:
 
 1. **Provenance.** The receipt carries an `Initiator` (`navigation`,
-   `subresource`, `frame`, `redirect`), and the action log beside it carries the
-   verb the agent asked for. A proxy sees a GET; h5i knows it was the third
+   `subresource`, `frame`, `redirect`, `replay`), and the action log beside it
+   carries the verb the agent asked for. `replay` is the workbench's own: a
+   reviewer separating what the application did from what the tester did is
+   asking that field, and a resend recorded as a navigation said the browser
+   had gone somewhere it never went. A proxy sees a GET; h5i knows it was the third
    redirect hop of a click on "Export".
 2. **No interception gap.** There is nothing to bypass. A request that is not in
    the log did not happen, which is the guarantee the whole product already

--- a/docs/design/design-websec.md
+++ b/docs/design/design-websec.md
@@ -204,6 +204,15 @@ Rules that have to be settled once:
   is an error naming the actual content type, not a coerced string. An edit
   whose path does not exist is an error unless `--set-create` is given, since a
   typo that silently no-ops is a wrong answer that looks right.
+- **An edit changes what it names and nothing else.** A `query.`, `form.` or
+  `cookie.` edit rewrites one piece of the string it lives in and leaves the
+  other pieces byte for byte, rather than decoding the whole thing and encoding
+  it again: `?debug` is not `?debug=`, `x[]=1` is not `x%5B%5D=1`, and a `Cookie`
+  header carrying a bare token still carries it afterwards. A `json.` edit is
+  the one that cannot manage that, because a structured JSON edit reserialises
+  the document; field order survives (`serde_json` is built with
+  `preserve_order` for exactly this) but whitespace does not, so a body whose
+  exact bytes are signed wants `body.raw` rather than `json.`.
 - **Raw is available and honest.** `--edits-file` accepts a `raw` key holding a
   whole request, in which case h5i sends the bytes given and reports which of
   its own invariants it had to break to do so.

--- a/docs/design/design-websec.md
+++ b/docs/design/design-websec.md
@@ -346,8 +346,11 @@ Bob's (it carried Alice's credential), and the answer would settle nothing.
 question, and a caller who wants one exact header can read it with `message` and
 set it with `--set`, which is a deliberate act rather than a default.
 
-The dropped names are printed, because a silent strip is a different request
-than the caller thinks they sent.
+The dropped names are reported, because a silent strip is a different request
+than the caller thinks they sent. In the reply as `credentials_dropped` and
+not only on the terminal: `--json` is how an agent reads this verb, and a
+note printed in the human view is a note the one reader who needs it cannot
+see.
 
 ### Stopping at a redirect
 

--- a/docs/design/design-websec.md
+++ b/docs/design/design-websec.md
@@ -123,6 +123,10 @@ exact bytes and headers, including credentials, so the artifacts stay separate.
 
 The format enforces an 8 MiB per-message cap, a 512 MiB session cap, and a MIME
 skip list for fonts and media. Truncated or skipped bodies have explicit states.
+The session cap counts the header sidecars as well as the bodies: a message
+file is not small, since the raw sender accepts a response head as large as the
+whole response cap, and counting only bodies left the directory unbounded in
+the one case the cap exists for.
 
 Built, 2026-09-02: `crates/h5i-browser/src/capture.rs`, reached by
 `h5i browser open --capture`. Messages land in `<session>/messages/` as one JSON

--- a/docs/man/man1/h5i.1
+++ b/docs/man/man1/h5i.1
@@ -1115,7 +1115,7 @@ End a session. Its record stays
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS SYNOPSIS
-\fBclose\fR [\fB\-s\fR|\fB\-\-session\fR] [\fB\-\-all\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBclose\fR [\fB\-s\fR|\fB\-\-session\fR] [\fB\-\-all\fR] [\fB\-\-capture\-drop\fR] [\fB\-\-json\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SS OPTIONS
@@ -1126,11 +1126,16 @@ Which session, when more than one is open. A name from `\-\-session` at open tim
 \fB\-\-all\fR
 End every live session on this machine
 .TP
+\fB\-\-capture\-drop\fR
+Delete the captured messages as well as ending the session.
+
+A `\-\-capture` store holds what the receipts deliberately do not: whole bodies, and `Cookie` and `Authorization` in full. The record and the request log stay either way, because those are the audit trail; this drops the evidence that is also a credential, once it is no longer being worked on.
+.TP
 \fB\-\-json\fR
 
 .TP
 \fB\-h\fR, \fB\-\-help\fR
-Print help
+Print help (see a summary with \*(Aq\-h\*(Aq)
 .SH "H5I BROWSER SNAPSHOT"
 The page as a model should read it: the outline, with `@ref` handles
 .ie \n(.g .ds Aq \(aq

--- a/docs/man/man1/h5i.1
+++ b/docs/man/man1/h5i.1
@@ -1714,7 +1714,7 @@ Only rows whose URL contains this
 Only responses with this status
 .TP
 \fB\-\-initiator\fR \fI<KIND>\fR
-Only `navigation`, `subresource`, `frame` or `redirect`
+Only `navigation`, `subresource`, `frame`, `redirect` or `replay`
 .TP
 \fB\-\-denied\-only\fR
 Only what policy refused

--- a/docs/man/man1/h5i.1
+++ b/docs/man/man1/h5i.1
@@ -1129,7 +1129,7 @@ End every live session on this machine
 \fB\-\-capture\-drop\fR
 Delete the captured messages as well as ending the session.
 
-A `\-\-capture` store holds what the receipts deliberately do not: whole bodies, and `Cookie` and `Authorization` in full. The record and the request log stay either way, because those are the audit trail; this drops the evidence that is also a credential, once it is no longer being worked on.
+The store holds whole bodies and `Cookie` and `Authorization` in full. The record and the request log stay either way.
 .TP
 \fB\-\-json\fR
 

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -1614,21 +1614,28 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
             // request holds credentials, and a verb's reply would carry them
             // out through a renderer.
             let mut argv = vec!["resend".to_string()];
+            // Named in the reply as well as on the terminal. A silent strip is
+            // a different request from the one the caller thinks they sent, and
+            // `--json` is how an agent reads this verb: printing the names only
+            // in the human view told the one reader who cannot see them.
+            let mut dropped: Vec<String> = Vec::new();
             match &as_session {
                 None => {
                     argv.push("--from".into());
                     argv.push(from.to_string());
                 }
                 Some(_) => {
-                    let (request, dropped) = super::websec::carry(
+                    let (request, left_behind) = super::websec::carry(
                         &root,
                         session.as_deref(),
                         from,
                         keep_credentials,
                     )?;
+                    dropped = left_behind;
                     if !dropped.is_empty() && !json {
                         println!(
-                            "  note     : {} left behind, so this is the other session's                              own request",
+                            "  note     : {} left behind, so this is the other session's \
+                             own request",
                             dropped.join(", ")
                         );
                     }
@@ -1700,6 +1707,9 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
                     && let Some(summary) = super::websec::timing_summary(samples)
                 {
                     answer["timing"] = summary;
+                }
+                if !dropped.is_empty() {
+                    answer["credentials_dropped"] = serde_json::json!(dropped);
                 }
                 Ok(())
             })

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -248,6 +248,15 @@ pub enum BrowserCommands {
         /// End every live session on this machine.
         #[arg(long, conflicts_with = "session")]
         all: bool,
+        /// Delete the captured messages as well as ending the session.
+        ///
+        /// A `--capture` store holds what the receipts deliberately do not:
+        /// whole bodies, and `Cookie` and `Authorization` in full. The record
+        /// and the request log stay either way, because those are the audit
+        /// trail; this drops the evidence that is also a credential, once it is
+        /// no longer being worked on.
+        #[arg(long = "capture-drop")]
+        capture_drop: bool,
         #[arg(long)]
         json: bool,
     },
@@ -1197,7 +1206,12 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
         ),
         BrowserCommands::List { all, json } => list(&root, all, json),
         BrowserCommands::Status { session, json } => status(&root, session.as_deref(), json),
-        BrowserCommands::Close { session, all, json } => close(&root, session.as_deref(), all, json),
+        BrowserCommands::Close {
+            session,
+            all,
+            capture_drop,
+            json,
+        } => close(&root, session.as_deref(), all, capture_drop, json),
 
         BrowserCommands::Snapshot {
             session,
@@ -3732,6 +3746,7 @@ fn close(
     root: &Path,
     selector: Option<&str>,
     all: bool,
+    capture_drop: bool,
     json: bool,
 ) -> anyhow::Result<()> {
     let targets: Vec<bs::Session> = if all {
@@ -3759,10 +3774,21 @@ fn close(
     }
 
     let mut closed = Vec::new();
+    let mut dropped: Vec<String> = Vec::new();
     for mut session in targets {
         if session.state.is_live() {
             stop_engine(&session)?;
             bs::end(root, &mut session, bs::State::Closed, "closed by the user");
+        }
+        // After the engine has stopped, so nothing is still writing into the
+        // directory being removed.
+        if capture_drop {
+            let store = bs::dir(root, &session.id).join(bs::MESSAGES_DIR);
+            match std::fs::remove_dir_all(&store) {
+                Ok(()) => dropped.push(session.id.clone()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => anyhow::bail!("{} could not be removed: {e}", store.display()),
+            }
         }
         if !json {
             println!(
@@ -3772,6 +3798,9 @@ fn close(
                 session.state.describe(),
                 bs::dir(root, &session.id).display()
             );
+            if dropped.last() == Some(&session.id) {
+                println!("  dropped  : its captured messages. The request log stays.");
+            }
         }
         closed.push(session);
     }

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -250,11 +250,8 @@ pub enum BrowserCommands {
         all: bool,
         /// Delete the captured messages as well as ending the session.
         ///
-        /// A `--capture` store holds what the receipts deliberately do not:
-        /// whole bodies, and `Cookie` and `Authorization` in full. The record
-        /// and the request log stay either way, because those are the audit
-        /// trail; this drops the evidence that is also a credential, once it is
-        /// no longer being worked on.
+        /// The store holds whole bodies and `Cookie` and `Authorization` in
+        /// full. The record and the request log stay either way.
         #[arg(long = "capture-drop")]
         capture_drop: bool,
         #[arg(long)]
@@ -1628,10 +1625,8 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
             // request holds credentials, and a verb's reply would carry them
             // out through a renderer.
             let mut argv = vec!["resend".to_string()];
-            // Named in the reply as well as on the terminal. A silent strip is
-            // a different request from the one the caller thinks they sent, and
-            // `--json` is how an agent reads this verb: printing the names only
-            // in the human view told the one reader who cannot see them.
+            // In the reply as well as on the terminal: `--json` is how an
+            // agent reads this verb, and a silent strip is a different request.
             let mut dropped: Vec<String> = Vec::new();
             match &as_session {
                 None => {
@@ -1717,8 +1712,7 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
             // With one send there is nothing to summarise and the reply is the
             // answer. With several, the medians go in beside the samples.
             verb_then(&root, target, argv, true, json, |answer, _refused| {
-                // On a refusal too: a burst that half happened is exactly when
-                // "how many of these were answered" is the question.
+                // On a refusal too: that is when the count matters most.
                 if let Some(samples) = answer.get("samples").and_then(Value::as_array)
                     && let Some(summary) = super::websec::timing_summary(samples)
                 {
@@ -2921,8 +2915,7 @@ fn screenshot(
     let moves_the_page = argv.iter().any(|a| a == "--url");
 
     verb_then(root, selector, argv, moves_the_page, json, |answer, refused| {
-        // Nothing was painted, so there is nothing to move and nowhere to
-        // point a caller.
+        // Nothing was painted, so there is nothing to move.
         if refused {
             return Ok(());
         }
@@ -3135,11 +3128,9 @@ fn verb_then(
     // script that checks the status code would read "denied by policy" as
     // success, which is the failure this whole design is arranged against.
     let refused = answer.get("ok").and_then(Value::as_bool) == Some(false);
-    // The hook runs either way and is told which it is. It used to be skipped
-    // on a refusal, which is right for one that moves a file and wrong for one
-    // that only annotates: a `--repeat` burst the budget stopped halfway came
-    // back with a hundred samples, no summary, and so no way to see that only
-    // twelve of them had happened. Each hook decides for itself now.
+    // The hook runs either way and is told which it is. Skipping it on a
+    // refusal is right for one that moves a file and wrong for one that only
+    // annotates: a burst stopped halfway came back with samples and no summary.
     after(&mut answer, refused)?;
 
     if json {
@@ -3679,12 +3670,9 @@ fn status(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()>
             "the engine stopped answering",
         );
     }
-    // What the engine knows and the record cannot: how the message store is
-    // doing. `errors` there is the only signal that the evidence an agent is
-    // about to read has a hole in it — the messages that *are* stored look no
-    // different either way — and it was computed, documented and shown by no
-    // verb at all. Best-effort and only while the session is live, because
-    // `status` answers about ended sessions too and must not need an engine.
+    // What the engine knows and the record cannot. `errors` is the only signal
+    // that the stored evidence has a hole in it. Best-effort and live-only,
+    // because `status` answers about ended sessions too.
     let health = session
         .state
         .is_live()
@@ -3820,8 +3808,7 @@ fn close(
             stop_engine(&session)?;
             bs::end(root, &mut session, bs::State::Closed, "closed by the user");
         }
-        // After the engine has stopped, so nothing is still writing into the
-        // directory being removed.
+        // After the engine has stopped, so nothing is still writing there.
         if capture_drop {
             let store = bs::dir(root, &session.id).join(bs::MESSAGES_DIR);
             match std::fs::remove_dir_all(&store) {
@@ -3856,13 +3843,10 @@ fn close(
 /// reviewer most wants to audit is usually the one that has already ended.
 /// The session a *reader* means, live or not.
 ///
-/// `resolve` answers for the verbs that act, so a name only ever finds a live
-/// session — which is right for a click and wrong for every verb whose subject
-/// is usually the run that just finished. `status`, `audit` and the whole
-/// websec surface (`message`, `diff`, `match`, `sitemap`) read a record and a
-/// store that both outlive the engine, and asking for them by the name the
-/// session was opened with answered "no such session": the caller had to know
-/// the opaque id, for evidence `close` had just promised was still there.
+/// `resolve` answers for the verbs that act, so a name only finds a live
+/// session. The readers — `status`, `audit`, and the websec surface — work on a
+/// record and a store that outlive the engine, and asking by name answered "no
+/// such session" for evidence `close` had just promised was still there.
 pub(crate) fn resolve_for_reading(
     root: &Path,
     selector: Option<&str>,

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -762,7 +762,7 @@ pub enum BrowserCommands {
         /// Only responses with this status.
         #[arg(long, value_name = "CODE")]
         status: Option<u16>,
-        /// Only `navigation`, `subresource`, `frame` or `redirect`.
+        /// Only `navigation`, `subresource`, `frame`, `redirect` or `replay`.
         #[arg(long, value_name = "KIND")]
         initiator: Option<String>,
         /// Only what policy refused.

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -1716,7 +1716,9 @@ pub fn run(action: BrowserCommands) -> anyhow::Result<()> {
             let target = as_session.as_deref().or(session.as_deref());
             // With one send there is nothing to summarise and the reply is the
             // answer. With several, the medians go in beside the samples.
-            verb_then(&root, target, argv, true, json, |answer| {
+            verb_then(&root, target, argv, true, json, |answer, _refused| {
+                // On a refusal too: a burst that half happened is exactly when
+                // "how many of these were answered" is the question.
                 if let Some(samples) = answer.get("samples").and_then(Value::as_array)
                     && let Some(summary) = super::websec::timing_summary(samples)
                 {
@@ -2918,7 +2920,12 @@ fn screenshot(
     // control lock exists so a human at the wheel is not steered from under.
     let moves_the_page = argv.iter().any(|a| a == "--url");
 
-    verb_then(root, selector, argv, moves_the_page, json, |answer| {
+    verb_then(root, selector, argv, moves_the_page, json, |answer, refused| {
+        // Nothing was painted, so there is nothing to move and nowhere to
+        // point a caller.
+        if refused {
+            return Ok(());
+        }
         let Some(out) = out else {
             return Ok(());
         };
@@ -2993,7 +3000,7 @@ fn verb(
     mutating: bool,
     json: bool,
 ) -> anyhow::Result<()> {
-    verb_then(root, selector, argv, mutating, json, |_| Ok(()))
+    verb_then(root, selector, argv, mutating, json, |_, _| Ok(()))
 }
 
 /// The same, with something to do to the answer before it is printed.
@@ -3078,7 +3085,7 @@ fn verb_then(
     argv: Vec<String>,
     mutating: bool,
     json: bool,
-    after: impl FnOnce(&mut Value) -> anyhow::Result<()>,
+    after: impl FnOnce(&mut Value, bool) -> anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     let session = match bs::resolve(root, selector) {
         Ok(session) => session,
@@ -3128,9 +3135,12 @@ fn verb_then(
     // script that checks the status code would read "denied by policy" as
     // success, which is the failure this whole design is arranged against.
     let refused = answer.get("ok").and_then(Value::as_bool) == Some(false);
-    if !refused {
-        after(&mut answer)?;
-    }
+    // The hook runs either way and is told which it is. It used to be skipped
+    // on a refusal, which is right for one that moves a file and wrong for one
+    // that only annotates: a `--repeat` burst the budget stopped halfway came
+    // back with a hundred samples, no summary, and so no way to see that only
+    // twelve of them had happened. Each hook decides for itself now.
+    after(&mut answer, refused)?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&answer)?);

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -3668,18 +3668,7 @@ fn list(root: &Path, all: bool, json: bool) -> anyhow::Result<()> {
 fn status(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()> {
     // Not `resolve`: a status on a session that has ended is exactly the
     // question worth answering, so this reads the record rather than refusing.
-    let mut session = match bs::resolve(root, selector) {
-        Ok(session) => session,
-        Err(bs::SessionGone::Ended { id, .. }) => bs::read(root, &id)?,
-        // A name only ever resolves to a *live* session, so a closed one asked
-        // for by the name it was opened with arrived here as "no such session".
-        // Which is the one question this verb exists to answer, and `close`
-        // itself says the record stays — the caller has the name, not the id.
-        Err(gone) => match selector.and_then(|name| bs::find_ended_by_name(root, name)) {
-            Some(ended) => ended,
-            None => anyhow::bail!("{gone}"),
-        },
-    };
+    let mut session = resolve_for_reading(root, selector)?;
     let id = &session.id.clone();
     // Reading status is the moment to notice a death and write it down.
     if session.state.is_live() && !session.probe() {
@@ -3865,12 +3854,31 @@ fn close(
 ///
 /// Reads the record rather than requiring a live session: the session a
 /// reviewer most wants to audit is usually the one that has already ended.
+/// The session a *reader* means, live or not.
+///
+/// `resolve` answers for the verbs that act, so a name only ever finds a live
+/// session — which is right for a click and wrong for every verb whose subject
+/// is usually the run that just finished. `status`, `audit` and the whole
+/// websec surface (`message`, `diff`, `match`, `sitemap`) read a record and a
+/// store that both outlive the engine, and asking for them by the name the
+/// session was opened with answered "no such session": the caller had to know
+/// the opaque id, for evidence `close` had just promised was still there.
+pub(crate) fn resolve_for_reading(
+    root: &Path,
+    selector: Option<&str>,
+) -> anyhow::Result<bs::Session> {
+    match bs::resolve(root, selector) {
+        Ok(session) => Ok(session),
+        Err(bs::SessionGone::Ended { id, .. }) => Ok(bs::read(root, &id)?),
+        Err(gone) => match selector.and_then(|name| bs::find_ended_by_name(root, name)) {
+            Some(ended) => Ok(ended),
+            None => anyhow::bail!("{gone}"),
+        },
+    }
+}
+
 fn audit(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()> {
-    let session = match bs::resolve(root, selector) {
-        Ok(session) => session,
-        Err(bs::SessionGone::Ended { id, .. }) => bs::read(root, &id)?,
-        Err(gone) => anyhow::bail!("{gone}"),
-    };
+    let session = resolve_for_reading(root, selector)?;
     let audit = bs::audit(root, &session);
 
     if json {

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -3982,6 +3982,8 @@ fn availability(a: bs::Availability) -> console::StyledObject<&'static str> {
         // The one that must stand out: nothing can be concluded from the
         // silence of a log h5i could not read.
         bs::Availability::Unavailable => style(a.as_str()).red(),
+        // Nor from the end of one that was cut short.
+        bs::Availability::Partial => style(a.as_str()).yellow(),
     }
 }
 

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -3683,10 +3683,27 @@ fn status(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()>
             "the engine stopped answering",
         );
     }
+    // What the engine knows and the record cannot: how the message store is
+    // doing. `errors` there is the only signal that the evidence an agent is
+    // about to read has a hole in it — the messages that *are* stored look no
+    // different either way — and it was computed, documented and shown by no
+    // verb at all. Best-effort and only while the session is live, because
+    // `status` answers about ended sessions too and must not need an engine.
+    let health = session
+        .state
+        .is_live()
+        .then(|| deliver(&session, &bs::dir(root, id), vec!["status".to_string()]).ok())
+        .flatten()
+        .and_then(|reply| reply.get("capture").cloned())
+        .filter(|capture| !capture.is_null());
+
     if json {
         let control = h5i_core::control::read(&bs::dir(root, id));
         let mut value = serde_json::to_value(&session)?;
         value["control_lock"] = serde_json::to_value(&control)?;
+        if let Some(health) = health {
+            value["capture"] = health;
+        }
         println!("{}", serde_json::to_string_pretty(&value)?);
         return Ok(());
     }
@@ -3711,6 +3728,23 @@ fn status(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()>
              (`h5i browser snapshot`)",
             style("stale").yellow()
         );
+    }
+    if let Some(health) = &health {
+        let number = |key: &str| health.get(key).and_then(Value::as_u64).unwrap_or(0);
+        let errors = number("errors");
+        let line = format!(
+            "{} messages, {} bytes",
+            number("messages"),
+            number("bytes")
+        );
+        if errors > 0 {
+            println!(
+                "  captured : {line}, and {} it could not write — the store has a hole in it",
+                style(errors).red()
+            );
+        } else {
+            println!("  captured : {line}");
+        }
     }
     if let Some(reason) = &session.end_reason {
         println!("  ended    : {} — {}", session.state.as_str(), reason);

--- a/src/cli/browser.rs
+++ b/src/cli/browser.rs
@@ -3671,7 +3671,14 @@ fn status(root: &Path, selector: Option<&str>, json: bool) -> anyhow::Result<()>
     let mut session = match bs::resolve(root, selector) {
         Ok(session) => session,
         Err(bs::SessionGone::Ended { id, .. }) => bs::read(root, &id)?,
-        Err(gone) => anyhow::bail!("{gone}"),
+        // A name only ever resolves to a *live* session, so a closed one asked
+        // for by the name it was opened with arrived here as "no such session".
+        // Which is the one question this verb exists to answer, and `close`
+        // itself says the record stays — the caller has the name, not the id.
+        Err(gone) => match selector.and_then(|name| bs::find_ended_by_name(root, name)) {
+            Some(ended) => ended,
+            None => anyhow::bail!("{gone}"),
+        },
     };
     let id = &session.id.clone();
     // Reading status is the moment to notice a death and write it down.

--- a/src/cli/plugin.rs
+++ b/src/cli/plugin.rs
@@ -135,7 +135,10 @@ pub fn not_installed(name: &str) -> String {
          It is not part of the default build on purpose: h5i ships a browser, and \
          an install should not quietly include everything that could be built on \
          one. Adding it is a deliberate act.\n\n  \
-         Build it and install it with:\n    \
+         Download `h5i-{name}` for this platform from the release and install \
+         it:\n    \
+         h5i plugin install {name} --from ./h5i-{name}\n\n  \
+         Or build it first:\n    \
          cargo build --release -p h5i-{name}\n    \
          h5i plugin install {name} --from target/release/h5i-{name}\n\n  \
          `h5i plugin list` shows what is installed."

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use h5i_browser::capture::{Body, StoredRequest, StoredResponse};
+use h5i_browser::capture::{body_file, Body, StoredRequest, StoredResponse};
 use h5i_core::browser_session as bs;
 use serde_json::{json, Value};
 
@@ -113,7 +113,7 @@ fn body_bytes(dir: &Path, body: &Body) -> Option<Vec<u8>> {
     match body {
         Body::Empty => Some(Vec::new()),
         Body::Skipped { .. } => None,
-        Body::Stored { sha256, .. } => std::fs::read(dir.join("bodies").join(sha256)).ok(),
+        Body::Stored { sha256, .. } => std::fs::read(body_file(dir, sha256)?).ok(),
     }
 }
 
@@ -129,7 +129,11 @@ fn body_text(dir: &Path, body: &Body) -> Text {
             (reason, None) => format!("{reason:?}").to_lowercase(),
         }),
         Body::Stored { sha256, bytes, .. } => {
-            let path = dir.join("bodies").join(sha256);
+            let Some(path) = body_file(dir, sha256) else {
+                return Text::Missing(format!(
+                    "{sha256:?} is not a body hash, so the store has nothing under it"
+                ));
+            };
             match std::fs::read(&path) {
                 Err(e) => Text::Missing(format!("the stored body could not be read: {e}")),
                 Ok(raw) => match String::from_utf8(raw) {
@@ -467,8 +471,12 @@ pub fn carry(
 
     let body = match body_text(&dir, &stored.body) {
         Text::Utf8(text) => text.into_bytes(),
-        Text::Binary { sha256, .. } => std::fs::read(dir.join("bodies").join(&sha256))
-            .map_err(|e| anyhow::anyhow!("the stored body could not be read: {e}"))?,
+        Text::Binary { sha256, .. } => {
+            let path = body_file(&dir, &sha256)
+                .ok_or_else(|| anyhow::anyhow!("{sha256:?} is not a body hash"))?;
+            std::fs::read(path)
+                .map_err(|e| anyhow::anyhow!("the stored body could not be read: {e}"))?
+        }
         Text::Missing(why) => {
             anyhow::bail!("request {seq}'s body is not in the store ({why}), so it cannot be carried")
         }
@@ -1656,6 +1664,34 @@ pub fn sequence(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A session that runs in a box keeps its store on a filesystem the boxed
+    /// code can write to, so the hash a message sidecar names is target input
+    /// like everything else in there. Joined unchecked, `../` in that field
+    /// read a host file and handed it back as a captured body — and `resend`
+    /// would then have sent it to the target.
+    #[test]
+    fn a_body_hash_that_is_not_one_names_nothing_in_the_store() {
+        let dir = std::env::temp_dir().join(format!(
+            "h5i-websec-hash-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(dir.join("bodies")).expect("a store");
+        std::fs::write(dir.join("outside.txt"), b"host secret").expect("a file beside it");
+        let escaped = Body::Stored {
+            sha256: "../outside.txt".to_string(),
+            bytes: 11,
+            of_bytes: None,
+            truncated: false,
+        };
+        match body_text(&dir, &escaped) {
+            Text::Missing(why) => assert!(why.contains("not a body hash"), "{why}"),
+            read => panic!("read outside the store: {read:?}"),
+        }
+        assert_eq!(body_bytes(&dir, &escaped), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     fn response(status: u16, kind: &str) -> StoredResponse {
         StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -20,11 +20,10 @@ pub enum Part {
 
 /// Where a session's messages are, or why they cannot be read.
 fn store_dir(root: &Path, selector: Option<&str>) -> anyhow::Result<(bs::Session, PathBuf)> {
-    let session = match bs::resolve(root, selector) {
-        Ok(session) => session,
-        Err(bs::SessionGone::Ended { id, .. }) => bs::read(root, &id)?,
-        Err(gone) => anyhow::bail!("{gone}"),
-    };
+    // Live or ended: a store outlives its engine, and reading one after the run
+    // is the ordinary case rather than the exception. See
+    // [`super::browser::resolve_for_reading`].
+    let session = super::browser::resolve_for_reading(root, selector)?;
     // The id off the record, checked before it names a directory: for a boxed
     // session that file sits where the boxed code can write to it, and
     // everything under a session directory is addressed by joining onto this.
@@ -1690,17 +1689,35 @@ pub fn map_of(records: &[Value]) -> Map {
 
 /// `h5i browser sitemap`.
 pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::Result<()> {
-    let answer = super::browser::ask_session(
-        root,
-        selector,
-        vec!["requests".to_string()],
-        false,
-    )?;
-    let empty = Vec::new();
-    let records = answer
-        .get("requests")
-        .and_then(Value::as_array)
-        .unwrap_or(&empty);
+    // From the engine while there is one, and off the log on disk once there is
+    // not. The map of a finished run is the one a reviewer wants, and asking
+    // the engine for it meant closing the session took the site map with it.
+    // The log outlives the engine — that is what `close` means by "its record
+    // stays" — and each of its lines is the record `map_of` already reads.
+    let session = super::browser::resolve_for_reading(root, selector)?;
+    let owned: Vec<Value>;
+    let answer;
+    let records: &[Value] = if session.state.is_live() {
+        answer = super::browser::ask_session(
+            root,
+            selector,
+            vec!["requests".to_string()],
+            false,
+        )?;
+        answer
+            .get("requests")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    } else {
+        let path = bs::dir(root, &session.id).join(bs::RECEIPTS_FILE);
+        owned = bs::read_log_capped(&path)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .collect();
+        &owned
+    };
     let map = map_of(records);
 
     if json_out {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -2023,7 +2023,25 @@ pub fn sequence(
         if !step.extract.is_empty() {
             let target = step.as_session.as_deref().or(selector);
             let (_, dir) = store_dir(root, target)?;
-            let seq = record.seq.unwrap_or_default();
+            // The step's own answer, or nothing. Defaulting a missing sequence
+            // number to zero read message 0 instead — the session's first
+            // request, usually the navigation that opened it — and bound the
+            // token, the flag or the CSRF value out of a response that belongs
+            // to a different message. A wrong answer that looks right, in the
+            // verb whose whole job is to carry one step's answer into the next.
+            let Some(seq) = record.seq else {
+                record.error = Some(format!(
+                    "step {index} came back without a sequence number, so there is no \
+                     answer of its own to extract from"
+                ));
+                record.ok = false;
+                failed = true;
+                ran.push(record);
+                if !keep_going {
+                    break;
+                }
+                continue;
+            };
             let stored: StoredResponse =
                 read_json(&dir.join(format!("{seq}.response.json"))).map_err(|_| {
                     anyhow::anyhow!("step {index} left no stored response {seq} to extract from")

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -20,13 +20,10 @@ pub enum Part {
 
 /// Where a session's messages are, or why they cannot be read.
 fn store_dir(root: &Path, selector: Option<&str>) -> anyhow::Result<(bs::Session, PathBuf)> {
-    // Live or ended: a store outlives its engine, and reading one after the run
-    // is the ordinary case rather than the exception. See
-    // [`super::browser::resolve_for_reading`].
+    // Live or ended: a store outlives its engine.
     let session = super::browser::resolve_for_reading(root, selector)?;
-    // The id off the record, checked before it names a directory: for a boxed
-    // session that file sits where the boxed code can write to it, and
-    // everything under a session directory is addressed by joining onto this.
+    // A boxed session's record sits where boxed code can write it, and this id
+    // becomes a path.
     if !bs::id_is_one_component(&session.id) {
         anyhow::bail!(
             "session record names `{}` as its id, which is not one this registry could \
@@ -84,12 +81,9 @@ pub enum Text {
     Utf8(String),
     /// Decoded, and only the head of what the response carried.
     ///
-    /// The store keeps at most [`h5i_browser::capture::MAX_BODY_BYTES`] of one
-    /// body, so a response past that is text this can read and cannot read all
-    /// of. Distinct from [`Text::Utf8`] because every verb here turns on the
-    /// difference: a search that finds nothing in the head has said nothing
-    /// about the rest, and a length read off the head is the cap's number, not
-    /// the body's. Eight megabytes is a page a target can serve on purpose.
+    /// Its own state because every verb here turns on the difference: a search
+    /// over the head says nothing about the rest, and its length is the cap's
+    /// number rather than the body's.
     Cut {
         text: String,
         /// How many bytes the response actually carried.
@@ -108,14 +102,9 @@ pub enum Text {
 impl Text {
     /// How many bytes the body actually had.
     ///
-    /// Not `as_str().len()`, which for a body that is not UTF-8 is the length
-    /// of a 64 KiB lossy *preview*. One invalid byte anywhere in a response is
-    /// enough to put it on that path, so a length verdict read off the preview
-    /// is a number a target can choose: pad past 64 KiB and every
-    /// `--longer-than` and `--shorter-than` answers about the cap instead of
-    /// about the page.
-    ///
-    /// `None` when the body is not in the store, which is not a length of zero.
+    /// Not `as_str().len()`: one invalid byte puts a response on the preview
+    /// path, and a length read off a 64 KiB preview is a number the target
+    /// chose. `None` when the body is not stored, which is not a length of zero.
     fn len(&self) -> Option<u64> {
         match self {
             Text::Utf8(text) => Some(text.len() as u64),
@@ -125,11 +114,8 @@ impl Text {
         }
     }
 
-    /// Whether [`Text::as_str`] is the whole body or only the head of it.
-    ///
-    /// A body that is not UTF-8 is read back as a lossy preview of its first
-    /// [`LOSSY_BODY_BYTES`], so a search over it that finds nothing has looked
-    /// at part of the response and can say nothing about the rest.
+    /// Whether [`Text::as_str`] is the whole body or only its head. A search
+    /// over part of a body cannot answer "not there".
     fn whole(&self) -> bool {
         match self {
             Text::Utf8(_) => true,
@@ -169,19 +155,11 @@ impl Text {
 
 /// Target text with what a terminal would act on made visible instead.
 ///
-/// Every string in this module that came off the wire is printed to a terminal
-/// by the human view: a header value, a body line, a captured group, a query
-/// parameter name. An escape sequence in one of them repaints the screen —
-/// it can erase the line naming which request this was, or draw a status that
-/// never arrived, which is the one thing a workbench must not let a target do
-/// to the report of what the target did.
-///
-/// Escaped rather than dropped, so a `\u{1b}` in a response is still visible as
-/// one, and still countable. Bidi controls go the same way: `char::is_control`
-/// is false for every one of them and they reorder the line around them without
-/// being seen. `--raw`, `--body-to` and `--json` are untouched, and that is
-/// where exact bytes belong: the first two are the byte channels, and JSON
-/// escapes a control character on the way out by itself.
+/// The human view prints strings the target wrote; an escape in one repaints
+/// the report of what the target did. Escaped rather than dropped, so it stays
+/// visible. Bidi controls go too: they are not `is_control` and reorder the
+/// line around them. `--raw`, `--body-to` and `--json` are the byte channels
+/// and are untouched.
 fn printable(text: &str) -> String {
     if !text
         .chars()
@@ -201,10 +179,7 @@ fn printable(text: &str) -> String {
 }
 
 /// Bidirectional formatting characters, which reorder the text *around* them.
-///
-/// The overrides, embeddings and isolates only; `U+200C`/`U+200D` carry no
-/// reordering power and are ordinary text. The same set the engine drops from
-/// page text in `snapshot.rs`.
+/// Overrides, embeddings and isolates only, as `snapshot.rs` drops from page text.
 fn is_bidi_control(c: char) -> bool {
     matches!(c,
         '\u{200E}' | '\u{200F}'
@@ -247,11 +222,8 @@ fn body_text(dir: &Path, body: &Body) -> Text {
             match std::fs::read(&path) {
                 Err(e) => Text::Missing(format!("the stored body could not be read: {e}")),
                 Ok(raw) => match String::from_utf8(raw) {
-                    // Text, and whether it is all of the text. A body past the
-                    // store's per-message cap is kept as its head, and a cut
-                    // that lands on a character boundary — which for an ASCII
-                    // or HTML page is every cut — still decodes cleanly, so
-                    // this used to be indistinguishable from a whole body.
+                    // A cut on a character boundary — every cut, for ASCII —
+                    // decodes cleanly, so the head used to look like a body.
                     Ok(text) if *truncated => Text::Cut {
                         of_bytes: of_bytes.unwrap_or(text.len() as u64),
                         text,
@@ -422,10 +394,8 @@ pub fn show(
         })?;
         std::fs::write(path, &bytes)
             .map_err(|e| anyhow::anyhow!("{} could not be written: {e}", path.display()))?;
-        // Whether this file is the body or the head of it. This is the exact
-        // byte channel — the one every other view points a caller at when it
-        // has had to bound something — so a body the store cut has to say so
-        // here rather than hand over a shorter file and a byte count.
+        // The exact byte channel every bounded view points at, so a body the
+        // store cut has to say so rather than hand over a shorter file.
         let of_bytes = match body {
             Body::Stored {
                 truncated: true,
@@ -539,11 +509,8 @@ pub fn show(
 
 /// How much of one line a preview shows.
 ///
-/// The line *count* was bounded and the line *length* was not, so a minified
-/// page — one line, no newlines, megabytes of it — printed whole: into a
-/// terminal, or into the context of the agent that asked. The body diff has
-/// always cut its lines here; this is the same number, for the same reason.
-/// `--raw` and `--body-to` are where the exact bytes live.
+/// The line count was bounded and the length was not, so a minified page — one
+/// line, megabytes of it — printed whole. The same number the body diff cuts at.
 const MAX_PREVIEW_LINE: usize = 400;
 
 /// One line of a body, bounded and inert.
@@ -616,10 +583,8 @@ fn header_is_the_users(name: &str) -> bool {
 
 /// The exact body to send again, or why there is not one.
 ///
-/// The truncation rule is the in-session resend's, kept here so the two cannot
-/// disagree: a body the store had to cut short is not the body that was sent,
-/// and carrying it into another session would put a request on the wire that
-/// nobody recorded, then read the answer as a replay of one that was.
+/// The in-session resend's truncation rule, kept here so the two cannot
+/// disagree: a body the store cut short is not the body that was sent.
 fn carried_body(dir: &Path, seq: u64, body: &Body) -> anyhow::Result<Vec<u8>> {
     if let Body::Stored { truncated: true, .. } = body {
         anyhow::bail!(
@@ -629,8 +594,8 @@ fn carried_body(dir: &Path, seq: u64, body: &Body) -> anyhow::Result<Vec<u8>> {
     }
     match body_text(dir, body) {
         Text::Utf8(text) => Ok(text.into_bytes()),
-        // Unreachable while the check above stands, and spelled out rather than
-        // folded into a catch-all so that a change to that check fails here.
+        // Unreachable while the check above stands; spelled out so a change
+        // to it fails here.
         Text::Cut { of_bytes, .. } => anyhow::bail!(
             "request {seq} carried {of_bytes} bytes and the store kept only its head, so \
              carrying it would send a request that is not the one recorded"
@@ -717,24 +682,17 @@ pub struct Difference {
     pub similarity: f64,
     /// Whether there were two bodies to compare at all.
     ///
-    /// A body that is not in the store reads as the empty string, so two
-    /// responses whose bodies were skipped compared as identical: `same`,
-    /// `similarity` 1.0, nothing to see. That is the mistake `match` refuses to
-    /// make, and it is reachable on purpose — the store refuses new bodies once
-    /// it is full, and a target that answers with 512 MiB of anything, or
-    /// serves its pages as `font/woff`, turns every later comparison into
-    /// "these are the same page". The oracle then says "false page" for every
-    /// candidate character, which is the shape of a finding that is not there.
+    /// An unstored body reads as the empty string, so two of them compared as
+    /// identical. Reachable on purpose: fill the store, or serve pages as
+    /// `font/woff`, and every later comparison says "the same page".
     pub bodies_compared: bool,
     pub headers_added: Vec<String>,
     pub headers_removed: Vec<String>,
     pub headers_changed: Vec<String>,
     /// Changed body fields, when both bodies are JSON. Keyed by dotted path.
     pub json_changes: Vec<JsonChange>,
-    /// How many there were, when the list above is only the first of them.
-    ///
-    /// The lists are capped so one reply cannot be a whole page, and a cap that
-    /// did not say so was a diff reporting part of itself as all of itself.
+    /// How many there were, when the list above is only the first of them. A
+    /// cap that says nothing is a partial diff shaped like a complete one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub json_changes_of: Option<usize>,
     /// Changed lines, when they are not.
@@ -808,19 +766,16 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
     // Two bodies, or none of this is a comparison. `Text::Missing` reads as the
     // empty string, which made "neither body was kept" indistinguishable from
     // "both bodies were empty".
-    // Whole bodies, or none of this is a comparison. `Text::Missing` reads as
-    // the empty string, which made "neither body was kept" indistinguishable
-    // from "both bodies were empty"; a body that is not UTF-8 reads as the head
-    // of itself, which made two different large responses look identical.
+    // Whole bodies, or none of this is a comparison: an unstored one reads as
+    // empty and a previewed one as its own head.
     let bodies_compared = a_body.whole() && b_body.whole();
     let left_text = a_body.as_str();
     let right_text = b_body.as_str();
     let (json_changes, json_total, line_changes, line_total) =
         body_changes(a, b, left_text, right_text);
 
-    // The bodies' own lengths, not the previews'. A body that is not UTF-8
-    // reaches `as_str` as at most 64 KiB, so `length_delta` — a headline
-    // verdict field — read zero for any two binary responses past the cap.
+    // The bodies' own lengths, not the previews': `length_delta` read zero for
+    // any two binary responses past the 64 KiB cap.
     let bytes = (
         a_body.len().unwrap_or_default(),
         b_body.len().unwrap_or_default(),
@@ -836,8 +791,7 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
         status_changed: a.status != b.status,
         bytes,
         length_delta: bytes.1 as i64 - bytes.0 as i64,
-        // Zero rather than one, so a caller that reads the number without the
-        // flag beside it errs towards looking again.
+        // Zero rather than one, so a caller ignoring the flag looks again.
         similarity: if bodies_compared {
             similarity(left_text, right_text)
         } else {
@@ -891,11 +845,8 @@ fn body_changes(
 
 /// Field-by-field, so a re-ordered object is not a difference.
 /// Every difference between two documents, pushing at most [`MAX_JSON_CHANGES`]
-/// of them and counting all of them in `total`.
-///
-/// Counted rather than stopped at. Returning as soon as the list was full meant
-/// the walk itself ended there, so "how many changed" and "how many are listed"
-/// were the same number and a capped diff could not say it had been capped.
+/// and counting all of them in `total`. Stopping the walk at the cap made those
+/// two numbers equal, so a capped diff could not say it had been capped.
 fn walk_json(
     path: &str,
     left: &Value,
@@ -978,10 +929,8 @@ fn walk_json(
 /// two HTML documents, which is the wrong cost for a loop.
 /// The changed lines, and how many there were before the cap.
 ///
-/// Both sides are cut, not just the tail. The list used to be every addition
-/// followed by every removal and then truncated, so a response with sixty new
-/// lines reported no removals at all — and "this line is gone" is as much of an
-/// answer as "this line is new".
+/// Both sides are cut, not just the tail: additions came first and truncating
+/// the end meant sixty new lines reported no removals at all.
 fn line_changes(left: &str, right: &str) -> (Vec<LineChange>, usize) {
     let before: BTreeSet<&str> = left.lines().collect();
     let after: BTreeSet<&str> = right.lines().collect();
@@ -1007,8 +956,7 @@ fn line_changes(left: &str, right: &str) -> (Vec<LineChange>, usize) {
     }
     let total = added.len() + removed.len();
     if total > MAX_LINE_CHANGES {
-        // Half each, and whatever the shorter side does not use goes to the
-        // longer one, so the cap costs a lopsided diff nothing.
+        // Half each, with the shorter side's unused share going to the longer.
         let half = MAX_LINE_CHANGES / 2;
         let keep_added = if removed.len() < half {
             MAX_LINE_CHANGES - removed.len()
@@ -1072,12 +1020,8 @@ pub fn diff(
     let (b, b_body) = read(right)?;
     let difference = compare((&a, &a_body), (&b, &b_body));
 
-    // The same discipline `match` applies, and the same division: a body that
-    // is not in the store, or is only previewed, cannot be compared, and a
-    // number reported anyway would be an absence wearing a measurement's name.
-    // The status and the headers are still real, so they are still reported —
-    // what changes is the exit code, so a script cannot read this as a clean
-    // answer the way it reads a real one.
+    // The division `match` makes: the status and headers are real and still
+    // reported; only the exit code says the bodies could not be compared.
     let unanswerable = |seq: u64, body: &Text| match body {
         Text::Missing(reason) => Some(format!("{seq}'s body is not in the store ({reason})")),
         Text::Binary { bytes, .. } if !body.whole() => Some(format!(
@@ -1143,8 +1087,7 @@ pub fn diff(
         let mark = if change.side == "added" { '+' } else { '-' };
         println!("  {mark} {}", printable(&change.text));
     }
-    // Said, not implied. A capped list that reads as the whole answer is a
-    // partial diff wearing a complete one's shape.
+    // Said, not implied.
     if let Some(total) = difference.json_changes_of {
         println!(
             "  … {} more changed fields not listed",
@@ -1216,12 +1159,8 @@ pub struct Found {
     /// is running a match and reading this.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub captures: Vec<String>,
-    /// Whether this condition could be answered at all.
-    ///
-    /// A `false` here is never a "no": a pattern that does not compile, or a
-    /// body search that only had the head of the body to search. `matches`
-    /// turns it into the "could not look" exit rather than the "did not match"
-    /// one, which is the whole discipline of this verb.
+    /// Whether this condition could be answered at all. `false` is never a
+    /// "no", and `matches` turns it into the "could not look" exit.
     pub conclusive: bool,
 }
 
@@ -1269,8 +1208,7 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
                             }
                         })
                         .unwrap_or_default(),
-                    // A miss over part of a body is not a miss. See
-                    // [`Text::whole`].
+                    // A miss over part of a body is not a miss.
                     conclusive: hit || body.whole(),
                 }
             }
@@ -1448,9 +1386,7 @@ fn look(
         .iter()
         .map(|condition| evaluate(condition, &stored, &body))
         .collect();
-    // "Could not look" is read off the condition rather than sniffed out of its
-    // rendered text: a pattern that did not compile said so in `expr`, and a
-    // search that only had the head of a body to search said nothing at all.
+    // Read off the condition rather than sniffed out of its rendered text.
     let could_not_look = found.iter().any(|f| !f.conclusive);
     let matched = found.iter().all(|f| f.matched);
 
@@ -1472,11 +1408,8 @@ fn look(
                 one.expr
             );
             for capture in &one.captures {
-                // Bounded in the human view for the reason a body line is: the
-                // target chooses how much text sits between a pattern's
-                // anchors, so `--regex 'flag=(.*)'` over a one-line page
-                // captures the page. `--json` still carries it whole, because
-                // that is the channel a script reads a token out of.
+                // The target chooses how much page sits between a pattern's
+                // anchors. `--json` still carries it whole, for tokens.
                 println!("      {}", preview_line(capture));
             }
         }
@@ -1526,13 +1459,9 @@ pub fn timing_summary(samples: &[Value]) -> Option<Value> {
     if samples.len() < 2 {
         return None;
     }
-    // Only the sends a server answered. A send that never reached the wire —
-    // refused by policy, or by the budget running out partway through a
-    // `--repeat` — still carries a clock, and that clock measures the refusal:
-    // near zero. Folded in with the rest it drags the median down, and a
-    // time-based injection that was answering three seconds late reads as no
-    // delay at all. Which is the failure this verb exists to avoid: a burst
-    // that half happened, reported as a measurement of the half that did not.
+    // Only the sends a server answered. One refused by policy or budget still
+    // carries a clock, and it is the refusal's — near zero — which drags the
+    // median down until a three-second delay reads as none.
     let answered: Vec<&Value> = samples
         .iter()
         .filter(|s| s.get("status").is_some_and(|status| !status.is_null()))
@@ -1689,11 +1618,9 @@ pub fn map_of(records: &[Value]) -> Map {
 
 /// `h5i browser sitemap`.
 pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::Result<()> {
-    // From the engine while there is one, and off the log on disk once there is
-    // not. The map of a finished run is the one a reviewer wants, and asking
-    // the engine for it meant closing the session took the site map with it.
-    // The log outlives the engine — that is what `close` means by "its record
-    // stays" — and each of its lines is the record `map_of` already reads.
+    // From the engine while there is one, and off the log once there is not:
+    // the map of a finished run is the one a reviewer wants, and each line of
+    // that log is already the record `map_of` reads.
     let session = super::browser::resolve_for_reading(root, selector)?;
     let owned: Vec<Value>;
     let answer;
@@ -1713,9 +1640,7 @@ pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::R
         let path = bs::dir(root, &session.id).join(bs::RECEIPTS_FILE);
         let (text, cut) = bs::read_log_capped_saying(&path).unwrap_or_default();
         if cut {
-            // Said, not implied. A map built from the head of a log is a map of
-            // part of the run, and for a crawl the endpoints past the cap are
-            // the ones worth seeing.
+            // A map built from the head of a log covers part of the run.
             eprintln!(
                 "  note     : this session's request log is larger than the {} bytes read \
                  back, so this map covers the start of the run and not all of it",
@@ -1924,12 +1849,8 @@ fn extract_one(spec: &str, response: &StoredResponse, body: &Text) -> anyhow::Re
         ),
     };
     found.ok_or_else(|| {
-        // "Found nothing" is a claim about the response. It is only true when
-        // the whole response was there to look at: a body that is not in the
-        // store, or one read back as a preview of its head, means the binding
-        // failed because there was nothing to search, and a sequence that
-        // stopped on that reason would send its author looking at the target.
-        // The same rule `match` applies, in the verb that chains on the answer.
+        // "Found nothing" is a claim about the response, and only true when
+        // the whole response was there to look at.
         let searched_the_body = matches!(kind.trim(), "regex" | "json");
         if searched_the_body && !body.whole() {
             match body {
@@ -1950,14 +1871,10 @@ fn extract_one(spec: &str, response: &StoredResponse, body: &Text) -> anyhow::Re
     })
 }
 
-/// Why a step failed, out of wherever the reply put it.
-///
-/// A refusal carries `code` and `message`; a send that reached the wire and
-/// failed there carries neither, and puts what happened under `response.error`.
-/// Reading only the first meant a sequence stopped and said "the step failed"
-/// while the answer it was holding said "error sending request for url …". A
-/// sequence stops at the first failure by design, so the reason it gives is the
-/// whole of what its author has to act on.
+/// Why a step failed, out of wherever the reply put it: a refusal carries
+/// `code` and `message`, a send that failed at the wire puts it under
+/// `response.error`. A sequence stops at the first failure, so this string is
+/// all its author gets.
 fn why_a_step_failed(answer: &Value) -> String {
     let text = |value: &Value| value.as_str().map(str::to_string);
     let refusal = answer.get("message").and_then(text).map(|message| {
@@ -2075,12 +1992,8 @@ pub fn sequence(
         if !step.extract.is_empty() {
             let target = step.as_session.as_deref().or(selector);
             let (_, dir) = store_dir(root, target)?;
-            // The step's own answer, or nothing. Defaulting a missing sequence
-            // number to zero read message 0 instead — the session's first
-            // request, usually the navigation that opened it — and bound the
-            // token, the flag or the CSRF value out of a response that belongs
-            // to a different message. A wrong answer that looks right, in the
-            // verb whose whole job is to carry one step's answer into the next.
+            // The step's own answer, or nothing. Defaulting to zero bound the
+            // token out of message 0 — the navigation that opened the session.
             let Some(seq) = record.seq else {
                 record.error = Some(format!(
                     "step {index} came back without a sequence number, so there is no \
@@ -2164,11 +2077,8 @@ pub fn sequence(
 mod tests {
     use super::*;
 
-    /// A session that runs in a box keeps its store on a filesystem the boxed
-    /// code can write to, so the hash a message sidecar names is target input
-    /// like everything else in there. Joined unchecked, `../` in that field
-    /// read a host file and handed it back as a captured body — and `resend`
-    /// would then have sent it to the target.
+    /// A boxed session's store is writable by boxed code, so the hash in a
+    /// sidecar is target input: joined unchecked, `../` read a host file.
     #[test]
     fn a_body_hash_that_is_not_one_names_nothing_in_the_store() {
         let dir = std::env::temp_dir().join(format!(
@@ -2192,10 +2102,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The in-session resend refuses to replay a body the store cut short,
-    /// because the request that would go out is not the one recorded. The
-    /// cross-session path read the same store and did not, so `--as` sent a
-    /// shortened body and reported the answer as a replay.
+    /// The in-session resend refuses a body the store cut short; `--as` read
+    /// the same store and did not, so it sent a shortened body as a replay.
     #[test]
     fn a_truncated_body_is_not_carried_into_another_session() {
         let dir = std::env::temp_dir().join(format!(
@@ -2217,10 +2125,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A header value and a body line are strings the target wrote, and the
-    /// human view prints them to a terminal. An escape sequence in one repaints
-    /// the screen: `\r` alone rewrites the line that says which request this
-    /// was, and `ESC[2J` clears what came before it.
+    /// The human view prints strings the target wrote. `\r` alone rewrites the
+    /// line naming which request this was; `ESC[2J` clears what came before it.
     #[test]
     fn what_a_terminal_would_act_on_is_shown_rather_than_obeyed() {
         let hostile = "ok\u{1b}[2J\rHTTP/1.1 200 forged\u{202e}";
@@ -2233,12 +2139,9 @@ mod tests {
         assert_eq!(printable("ordinary text"), "ordinary text");
     }
 
-    /// A body that is not in the store reads as the empty string, so two
-    /// responses whose bodies the store skipped compared as identical:
-    /// `same`, similarity 1.0. The store refuses new bodies once it is full and
-    /// skips media outright, so a target can reach that state on purpose and
-    /// turn every later comparison into "the same page" — which is the answer a
-    /// blind-injection loop reads as "false" for every candidate character.
+    /// An unstored body reads as the empty string, so two of them compared as
+    /// identical. A target reaches that state on purpose by filling the store
+    /// or serving `font/woff`, and the oracle then says "false page" forever.
     #[test]
     fn two_bodies_that_were_never_kept_are_not_the_same_page() {
         let left = response(200, "text/html");
@@ -2265,10 +2168,8 @@ mod tests {
         assert!(difference.same);
     }
 
-    /// A body that is not UTF-8 reaches the matcher as a 64 KiB lossy preview,
-    /// and one invalid byte anywhere in a response is enough to put it there.
-    /// Length verdicts read off the preview answered about the cap, so a target
-    /// could pick the number by padding past it.
+    /// One invalid byte puts a response on the 64 KiB preview path, so a
+    /// length read off the preview is a number the target picked.
     #[test]
     fn a_length_condition_measures_the_body_and_not_its_preview() {
         let stored = response(200, "application/octet-stream");
@@ -2284,9 +2185,8 @@ mod tests {
         assert!(longer.matched, "and it is longer than 1 MB");
     }
 
-    /// The same number is the one `diff` reports, and `length_delta` is a
-    /// headline field: two binary responses past the cap both measured 64 KiB
-    /// and read as no change at all.
+    /// `length_delta` is a headline field, and two binary responses past the
+    /// cap both measured 64 KiB: no change at all.
     #[test]
     fn a_length_delta_is_over_the_bodies_not_the_previews() {
         let stored = response(200, "application/octet-stream");
@@ -2306,11 +2206,8 @@ mod tests {
         assert_eq!(difference.length_delta, 4_000_000);
     }
 
-    /// A body that is not text is read back as a preview of its head. A
-    /// search that finds nothing in the preview has said nothing about the
-    /// rest, so answering "did not match" would be a conclusion drawn from an
-    /// absence — and a target only has to emit one invalid byte and pad past
-    /// the cap to put every body search on that path.
+    /// A search over a preview that finds nothing has said nothing about the
+    /// rest, and one invalid byte puts every body search on that path.
     #[test]
     fn a_miss_over_part_of_a_body_is_not_a_miss() {
         let stored = response(200, "application/octet-stream");
@@ -2350,10 +2247,8 @@ mod tests {
         assert!(!found.matched && found.conclusive);
     }
 
-    /// The change lists are capped, and a cap that says nothing turns a partial
-    /// diff into a complete-looking one. Worse, every addition used to be
-    /// pushed before every removal and the tail cut, so a response with sixty
-    /// new lines reported that nothing had been removed.
+    /// A cap that says nothing turns a partial diff into a complete-looking
+    /// one — and additions came first, so sixty new lines hid every removal.
     #[test]
     fn a_capped_diff_says_how_much_it_left_out_and_keeps_both_sides() {
         let stored = response(200, "text/html");
@@ -2385,10 +2280,8 @@ mod tests {
         assert_eq!(difference.line_changes.len(), 2);
     }
 
-    /// The JSON walk used to return as soon as its list was full, so the
-    /// number of changes and the number listed were the same number and a
-    /// capped diff could not tell a reader it had been capped. The line diff
-    /// said so; this one silently claimed sixty changes were all of them.
+    /// The JSON walk stopped at the cap, so the count and the listed count
+    /// were equal and the diff could not say it had been capped.
     #[test]
     fn a_capped_json_diff_counts_the_changes_it_did_not_list() {
         let stored = response(200, "application/json");
@@ -2414,10 +2307,9 @@ mod tests {
         assert_eq!(difference.json_changes_of, Some(200));
     }
 
-    /// A binding that fails stops the sequence, so the reason it gives is the
-    /// reason its author acts on. "Found nothing in this response" sends them
-    /// to the target; the truth was that this response's body was never
-    /// searched, or only its head was.
+    /// A failed binding stops the sequence, so its reason is what the author
+    /// acts on: "found nothing" sent them to the target when the truth was
+    /// that the body was never searched.
     #[test]
     fn a_binding_that_could_not_look_says_so_rather_than_saying_it_is_not_there() {
         let stored = response(200, "application/octet-stream");
@@ -2448,13 +2340,9 @@ mod tests {
         assert!(why.to_string().contains("found nothing in this response"), "{why}");
     }
 
-    /// The store keeps at most 8 MiB of one body, and a cut that lands on a
-    /// character boundary — which for an ASCII or HTML page is every cut —
-    /// still decodes cleanly. So a truncated page arrived as ordinary text and
-    /// every verb treated its head as the whole thing: `--contains` answered a
-    /// confident "no" over the first 8 MiB, and two different long pages
-    /// compared as the same response. Eight megabytes is a page a target can
-    /// serve on purpose.
+    /// A cut at the store's 8 MiB cap lands on a character boundary — every
+    /// cut, for ASCII — and still decodes, so the head arrived as ordinary
+    /// text and every verb treated it as the whole body.
     #[test]
     fn a_body_the_store_cut_is_not_a_whole_body() {
         let cut = Text::Cut {
@@ -2477,10 +2365,8 @@ mod tests {
         assert!(!difference.same);
     }
 
-    /// The preview bounded how many lines it showed and not how long one could
-    /// be, so a minified page — one line, no newlines, megabytes of it —
-    /// printed whole into the terminal, or into the context of the agent that
-    /// asked for it. A target chooses whether its page has newlines in it.
+    /// The line count was bounded and the length was not, so a minified page —
+    /// one line, megabytes of it — printed whole. The target picks the newlines.
     #[test]
     fn one_enormous_line_is_bounded_like_every_other() {
         let shown = preview_line(&"A".repeat(2_000_000));
@@ -2496,10 +2382,8 @@ mod tests {
         assert!(!preview_line("a\u{1b}[2Jb").contains('\u{1b}'));
     }
 
-    /// The same bound, everywhere a target's text reaches the terminal. A
-    /// capture is the clearest case: the target chooses how much page sits
-    /// between a pattern's anchors, so `--regex 'flag=(.*)'` over a page with
-    /// no newlines in it captures the page.
+    /// The same bound wherever target text reaches a terminal. The target
+    /// chooses how much page sits between a pattern's anchors.
     #[test]
     fn a_capture_over_a_whole_page_is_bounded_in_the_human_view() {
         let stored = response(200, "text/html");
@@ -2513,11 +2397,9 @@ mod tests {
         assert!(preview_line(&found.captures[0]).chars().count() < MAX_PREVIEW_LINE + 80);
     }
 
-    /// The site map's `*` means the browser went to this endpoint. A replay
-    /// was recorded as a navigation, so bending a parameter at an endpoint
-    /// marked it as one the application had navigated to — a reviewer
-    /// separating "the application did this" from "the tester did this" reads
-    /// exactly that mark.
+    /// The site map's `*` means the browser went here. Replays were recorded
+    /// as navigations, which is the mark a reviewer reads to tell what the
+    /// application did from what the tester did.
     #[test]
     fn a_replay_is_not_a_page_somebody_went_to() {
         let map = map_of(&[
@@ -2534,12 +2416,8 @@ mod tests {
         assert_eq!(admin.hits, 1, "but it is still on the map");
     }
 
-    /// A sequence stops at the first failure by design, so the reason it gives
-    /// is the whole of what its author has to act on. A refusal carries `code`
-    /// and `message`; a send that reached the wire and failed there carries
-    /// neither and puts what happened in `response.error`. Reading only the
-    /// first meant a step reported "the step failed" while the reply it was
-    /// holding said "error sending request for url …".
+    /// A step that failed at the wire carries no `message`, so reading only
+    /// that reported "the step failed" while the reply said why.
     #[test]
     fn a_failed_step_reports_the_reason_the_reply_carried() {
         assert_eq!(
@@ -2801,11 +2679,9 @@ mod tests {
         // A mean would have said ~750.
     }
 
-    /// A `--repeat` burst can stop reaching the wire partway through: the
-    /// budget runs out, or policy refuses. Those sends still carry a clock, and
-    /// it is the refusal's — a millisecond or two. Averaged in with the real
-    /// ones they pull the median down, so a payload that made the server wait
-    /// three seconds reports as no delay, which is the finding not found.
+    /// A burst can stop reaching the wire partway through, and those sends
+    /// carry the refusal's clock — a millisecond or two — which pulls the
+    /// median down until a three-second delay reports as none.
     #[test]
     fn sends_that_never_reached_the_wire_are_not_part_of_the_timing() {
         let answered = |ms: u64| json!({"status": 200, "ttfb_ms": ms, "total_ms": ms});

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -1789,7 +1789,29 @@ fn extract_one(spec: &str, response: &StoredResponse, body: &Text) -> anyhow::Re
         ),
     };
     found.ok_or_else(|| {
-        anyhow::anyhow!("`{spec}` found nothing in this response")
+        // "Found nothing" is a claim about the response. It is only true when
+        // the whole response was there to look at: a body that is not in the
+        // store, or one read back as a preview of its head, means the binding
+        // failed because there was nothing to search, and a sequence that
+        // stopped on that reason would send its author looking at the target.
+        // The same rule `match` applies, in the verb that chains on the answer.
+        let searched_the_body = matches!(kind.trim(), "regex" | "json");
+        if searched_the_body && !body.whole() {
+            match body {
+                Text::Missing(why) => anyhow::anyhow!(
+                    "`{spec}` could not be answered: this response's body is not in the \
+                     store ({why})"
+                ),
+                _ => anyhow::anyhow!(
+                    "`{spec}` found nothing in the first {LOSSY_BODY_BYTES} bytes of this \
+                     response, which is all of a body that is not text that is read back. \
+                     Whether it is in the rest is not something this can answer; \
+                     `message --body-to PATH` writes the exact bytes"
+                ),
+            }
+        } else {
+            anyhow::anyhow!("`{spec}` found nothing in this response")
+        }
     })
 }
 
@@ -2215,6 +2237,40 @@ mod tests {
         );
         assert_eq!(difference.json_changes.len(), MAX_JSON_CHANGES);
         assert_eq!(difference.json_changes_of, Some(200));
+    }
+
+    /// A binding that fails stops the sequence, so the reason it gives is the
+    /// reason its author acts on. "Found nothing in this response" sends them
+    /// to the target; the truth was that this response's body was never
+    /// searched, or only its head was.
+    #[test]
+    fn a_binding_that_could_not_look_says_so_rather_than_saying_it_is_not_there() {
+        let stored = response(200, "application/octet-stream");
+
+        let absent = Text::Missing("store-full (900000 bytes)".to_string());
+        let why = extract_one("regex:FLAG\\{(.+)\\}", &stored, &absent)
+            .expect_err("nothing to search");
+        assert!(why.to_string().contains("not in the store"), "{why}");
+
+        let partial = Text::Binary {
+            bytes: 5_000_000,
+            sha256: "b".repeat(64),
+            text: "nothing here".to_string(),
+        };
+        let why = extract_one("regex:FLAG\\{(.+)\\}", &stored, &partial)
+            .expect_err("only the head was searched");
+        assert!(why.to_string().contains("is all of a body"), "{why}");
+
+        // And a body that really was searched whole still says it plainly.
+        let whole = Text::Utf8("nothing here".to_string());
+        let why = extract_one("regex:FLAG\\{(.+)\\}", &stored, &whole)
+            .expect_err("searched, and not there");
+        assert!(why.to_string().contains("found nothing in this response"), "{why}");
+
+        // A header extractor is not a body search, so a missing body does not
+        // change what it can say.
+        let why = extract_one("header:X-Nope", &stored, &absent).expect_err("no such header");
+        assert!(why.to_string().contains("found nothing in this response"), "{why}");
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -2421,6 +2421,27 @@ mod tests {
         assert!(preview_line(&found.captures[0]).chars().count() < MAX_PREVIEW_LINE + 80);
     }
 
+    /// The site map's `*` means the browser went to this endpoint. A replay
+    /// was recorded as a navigation, so bending a parameter at an endpoint
+    /// marked it as one the application had navigated to — a reviewer
+    /// separating "the application did this" from "the tester did this" reads
+    /// exactly that mark.
+    #[test]
+    fn a_replay_is_not_a_page_somebody_went_to() {
+        let map = map_of(&[
+            json!({"seq":0,"phase":"request","initiator":"navigation","method":"GET",
+                   "url":"https://app.test/users","allowed":true}),
+            json!({"seq":1,"phase":"request","initiator":"replay","method":"GET",
+                   "url":"https://app.test/admin","allowed":true}),
+        ]);
+        let endpoints = &map.origins[0].endpoints;
+        let users = endpoints.iter().find(|e| e.path == "/users").expect("users");
+        let admin = endpoints.iter().find(|e| e.path == "/admin").expect("admin");
+        assert!(users.navigated, "the browser did go here");
+        assert!(!admin.navigated, "and it never went here: a replay is not a visit");
+        assert_eq!(admin.hits, 1, "but it is still on the map");
+    }
+
     fn response(status: u16, kind: &str) -> StoredResponse {
         StoredResponse {
             seq: 0,

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -619,8 +619,17 @@ pub struct Difference {
     pub headers_changed: Vec<String>,
     /// Changed body fields, when both bodies are JSON. Keyed by dotted path.
     pub json_changes: Vec<JsonChange>,
+    /// How many there were, when the list above is only the first of them.
+    ///
+    /// The lists are capped so one reply cannot be a whole page, and a cap that
+    /// did not say so was a diff reporting part of itself as all of itself.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub json_changes_of: Option<usize>,
     /// Changed lines, when they are not.
     pub line_changes: Vec<LineChange>,
+    /// How many there were. See [`Difference::json_changes_of`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_changes_of: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
@@ -694,7 +703,8 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
     let bodies_compared = a_body.whole() && b_body.whole();
     let left_text = a_body.as_str();
     let right_text = b_body.as_str();
-    let (json_changes, line_changes) = body_changes(a, b, left_text, right_text);
+    let (json_changes, json_total, line_changes, line_total) =
+        body_changes(a, b, left_text, right_text);
 
     // The bodies' own lengths, not the previews'. A body that is not UTF-8
     // reaches `as_str` as at most 64 KiB, so `length_delta` — a headline
@@ -725,6 +735,8 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
         headers_added: added,
         headers_removed: removed,
         headers_changed: changed,
+        json_changes_of: (json_total > json_changes.len()).then_some(json_total),
+        line_changes_of: (line_total > line_changes.len()).then_some(line_total),
         json_changes,
         line_changes,
     }
@@ -738,12 +750,14 @@ fn is_json(response: &StoredResponse) -> bool {
         .is_some_and(|(_, value)| value.to_ascii_lowercase().contains("json"))
 }
 
+/// The JSON changes and the line changes, each with the number there were
+/// before the cap took the rest.
 fn body_changes(
     a: &StoredResponse,
     b: &StoredResponse,
     left: &str,
     right: &str,
-) -> (Vec<JsonChange>, Vec<LineChange>) {
+) -> (Vec<JsonChange>, usize, Vec<LineChange>, usize) {
     // Both sides have to be JSON *and* parse. A body that claims JSON and is
     // not (a truncated answer, an error page served with the wrong type) falls
     // through to the line diff rather than reporting no changes at all.
@@ -756,10 +770,12 @@ fn body_changes(
     {
         let mut changes = Vec::new();
         walk_json("", &left, &right, &mut changes);
+        let total = changes.len();
         changes.truncate(MAX_JSON_CHANGES);
-        return (changes, Vec::new());
+        return (changes, total, Vec::new(), 0);
     }
-    (Vec::new(), line_changes(left, right))
+    let (lines, total) = line_changes(left, right);
+    (Vec::new(), 0, lines, total)
 }
 
 /// Field-by-field, so a re-ordered object is not a difference.
@@ -830,13 +846,20 @@ fn walk_json(path: &str, left: &Value, right: &Value, out: &mut Vec<JsonChange>)
 /// of a diff here is "what appeared and what vanished", and a page that moved a
 /// line without changing it is not a finding. An LCS would also be O(n·m) over
 /// two HTML documents, which is the wrong cost for a loop.
-fn line_changes(left: &str, right: &str) -> Vec<LineChange> {
+/// The changed lines, and how many there were before the cap.
+///
+/// Both sides are cut, not just the tail. The list used to be every addition
+/// followed by every removal and then truncated, so a response with sixty new
+/// lines reported no removals at all — and "this line is gone" is as much of an
+/// answer as "this line is new".
+fn line_changes(left: &str, right: &str) -> (Vec<LineChange>, usize) {
     let before: BTreeSet<&str> = left.lines().collect();
     let after: BTreeSet<&str> = right.lines().collect();
-    let mut out = Vec::new();
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
     for (index, line) in right.lines().enumerate() {
         if !before.contains(line) {
-            out.push(LineChange {
+            added.push(LineChange {
                 side: "added",
                 line: index + 1,
                 text: line.chars().take(400).collect(),
@@ -845,15 +868,28 @@ fn line_changes(left: &str, right: &str) -> Vec<LineChange> {
     }
     for (index, line) in left.lines().enumerate() {
         if !after.contains(line) {
-            out.push(LineChange {
+            removed.push(LineChange {
                 side: "removed",
                 line: index + 1,
                 text: line.chars().take(400).collect(),
             });
         }
     }
-    out.truncate(MAX_LINE_CHANGES);
-    out
+    let total = added.len() + removed.len();
+    if total > MAX_LINE_CHANGES {
+        // Half each, and whatever the shorter side does not use goes to the
+        // longer one, so the cap costs a lopsided diff nothing.
+        let half = MAX_LINE_CHANGES / 2;
+        let keep_added = if removed.len() < half {
+            MAX_LINE_CHANGES - removed.len()
+        } else {
+            half.max(MAX_LINE_CHANGES - removed.len().min(MAX_LINE_CHANGES))
+        };
+        added.truncate(keep_added);
+        removed.truncate(MAX_LINE_CHANGES - added.len());
+    }
+    added.extend(removed);
+    (added, total)
 }
 
 /// How alike two bodies are, 0.0 to 1.0.
@@ -967,6 +1003,20 @@ pub fn diff(
     for change in &difference.line_changes {
         let mark = if change.side == "added" { '+' } else { '-' };
         println!("  {mark} {}", printable(&change.text));
+    }
+    // Said, not implied. A capped list that reads as the whole answer is a
+    // partial diff wearing a complete one's shape.
+    if let Some(total) = difference.json_changes_of {
+        println!(
+            "  … {} more changed fields not listed",
+            total - difference.json_changes.len()
+        );
+    }
+    if let Some(total) = difference.line_changes_of {
+        println!(
+            "  … {} more changed lines not listed",
+            total - difference.line_changes.len()
+        );
     }
     Ok(())
 }
@@ -2034,6 +2084,41 @@ mod tests {
         };
         let found = evaluate(&Condition::Contains("FLAG{".to_string()), &stored, &whole);
         assert!(!found.matched && found.conclusive);
+    }
+
+    /// The change lists are capped, and a cap that says nothing turns a partial
+    /// diff into a complete-looking one. Worse, every addition used to be
+    /// pushed before every removal and the tail cut, so a response with sixty
+    /// new lines reported that nothing had been removed.
+    #[test]
+    fn a_capped_diff_says_how_much_it_left_out_and_keeps_both_sides() {
+        let stored = response(200, "text/html");
+        let left = Text::Utf8((0..100).map(|n| format!("old line {n}\n")).collect());
+        let right = Text::Utf8((0..100).map(|n| format!("new line {n}\n")).collect());
+        let difference = compare((&stored, &left), (&stored, &right));
+
+        assert_eq!(difference.line_changes.len(), MAX_LINE_CHANGES);
+        assert_eq!(difference.line_changes_of, Some(200));
+        assert!(
+            difference.line_changes.iter().any(|c| c.side == "added"),
+            "the additions survive the cap"
+        );
+        assert!(
+            difference.line_changes.iter().any(|c| c.side == "removed"),
+            "and so do the removals"
+        );
+    }
+
+    /// A diff that fits says nothing about a cap, because there was none.
+    #[test]
+    fn a_small_diff_carries_no_truncation_note() {
+        let stored = response(200, "text/html");
+        let difference = compare(
+            (&stored, &Text::Utf8("a\nb\n".to_string())),
+            (&stored, &Text::Utf8("a\nc\n".to_string())),
+        );
+        assert_eq!(difference.line_changes_of, None);
+        assert_eq!(difference.line_changes.len(), 2);
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -84,6 +84,24 @@ pub enum Text {
 }
 
 impl Text {
+    /// How many bytes the body actually had.
+    ///
+    /// Not `as_str().len()`, which for a body that is not UTF-8 is the length
+    /// of a 64 KiB lossy *preview*. One invalid byte anywhere in a response is
+    /// enough to put it on that path, so a length verdict read off the preview
+    /// is a number a target can choose: pad past 64 KiB and every
+    /// `--longer-than` and `--shorter-than` answers about the cap instead of
+    /// about the page.
+    ///
+    /// `None` when the body is not in the store, which is not a length of zero.
+    fn len(&self) -> Option<u64> {
+        match self {
+            Text::Utf8(text) => Some(text.len() as u64),
+            Text::Binary { bytes, .. } => Some(*bytes),
+            Text::Missing(_) => None,
+        }
+    }
+
     fn as_str(&self) -> &str {
         match self {
             Text::Utf8(text) => text,
@@ -662,7 +680,13 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
     let right_text = b_body.as_str();
     let (json_changes, line_changes) = body_changes(a, b, left_text, right_text);
 
-    let bytes = (left_text.len() as u64, right_text.len() as u64);
+    // The bodies' own lengths, not the previews'. A body that is not UTF-8
+    // reaches `as_str` as at most 64 KiB, so `length_delta` — a headline
+    // verdict field — read zero for any two binary responses past the cap.
+    let bytes = (
+        a_body.len().unwrap_or_default(),
+        b_body.len().unwrap_or_default(),
+    );
     Difference {
         same: bodies_compared
             && a.status == b.status
@@ -1087,17 +1111,18 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
             matched: response.status == Some(*want),
             captures: response.status.map(|s| s.to_string()).into_iter().collect(),
         },
+        // Off the body's own length, never the preview's. See [`Text::len`].
         Condition::LongerThan(bytes) => Found {
             kind: "longer-than",
             expr: bytes.to_string(),
-            matched: text.len() as u64 > *bytes,
-            captures: vec![text.len().to_string()],
+            matched: body.len().is_some_and(|had| had > *bytes),
+            captures: body.len().map(|had| had.to_string()).into_iter().collect(),
         },
         Condition::ShorterThan(bytes) => Found {
             kind: "shorter-than",
             expr: bytes.to_string(),
-            matched: (text.len() as u64) < *bytes,
-            captures: vec![text.len().to_string()],
+            matched: body.len().is_some_and(|had| had < *bytes),
+            captures: body.len().map(|had| had.to_string()).into_iter().collect(),
         },
     }
 }
@@ -1880,6 +1905,47 @@ mod tests {
         let difference = compare((&left, &empty), (&right, &empty));
         assert!(difference.bodies_compared);
         assert!(difference.same);
+    }
+
+    /// A body that is not UTF-8 reaches the matcher as a 64 KiB lossy preview,
+    /// and one invalid byte anywhere in a response is enough to put it there.
+    /// Length verdicts read off the preview answered about the cap, so a target
+    /// could pick the number by padding past it.
+    #[test]
+    fn a_length_condition_measures_the_body_and_not_its_preview() {
+        let stored = response(200, "application/octet-stream");
+        let big = Text::Binary {
+            bytes: 5_000_000,
+            sha256: "b".repeat(64),
+            text: "x".repeat(64 * 1024),
+        };
+        let shorter = evaluate(&Condition::ShorterThan(100_000), &stored, &big);
+        assert!(!shorter.matched, "5 MB is not shorter than 100 kB");
+        assert_eq!(shorter.captures, vec!["5000000".to_string()]);
+        let longer = evaluate(&Condition::LongerThan(1_000_000), &stored, &big);
+        assert!(longer.matched, "and it is longer than 1 MB");
+    }
+
+    /// The same number is the one `diff` reports, and `length_delta` is a
+    /// headline field: two binary responses past the cap both measured 64 KiB
+    /// and read as no change at all.
+    #[test]
+    fn a_length_delta_is_over_the_bodies_not_the_previews() {
+        let stored = response(200, "application/octet-stream");
+        let preview = "x".repeat(64 * 1024);
+        let small = Text::Binary {
+            bytes: 1_000_000,
+            sha256: "a".repeat(64),
+            text: preview.clone(),
+        };
+        let large = Text::Binary {
+            bytes: 5_000_000,
+            sha256: "b".repeat(64),
+            text: preview,
+        };
+        let difference = compare((&stored, &small), (&stored, &large));
+        assert_eq!(difference.bytes, (1_000_000, 5_000_000));
+        assert_eq!(difference.length_delta, 4_000_000);
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -1711,8 +1711,18 @@ pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::R
             .unwrap_or_default()
     } else {
         let path = bs::dir(root, &session.id).join(bs::RECEIPTS_FILE);
-        owned = bs::read_log_capped(&path)
-            .unwrap_or_default()
+        let (text, cut) = bs::read_log_capped_saying(&path).unwrap_or_default();
+        if cut {
+            // Said, not implied. A map built from the head of a log is a map of
+            // part of the run, and for a crawl the endpoints past the cap are
+            // the ones worth seeing.
+            eprintln!(
+                "  note     : this session's request log is larger than the {} bytes read \
+                 back, so this map covers the start of the run and not all of it",
+                8 * 1024 * 1024
+            );
+        }
+        owned = text
             .lines()
             .filter_map(|line| serde_json::from_str::<Value>(line).ok())
             .collect();

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -1030,14 +1030,7 @@ pub struct Found {
     /// body search that only had the head of the body to search. `matches`
     /// turns it into the "could not look" exit rather than the "did not match"
     /// one, which is the whole discipline of this verb.
-    #[serde(default = "yes")]
     pub conclusive: bool,
-}
-
-/// `serde`'s default for [`Found::conclusive`]: a condition was answerable
-/// unless something says otherwise.
-fn yes() -> bool {
-    true
 }
 
 fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Found {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -779,9 +779,8 @@ fn body_changes(
         )
     {
         let mut changes = Vec::new();
-        walk_json("", &left, &right, &mut changes);
-        let total = changes.len();
-        changes.truncate(MAX_JSON_CHANGES);
+        let mut total = 0usize;
+        walk_json("", &left, &right, &mut changes, &mut total);
         return (changes, total, Vec::new(), 0);
     }
     let (lines, total) = line_changes(left, right);
@@ -789,10 +788,25 @@ fn body_changes(
 }
 
 /// Field-by-field, so a re-ordered object is not a difference.
-fn walk_json(path: &str, left: &Value, right: &Value, out: &mut Vec<JsonChange>) {
-    if out.len() >= MAX_JSON_CHANGES {
-        return;
-    }
+/// Every difference between two documents, pushing at most [`MAX_JSON_CHANGES`]
+/// of them and counting all of them in `total`.
+///
+/// Counted rather than stopped at. Returning as soon as the list was full meant
+/// the walk itself ended there, so "how many changed" and "how many are listed"
+/// were the same number and a capped diff could not say it had been capped.
+fn walk_json(
+    path: &str,
+    left: &Value,
+    right: &Value,
+    out: &mut Vec<JsonChange>,
+    total: &mut usize,
+) {
+    let note = |change: JsonChange, out: &mut Vec<JsonChange>, total: &mut usize| {
+        *total += 1;
+        if out.len() < MAX_JSON_CHANGES {
+            out.push(change);
+        }
+    };
     let render = |v: &Value| match v {
         Value::String(s) => s.clone(),
         other => other.to_string(),
@@ -807,17 +821,17 @@ fn walk_json(path: &str, left: &Value, right: &Value, out: &mut Vec<JsonChange>)
                     format!("{path}.{name}")
                 };
                 match (a.get(name), b.get(name)) {
-                    (Some(l), Some(r)) => walk_json(&next, l, r, out),
-                    (Some(l), None) => out.push(JsonChange {
-                        path: next,
-                        from: Some(render(l)),
-                        to: None,
-                    }),
-                    (None, Some(r)) => out.push(JsonChange {
-                        path: next,
-                        from: None,
-                        to: Some(render(r)),
-                    }),
+                    (Some(l), Some(r)) => walk_json(&next, l, r, out, total),
+                    (Some(l), None) => note(
+                        JsonChange { path: next, from: Some(render(l)), to: None },
+                        out,
+                        total,
+                    ),
+                    (None, Some(r)) => note(
+                        JsonChange { path: next, from: None, to: Some(render(r)) },
+                        out,
+                        total,
+                    ),
                     (None, None) => {}
                 }
             }
@@ -826,26 +840,30 @@ fn walk_json(path: &str, left: &Value, right: &Value, out: &mut Vec<JsonChange>)
             for index in 0..a.len().max(b.len()) {
                 let next = format!("{path}.{index}");
                 match (a.get(index), b.get(index)) {
-                    (Some(l), Some(r)) => walk_json(&next, l, r, out),
-                    (Some(l), None) => out.push(JsonChange {
-                        path: next,
-                        from: Some(render(l)),
-                        to: None,
-                    }),
-                    (None, Some(r)) => out.push(JsonChange {
-                        path: next,
-                        from: None,
-                        to: Some(render(r)),
-                    }),
+                    (Some(l), Some(r)) => walk_json(&next, l, r, out, total),
+                    (Some(l), None) => note(
+                        JsonChange { path: next, from: Some(render(l)), to: None },
+                        out,
+                        total,
+                    ),
+                    (None, Some(r)) => note(
+                        JsonChange { path: next, from: None, to: Some(render(r)) },
+                        out,
+                        total,
+                    ),
                     (None, None) => {}
                 }
             }
         }
-        (l, r) if l != r => out.push(JsonChange {
-            path: path.to_string(),
-            from: Some(render(l)),
-            to: Some(render(r)),
-        }),
+        (l, r) if l != r => note(
+            JsonChange {
+                path: path.to_string(),
+                from: Some(render(l)),
+                to: Some(render(r)),
+            },
+            out,
+            total,
+        ),
         _ => {}
     }
 }
@@ -2168,6 +2186,35 @@ mod tests {
         );
         assert_eq!(difference.line_changes_of, None);
         assert_eq!(difference.line_changes.len(), 2);
+    }
+
+    /// The JSON walk used to return as soon as its list was full, so the
+    /// number of changes and the number listed were the same number and a
+    /// capped diff could not tell a reader it had been capped. The line diff
+    /// said so; this one silently claimed sixty changes were all of them.
+    #[test]
+    fn a_capped_json_diff_counts_the_changes_it_did_not_list() {
+        let stored = response(200, "application/json");
+        let left: String = format!(
+            "{{{}}}",
+            (0..200)
+                .map(|n| format!("\"k{n}\":\"a\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let right: String = format!(
+            "{{{}}}",
+            (0..200)
+                .map(|n| format!("\"k{n}\":\"b\""))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let difference = compare(
+            (&stored, &Text::Utf8(left)),
+            (&stored, &Text::Utf8(right)),
+        );
+        assert_eq!(difference.json_changes.len(), MAX_JSON_CHANGES);
+        assert_eq!(difference.json_changes_of, Some(200));
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -423,9 +423,34 @@ pub fn show(
         })?;
         std::fs::write(path, &bytes)
             .map_err(|e| anyhow::anyhow!("{} could not be written: {e}", path.display()))?;
-        wrote = Some(json!({"path": path.display().to_string(), "bytes": bytes.len()}));
+        // Whether this file is the body or the head of it. This is the exact
+        // byte channel — the one every other view points a caller at when it
+        // has had to bound something — so a body the store cut has to say so
+        // here rather than hand over a shorter file and a byte count.
+        let of_bytes = match body {
+            Body::Stored {
+                truncated: true,
+                of_bytes,
+                ..
+            } => *of_bytes,
+            _ => None,
+        };
+        let mut note = json!({"path": path.display().to_string(), "bytes": bytes.len()});
+        if let Some(had) = of_bytes {
+            note["of_bytes"] = json!(had);
+            note["truncated"] = json!(true);
+        }
+        wrote = Some(note);
         if !json_out {
-            println!("  wrote    : {} bytes to {}", bytes.len(), path.display());
+            match of_bytes {
+                None => println!("  wrote    : {} bytes to {}", bytes.len(), path.display()),
+                Some(had) => println!(
+                    "  wrote    : {} bytes to {} — the head of a {had} byte body, which is \
+                     all the store kept",
+                    bytes.len(),
+                    path.display()
+                ),
+            }
         }
     }
 

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -25,6 +25,16 @@ fn store_dir(root: &Path, selector: Option<&str>) -> anyhow::Result<(bs::Session
         Err(bs::SessionGone::Ended { id, .. }) => bs::read(root, &id)?,
         Err(gone) => anyhow::bail!("{gone}"),
     };
+    // The id off the record, checked before it names a directory: for a boxed
+    // session that file sits where the boxed code can write to it, and
+    // everything under a session directory is addressed by joining onto this.
+    if !bs::id_is_one_component(&session.id) {
+        anyhow::bail!(
+            "session record names `{}` as its id, which is not one this registry could \
+             have minted. Nothing was read",
+            session.id
+        );
+    }
     let dir = bs::dir(root, &session.id).join(bs::MESSAGES_DIR);
     if !dir.exists() {
         let placed = match &session.placement {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -431,6 +431,33 @@ fn header_is_the_users(name: &str) -> bool {
     )
 }
 
+/// The exact body to send again, or why there is not one.
+///
+/// The truncation rule is the in-session resend's, kept here so the two cannot
+/// disagree: a body the store had to cut short is not the body that was sent,
+/// and carrying it into another session would put a request on the wire that
+/// nobody recorded, then read the answer as a replay of one that was.
+fn carried_body(dir: &Path, seq: u64, body: &Body) -> anyhow::Result<Vec<u8>> {
+    if let Body::Stored { truncated: true, .. } = body {
+        anyhow::bail!(
+            "request {seq} was too large to keep whole, so carrying it into another \
+             session would send a request that is not the one recorded"
+        );
+    }
+    match body_text(dir, body) {
+        Text::Utf8(text) => Ok(text.into_bytes()),
+        Text::Binary { sha256, .. } => {
+            let path = body_file(dir, &sha256)
+                .ok_or_else(|| anyhow::anyhow!("{sha256:?} is not a body hash"))?;
+            std::fs::read(path)
+                .map_err(|e| anyhow::anyhow!("the stored body could not be read: {e}"))
+        }
+        Text::Missing(why) => anyhow::bail!(
+            "request {seq}'s body is not in the store ({why}), so it cannot be carried"
+        ),
+    }
+}
+
 /// One session's stored request, ready to hand to another session.
 ///
 /// Returns the JSON the `resend` verb takes, and the names of the headers that
@@ -469,18 +496,7 @@ pub fn carry(
         })
         .collect();
 
-    let body = match body_text(&dir, &stored.body) {
-        Text::Utf8(text) => text.into_bytes(),
-        Text::Binary { sha256, .. } => {
-            let path = body_file(&dir, &sha256)
-                .ok_or_else(|| anyhow::anyhow!("{sha256:?} is not a body hash"))?;
-            std::fs::read(path)
-                .map_err(|e| anyhow::anyhow!("the stored body could not be read: {e}"))?
-        }
-        Text::Missing(why) => {
-            anyhow::bail!("request {seq}'s body is not in the store ({why}), so it cannot be carried")
-        }
-    };
+    let body = carried_body(&dir, seq, &stored.body)?;
     use base64::Engine as _;
     Ok((
         json!({
@@ -1690,6 +1706,31 @@ mod tests {
             read => panic!("read outside the store: {read:?}"),
         }
         assert_eq!(body_bytes(&dir, &escaped), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The in-session resend refuses to replay a body the store cut short,
+    /// because the request that would go out is not the one recorded. The
+    /// cross-session path read the same store and did not, so `--as` sent a
+    /// shortened body and reported the answer as a replay.
+    #[test]
+    fn a_truncated_body_is_not_carried_into_another_session() {
+        let dir = std::env::temp_dir().join(format!(
+            "h5i-websec-cut-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(dir.join("bodies")).expect("a store");
+        let hash = "a".repeat(64);
+        std::fs::write(dir.join("bodies").join(&hash), b"the head of it").expect("a body");
+        let cut = Body::Stored {
+            sha256: hash,
+            bytes: 14,
+            of_bytes: Some(9_000_000),
+            truncated: true,
+        };
+        let refused = carried_body(&dir, 42, &cut).expect_err("a cut body is not replayable");
+        assert!(refused.to_string().contains("not the one recorded"), "{refused}");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -102,6 +102,19 @@ impl Text {
         }
     }
 
+    /// Whether [`Text::as_str`] is the whole body or only the head of it.
+    ///
+    /// A body that is not UTF-8 is read back as a lossy preview of its first
+    /// [`LOSSY_BODY_BYTES`], so a search over it that finds nothing has looked
+    /// at part of the response and can say nothing about the rest.
+    fn whole(&self) -> bool {
+        match self {
+            Text::Utf8(_) => true,
+            Text::Binary { bytes, .. } => *bytes <= LOSSY_BODY_BYTES as u64,
+            Text::Missing(_) => false,
+        }
+    }
+
     fn as_str(&self) -> &str {
         match self {
             Text::Utf8(text) => text,
@@ -674,8 +687,11 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
     // Two bodies, or none of this is a comparison. `Text::Missing` reads as the
     // empty string, which made "neither body was kept" indistinguishable from
     // "both bodies were empty".
-    let bodies_compared =
-        !matches!(a_body, Text::Missing(_)) && !matches!(b_body, Text::Missing(_));
+    // Whole bodies, or none of this is a comparison. `Text::Missing` reads as
+    // the empty string, which made "neither body was kept" indistinguishable
+    // from "both bodies were empty"; a body that is not UTF-8 reads as the head
+    // of itself, which made two different large responses look identical.
+    let bodies_compared = a_body.whole() && b_body.whole();
     let left_text = a_body.as_str();
     let right_text = b_body.as_str();
     let (json_changes, line_changes) = body_changes(a, b, left_text, right_text);
@@ -1008,6 +1024,20 @@ pub struct Found {
     /// is running a match and reading this.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub captures: Vec<String>,
+    /// Whether this condition could be answered at all.
+    ///
+    /// A `false` here is never a "no": a pattern that does not compile, or a
+    /// body search that only had the head of the body to search. `matches`
+    /// turns it into the "could not look" exit rather than the "did not match"
+    /// one, which is the whole discipline of this verb.
+    #[serde(default = "yes")]
+    pub conclusive: bool,
+}
+
+/// `serde`'s default for [`Found::conclusive`]: a condition was answerable
+/// unless something says otherwise.
+fn yes() -> bool {
+    true
 }
 
 fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Found {
@@ -1023,13 +1053,15 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
                 expr: format!("{pattern} (not a regular expression: {e})"),
                 matched: false,
                 captures: Vec::new(),
+                conclusive: false,
             },
             Ok(re) => {
                 let found = re.captures(text);
+                let hit = found.is_some();
                 Found {
                     kind: "regex",
                     expr: pattern.clone(),
-                    matched: found.is_some(),
+                    matched: hit,
                     // Groups when the pattern has them, the whole match when it
                     // does not. A pattern without a group is the ordinary way to
                     // ask "is this in there, and what was it", and handing back
@@ -1052,15 +1084,22 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
                             }
                         })
                         .unwrap_or_default(),
+                    // A miss over part of a body is not a miss. See
+                    // [`Text::whole`].
+                    conclusive: hit || body.whole(),
                 }
             }
         },
-        Condition::Contains(needle) => Found {
-            kind: "contains",
-            expr: needle.clone(),
-            matched: text.contains(needle.as_str()),
-            captures: Vec::new(),
-        },
+        Condition::Contains(needle) => {
+            let matched = text.contains(needle.as_str());
+            Found {
+                kind: "contains",
+                expr: needle.clone(),
+                matched,
+                captures: Vec::new(),
+                conclusive: matched || body.whole(),
+            }
+        }
         Condition::Json { path, value } => {
             let found = serde_json::from_str::<Value>(text)
                 .ok()
@@ -1082,6 +1121,7 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
                 },
                 matched,
                 captures: rendered.into_iter().collect(),
+                conclusive: matched || body.whole(),
             }
         }
         Condition::Header { name, value } => {
@@ -1103,6 +1143,8 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
                 },
                 matched,
                 captures: have.into_iter().collect(),
+                // Headers are stored whole; only bodies are previewed.
+                conclusive: true,
             }
         }
         Condition::Status(want) => Found {
@@ -1110,6 +1152,7 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
             expr: want.to_string(),
             matched: response.status == Some(*want),
             captures: response.status.map(|s| s.to_string()).into_iter().collect(),
+            conclusive: true,
         },
         // Off the body's own length, never the preview's. See [`Text::len`].
         Condition::LongerThan(bytes) => Found {
@@ -1117,12 +1160,14 @@ fn evaluate(condition: &Condition, response: &StoredResponse, body: &Text) -> Fo
             expr: bytes.to_string(),
             matched: body.len().is_some_and(|had| had > *bytes),
             captures: body.len().map(|had| had.to_string()).into_iter().collect(),
+            conclusive: body.len().is_some(),
         },
         Condition::ShorterThan(bytes) => Found {
             kind: "shorter-than",
             expr: bytes.to_string(),
             matched: body.len().is_some_and(|had| had < *bytes),
             captures: body.len().map(|had| had.to_string()).into_iter().collect(),
+            conclusive: body.len().is_some(),
         },
     }
 }
@@ -1218,9 +1263,10 @@ fn look(
         .iter()
         .map(|condition| evaluate(condition, &stored, &body))
         .collect();
-    let bad_pattern = found
-        .iter()
-        .any(|f| f.kind == "regex" && f.expr.contains("not a regular expression"));
+    // "Could not look" is read off the condition rather than sniffed out of its
+    // rendered text: a pattern that did not compile said so in `expr`, and a
+    // search that only had the head of a body to search said nothing at all.
+    let could_not_look = found.iter().any(|f| !f.conclusive);
     let matched = found.iter().all(|f| f.matched);
 
     if json_out {
@@ -1245,8 +1291,13 @@ fn look(
             }
         }
     }
-    if bad_pattern {
-        anyhow::bail!("a condition could not be evaluated; see the report above");
+    if could_not_look {
+        anyhow::bail!(
+            "a condition could not be answered, so this is not a `no`. A body that is not \
+             text is read back as a preview of its first {LOSSY_BODY_BYTES} bytes, and a \
+             search that found nothing in the preview has said nothing about the rest; \
+             `message --body-to PATH` writes the exact bytes"
+        );
     }
     Ok(matched)
 }
@@ -1946,6 +1997,50 @@ mod tests {
         let difference = compare((&stored, &small), (&stored, &large));
         assert_eq!(difference.bytes, (1_000_000, 5_000_000));
         assert_eq!(difference.length_delta, 4_000_000);
+    }
+
+    /// A body that is not text is read back as a preview of its head. A
+    /// search that finds nothing in the preview has said nothing about the
+    /// rest, so answering "did not match" would be a conclusion drawn from an
+    /// absence — and a target only has to emit one invalid byte and pad past
+    /// the cap to put every body search on that path.
+    #[test]
+    fn a_miss_over_part_of_a_body_is_not_a_miss() {
+        let stored = response(200, "application/octet-stream");
+        let partial = Text::Binary {
+            bytes: 5_000_000,
+            sha256: "b".repeat(64),
+            text: "nothing interesting".to_string(),
+        };
+        for condition in [
+            Condition::Contains("FLAG{".to_string()),
+            Condition::Regex("FLAG\\{.*\\}".to_string()),
+        ] {
+            let found = evaluate(&condition, &stored, &partial);
+            assert!(!found.matched);
+            assert!(!found.conclusive, "{:?} claimed to be a real no", found.kind);
+        }
+        // A hit is still a hit: finding it in the head proves it is there.
+        let hit = Text::Binary {
+            bytes: 5_000_000,
+            sha256: "b".repeat(64),
+            text: "FLAG{here}".to_string(),
+        };
+        let found = evaluate(&Condition::Contains("FLAG{".to_string()), &stored, &hit);
+        assert!(found.matched && found.conclusive);
+    }
+
+    /// And a body small enough to be previewed whole answers for real.
+    #[test]
+    fn a_miss_over_a_whole_body_is_a_miss() {
+        let stored = response(200, "application/octet-stream");
+        let whole = Text::Binary {
+            bytes: 19,
+            sha256: "b".repeat(64),
+            text: "nothing interesting".to_string(),
+        };
+        let found = evaluate(&Condition::Contains("FLAG{".to_string()), &stored, &whole);
+        assert!(!found.matched && found.conclusive);
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -513,16 +513,38 @@ pub fn show(
     Ok(())
 }
 
+/// How much of one line a preview shows.
+///
+/// The line *count* was bounded and the line *length* was not, so a minified
+/// page — one line, no newlines, megabytes of it — printed whole: into a
+/// terminal, or into the context of the agent that asked. The body diff has
+/// always cut its lines here; this is the same number, for the same reason.
+/// `--raw` and `--body-to` are where the exact bytes live.
+const MAX_PREVIEW_LINE: usize = 400;
+
+/// One line of a body, bounded and inert.
+fn preview_line(line: &str) -> String {
+    let mut shown: String = line.chars().take(MAX_PREVIEW_LINE).collect();
+    if shown.chars().count() < line.chars().count() {
+        shown.push_str(&format!(
+            " … [{} more characters on this line]",
+            line.chars().count() - MAX_PREVIEW_LINE
+        ));
+    }
+    printable(&shown)
+}
+
 fn summarise_body(body: &Text) {
     match body {
         Text::Utf8(text) if text.is_empty() => println!("  body     : empty"),
         Text::Utf8(text) => {
             println!("  body     : {} bytes", text.len());
+            let lines = text.lines().count();
             for line in text.lines().take(20) {
-                println!("    {}", printable(line));
+                println!("    {}", preview_line(line));
             }
-            if text.lines().count() > 20 {
-                println!("    … {} more lines", text.lines().count() - 20);
+            if lines > 20 {
+                println!("    … {} more lines", lines - 20);
             }
         }
         Text::Cut { text, of_bytes } => {
@@ -531,7 +553,7 @@ fn summarise_body(body: &Text) {
                 text.len()
             );
             for line in text.lines().take(20) {
-                println!("    {}", printable(line));
+                println!("    {}", preview_line(line));
             }
             println!("    … the rest of this body is not in the store");
         }
@@ -542,7 +564,7 @@ fn summarise_body(body: &Text) {
         } => {
             println!("  body     : {bytes} bytes, not text (sha256 {sha256})");
             for line in text.lines().take(20) {
-                println!("    {}", printable(line));
+                println!("    {}", preview_line(line));
             }
         }
         Text::Missing(why) => println!("  body     : not stored ({why})"),
@@ -946,7 +968,7 @@ fn line_changes(left: &str, right: &str) -> (Vec<LineChange>, usize) {
             added.push(LineChange {
                 side: "added",
                 line: index + 1,
-                text: line.chars().take(400).collect(),
+                text: line.chars().take(MAX_PREVIEW_LINE).collect(),
             });
         }
     }
@@ -955,7 +977,7 @@ fn line_changes(left: &str, right: &str) -> (Vec<LineChange>, usize) {
             removed.push(LineChange {
                 side: "removed",
                 line: index + 1,
-                text: line.chars().take(400).collect(),
+                text: line.chars().take(MAX_PREVIEW_LINE).collect(),
             });
         }
     }
@@ -2356,6 +2378,25 @@ mod tests {
             "two heads matching is not two pages matching"
         );
         assert!(!difference.same);
+    }
+
+    /// The preview bounded how many lines it showed and not how long one could
+    /// be, so a minified page — one line, no newlines, megabytes of it —
+    /// printed whole into the terminal, or into the context of the agent that
+    /// asked for it. A target chooses whether its page has newlines in it.
+    #[test]
+    fn one_enormous_line_is_bounded_like_every_other() {
+        let shown = preview_line(&"A".repeat(2_000_000));
+        assert!(
+            shown.chars().count() < MAX_PREVIEW_LINE + 80,
+            "a line is bounded: {} characters",
+            shown.chars().count()
+        );
+        assert!(shown.contains("more characters on this line"), "and says so");
+
+        // A line that fits is untouched, and still inert.
+        assert_eq!(preview_line("<p>hello</p>"), "<p>hello</p>");
+        assert!(!preview_line("a\u{1b}[2Jb").contains('\u{1b}'));
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -83,6 +83,19 @@ fn read_json<T: for<'de> serde::Deserialize<'de>>(path: &Path) -> anyhow::Result
 pub enum Text {
     /// Decoded, and safe to compare line by line.
     Utf8(String),
+    /// Decoded, and only the head of what the response carried.
+    ///
+    /// The store keeps at most [`h5i_browser::capture::MAX_BODY_BYTES`] of one
+    /// body, so a response past that is text this can read and cannot read all
+    /// of. Distinct from [`Text::Utf8`] because every verb here turns on the
+    /// difference: a search that finds nothing in the head has said nothing
+    /// about the rest, and a length read off the head is the cap's number, not
+    /// the body's. Eight megabytes is a page a target can serve on purpose.
+    Cut {
+        text: String,
+        /// How many bytes the response actually carried.
+        of_bytes: u64,
+    },
     /// Binary data with an inspection-only lossy preview.
     Binary {
         bytes: u64,
@@ -107,6 +120,7 @@ impl Text {
     fn len(&self) -> Option<u64> {
         match self {
             Text::Utf8(text) => Some(text.len() as u64),
+            Text::Cut { of_bytes, .. } => Some(*of_bytes),
             Text::Binary { bytes, .. } => Some(*bytes),
             Text::Missing(_) => None,
         }
@@ -120,6 +134,7 @@ impl Text {
     fn whole(&self) -> bool {
         match self {
             Text::Utf8(_) => true,
+            Text::Cut { .. } => false,
             Text::Binary { bytes, .. } => *bytes <= LOSSY_BODY_BYTES as u64,
             Text::Missing(_) => false,
         }
@@ -128,6 +143,7 @@ impl Text {
     fn as_str(&self) -> &str {
         match self {
             Text::Utf8(text) => text,
+            Text::Cut { text, .. } => text,
             // Let match and diff inspect the lossy preview.
             Text::Binary { text, .. } => text,
             Text::Missing(_) => "",
@@ -137,6 +153,9 @@ impl Text {
     fn to_json(&self) -> Value {
         match self {
             Text::Utf8(text) => json!({"kind": "text", "text": text}),
+            Text::Cut { text, of_bytes } => {
+                json!({"kind": "text", "text": text, "truncated": true, "of_bytes": of_bytes})
+            }
             Text::Binary {
                 bytes,
                 sha256,
@@ -215,7 +234,12 @@ fn body_text(dir: &Path, body: &Body) -> Text {
             (reason, Some(bytes)) => format!("{reason:?} ({bytes} bytes)").to_lowercase(),
             (reason, None) => format!("{reason:?}").to_lowercase(),
         }),
-        Body::Stored { sha256, bytes, .. } => {
+        Body::Stored {
+            sha256,
+            bytes,
+            of_bytes,
+            truncated,
+        } => {
             let Some(path) = body_file(dir, sha256) else {
                 return Text::Missing(format!(
                     "{sha256:?} is not a body hash, so the store has nothing under it"
@@ -224,6 +248,15 @@ fn body_text(dir: &Path, body: &Body) -> Text {
             match std::fs::read(&path) {
                 Err(e) => Text::Missing(format!("the stored body could not be read: {e}")),
                 Ok(raw) => match String::from_utf8(raw) {
+                    // Text, and whether it is all of the text. A body past the
+                    // store's per-message cap is kept as its head, and a cut
+                    // that lands on a character boundary — which for an ASCII
+                    // or HTML page is every cut — still decodes cleanly, so
+                    // this used to be indistinguishable from a whole body.
+                    Ok(text) if *truncated => Text::Cut {
+                        of_bytes: of_bytes.unwrap_or(text.len() as u64),
+                        text,
+                    },
                     Ok(text) => Text::Utf8(text),
                     Err(e) => Text::Binary {
                         bytes: *bytes,
@@ -302,6 +335,13 @@ fn raw_response(stored: &StoredResponse, body: &Text) -> String {
 fn push_body(out: &mut String, body: &Text) {
     match body {
         Text::Utf8(text) => out.push_str(text),
+        Text::Cut { text, of_bytes } => {
+            out.push_str(text);
+            out.push_str(&format!(
+                "\n[the store kept {} of this body's {of_bytes} bytes]\n",
+                text.len()
+            ));
+        }
         Text::Binary {
             bytes,
             sha256,
@@ -485,6 +525,16 @@ fn summarise_body(body: &Text) {
                 println!("    … {} more lines", text.lines().count() - 20);
             }
         }
+        Text::Cut { text, of_bytes } => {
+            println!(
+                "  body     : {of_bytes} bytes, of which the store kept {}",
+                text.len()
+            );
+            for line in text.lines().take(20) {
+                println!("    {}", printable(line));
+            }
+            println!("    … the rest of this body is not in the store");
+        }
         Text::Binary {
             bytes,
             sha256,
@@ -533,6 +583,12 @@ fn carried_body(dir: &Path, seq: u64, body: &Body) -> anyhow::Result<Vec<u8>> {
     }
     match body_text(dir, body) {
         Text::Utf8(text) => Ok(text.into_bytes()),
+        // Unreachable while the check above stands, and spelled out rather than
+        // folded into a catch-all so that a change to that check fails here.
+        Text::Cut { of_bytes, .. } => anyhow::bail!(
+            "request {seq} carried {of_bytes} bytes and the store kept only its head, so \
+             carrying it would send a request that is not the one recorded"
+        ),
         Text::Binary { sha256, .. } => {
             let path = body_file(dir, &sha256)
                 .ok_or_else(|| anyhow::anyhow!("{sha256:?} is not a body hash"))?;
@@ -2271,6 +2327,35 @@ mod tests {
         // change what it can say.
         let why = extract_one("header:X-Nope", &stored, &absent).expect_err("no such header");
         assert!(why.to_string().contains("found nothing in this response"), "{why}");
+    }
+
+    /// The store keeps at most 8 MiB of one body, and a cut that lands on a
+    /// character boundary — which for an ASCII or HTML page is every cut —
+    /// still decodes cleanly. So a truncated page arrived as ordinary text and
+    /// every verb treated its head as the whole thing: `--contains` answered a
+    /// confident "no" over the first 8 MiB, and two different long pages
+    /// compared as the same response. Eight megabytes is a page a target can
+    /// serve on purpose.
+    #[test]
+    fn a_body_the_store_cut_is_not_a_whole_body() {
+        let cut = Text::Cut {
+            text: "the first eight megabytes".to_string(),
+            of_bytes: 20_000_000,
+        };
+        assert!(!cut.whole());
+        assert_eq!(cut.len(), Some(20_000_000), "the body's length, not the head's");
+
+        let stored = response(200, "text/html");
+        let found = evaluate(&Condition::Contains("FLAG{".to_string()), &stored, &cut);
+        assert!(!found.matched);
+        assert!(!found.conclusive, "a search over the head is not a no");
+
+        let difference = compare((&stored, &cut), (&stored, &cut));
+        assert!(
+            !difference.bodies_compared,
+            "two heads matching is not two pages matching"
+        );
+        assert!(!difference.same);
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -942,34 +942,43 @@ pub fn diff(
     let (b, b_body) = read(right)?;
     let difference = compare((&a, &a_body), (&b, &b_body));
 
-    // The same discipline `match` applies: a body that is not in the store
-    // cannot be compared, and answering with a number anyway would report an
-    // absence as a measurement.
-    if !difference.bodies_compared {
-        let why = |seq: u64, body: &Text| match body {
-            Text::Missing(reason) => Some(format!("{seq}'s body is not in the store ({reason})")),
-            _ => None,
-        };
-        let missing: Vec<String> = [why(left, &a_body), why(right, &b_body)]
-            .into_iter()
-            .flatten()
-            .collect();
-        anyhow::bail!(
-            "response {}, so these two cannot be compared by body. \
-             `message` shows what the store does hold; a session opened with `--capture` \
-             that has not run out of room keeps them",
-            missing.join(", and response ")
-        );
-    }
+    // The same discipline `match` applies, and the same division: a body that
+    // is not in the store, or is only previewed, cannot be compared, and a
+    // number reported anyway would be an absence wearing a measurement's name.
+    // The status and the headers are still real, so they are still reported —
+    // what changes is the exit code, so a script cannot read this as a clean
+    // answer the way it reads a real one.
+    let unanswerable = |seq: u64, body: &Text| match body {
+        Text::Missing(reason) => Some(format!("{seq}'s body is not in the store ({reason})")),
+        Text::Binary { bytes, .. } if !body.whole() => Some(format!(
+            "{seq}'s body is {bytes} bytes of something that is not text, and only its \
+             first {LOSSY_BODY_BYTES} are read back"
+        )),
+        _ => None,
+    };
+    let why: Vec<String> = [unanswerable(left, &a_body), unanswerable(right, &b_body)]
+        .into_iter()
+        .flatten()
+        .collect();
 
     if json_out {
         println!("{}", serde_json::to_string_pretty(&difference)?);
+        if !difference.bodies_compared {
+            std::process::exit(EXIT_CANNOT_LOOK);
+        }
         return Ok(());
     }
 
     if difference.same {
         println!("  {left} and {right} are the same response.");
         return Ok(());
+    }
+    if !difference.bodies_compared {
+        println!("  bodies   : not compared. Response {}.", why.join("; and response "));
+        println!(
+            "             `message --body-to PATH` writes the exact bytes; a session \
+             opened with `--capture` that has not run out of room keeps them whole."
+        );
     }
     println!(
         "  status   : {} → {}",
@@ -1017,6 +1026,9 @@ pub fn diff(
             "  … {} more changed lines not listed",
             total - difference.line_changes.len()
         );
+    }
+    if !difference.bodies_compared {
+        std::process::exit(EXIT_CANNOT_LOOK);
     }
     Ok(())
 }

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -1401,22 +1401,49 @@ pub fn timing_summary(samples: &[Value]) -> Option<Value> {
     if samples.len() < 2 {
         return None;
     }
+    // Only the sends a server answered. A send that never reached the wire —
+    // refused by policy, or by the budget running out partway through a
+    // `--repeat` — still carries a clock, and that clock measures the refusal:
+    // near zero. Folded in with the rest it drags the median down, and a
+    // time-based injection that was answering three seconds late reads as no
+    // delay at all. Which is the failure this verb exists to avoid: a burst
+    // that half happened, reported as a measurement of the half that did not.
+    let answered: Vec<&Value> = samples
+        .iter()
+        .filter(|s| s.get("status").is_some_and(|status| !status.is_null()))
+        .collect();
     let field = |name: &str| -> Vec<u64> {
-        samples
+        answered
             .iter()
             .filter_map(|s| s.get(name).and_then(Value::as_u64))
             .collect()
     };
+    let unanswered = samples.len() - answered.len();
+    if answered.len() < 2 {
+        return Some(json!({
+            "sends": samples.len(),
+            "measured": answered.len(),
+            "unanswered": unanswered,
+            "note": "too few of these sends were answered to take a median. A send that \
+                     never reached the wire has a clock, and it is the refusal's, not the \
+                     server's",
+        }));
+    }
     let (ttfb, ttfb_spread) = median_and_deviation(&field("ttfb_ms"))?;
     let (total, total_spread) = median_and_deviation(&field("total_ms"))?;
-    Some(json!({
+    let mut summary = json!({
         "sends": samples.len(),
+        "measured": answered.len(),
         "ttfb_ms": {"median": ttfb, "deviation": ttfb_spread},
         "total_ms": {"median": total, "deviation": total_spread},
-        "note": "medians over this session's own sends. A session in a box pays a proxy \
-                 hop and a namespace, so compare within one session rather than across \
-                 placements",
-    }))
+        "note": "medians over the sends this session got an answer to. A session in a box \
+                 pays a proxy hop and a namespace, so compare within one session rather \
+                 than across placements",
+    });
+    if unanswered > 0 {
+        summary["unanswered"] = json!(unanswered);
+    }
+    Some(summary)
 }
 
 
@@ -2382,6 +2409,49 @@ mod tests {
             "one 4-second sample must not become the answer: {median}"
         );
         // A mean would have said ~750.
+    }
+
+    /// A `--repeat` burst can stop reaching the wire partway through: the
+    /// budget runs out, or policy refuses. Those sends still carry a clock, and
+    /// it is the refusal's — a millisecond or two. Averaged in with the real
+    /// ones they pull the median down, so a payload that made the server wait
+    /// three seconds reports as no delay, which is the finding not found.
+    #[test]
+    fn sends_that_never_reached_the_wire_are_not_part_of_the_timing() {
+        let answered = |ms: u64| json!({"status": 200, "ttfb_ms": ms, "total_ms": ms});
+        let refused = json!({"status": Value::Null, "ttfb_ms": 0, "total_ms": 0});
+        let samples = vec![
+            answered(3000),
+            answered(3010),
+            answered(2990),
+            refused.clone(),
+            refused.clone(),
+            refused.clone(),
+            refused,
+        ];
+        let summary = timing_summary(&samples).expect("a summary");
+        assert_eq!(summary["sends"], json!(7));
+        assert_eq!(summary["measured"], json!(3));
+        assert_eq!(summary["unanswered"], json!(4));
+        let median = summary["ttfb_ms"]["median"].as_u64().expect("a median");
+        assert!(
+            (2990..=3010).contains(&median),
+            "the delay is the answer, not the refusals: {median}"
+        );
+    }
+
+    /// And a burst that mostly did not happen says so rather than taking a
+    /// median of one.
+    #[test]
+    fn a_burst_that_almost_never_answered_reports_that_instead_of_a_number() {
+        let samples = vec![
+            json!({"status": 200, "ttfb_ms": 3000, "total_ms": 3000}),
+            json!({"status": Value::Null, "ttfb_ms": 0, "total_ms": 0}),
+            json!({"status": Value::Null, "ttfb_ms": 0, "total_ms": 0}),
+        ];
+        let summary = timing_summary(&samples).expect("a summary");
+        assert_eq!(summary["measured"], json!(1));
+        assert!(summary.get("ttfb_ms").is_none(), "{summary}");
     }
 
     /// A blind test's whole signal: one payload is reliably slower.

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -1898,6 +1898,32 @@ fn extract_one(spec: &str, response: &StoredResponse, body: &Text) -> anyhow::Re
     })
 }
 
+/// Why a step failed, out of wherever the reply put it.
+///
+/// A refusal carries `code` and `message`; a send that reached the wire and
+/// failed there carries neither, and puts what happened under `response.error`.
+/// Reading only the first meant a sequence stopped and said "the step failed"
+/// while the answer it was holding said "error sending request for url …". A
+/// sequence stops at the first failure by design, so the reason it gives is the
+/// whole of what its author has to act on.
+fn why_a_step_failed(answer: &Value) -> String {
+    let text = |value: &Value| value.as_str().map(str::to_string);
+    let refusal = answer.get("message").and_then(text).map(|message| {
+        match answer.get("code").and_then(text) {
+            Some(code) => format!("{code}: {message}"),
+            None => message,
+        }
+    });
+    refusal
+        .or_else(|| {
+            answer
+                .get("response")
+                .and_then(|response| response.get("error"))
+                .and_then(text)
+        })
+        .unwrap_or_else(|| "the step failed, and the reply said nothing about why".to_string())
+}
+
 /// `h5i browser sequence <file>`.
 ///
 /// Stops at the first failure. A sequence is a chain, and a step that runs after
@@ -1982,11 +2008,7 @@ pub fn sequence(
             .and_then(|r| r.get("status"))
             .and_then(Value::as_u64);
         if !ok {
-            record.error = answer
-                .get("message")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .or_else(|| Some("the step failed".to_string()));
+            record.error = Some(why_a_step_failed(&answer));
             ran.push(record);
             failed = true;
             if !keep_going {
@@ -2440,6 +2462,32 @@ mod tests {
         assert!(users.navigated, "the browser did go here");
         assert!(!admin.navigated, "and it never went here: a replay is not a visit");
         assert_eq!(admin.hits, 1, "but it is still on the map");
+    }
+
+    /// A sequence stops at the first failure by design, so the reason it gives
+    /// is the whole of what its author has to act on. A refusal carries `code`
+    /// and `message`; a send that reached the wire and failed there carries
+    /// neither and puts what happened in `response.error`. Reading only the
+    /// first meant a step reported "the step failed" while the reply it was
+    /// holding said "error sending request for url …".
+    #[test]
+    fn a_failed_step_reports_the_reason_the_reply_carried() {
+        assert_eq!(
+            why_a_step_failed(&json!({
+                "ok": false,
+                "code": "bad-edit",
+                "message": "path: a path has no query in it"
+            })),
+            "bad-edit: path: a path has no query in it"
+        );
+        assert_eq!(
+            why_a_step_failed(&json!({
+                "ok": false,
+                "response": {"error": "error sending request for url (http://a.test/)"}
+            })),
+            "error sending request for url (http://a.test/)"
+        );
+        assert!(why_a_step_failed(&json!({"ok": false})).contains("said nothing about why"));
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -474,7 +474,7 @@ pub fn show(
             println!("  request  : {} {}", request.method, request.url);
             println!("  at       : {}", request.at);
             for (name, value) in &request.headers {
-                println!("    {}: {}", printable(name), printable(value));
+                println!("    {}: {}", preview_line(name), preview_line(value));
             }
             summarise_body(body);
         }
@@ -499,7 +499,7 @@ pub fn show(
                 None => println!("  response : (none: the request did not complete)"),
             }
             for (name, value) in &response.headers {
-                println!("    {}: {}", printable(name), printable(value));
+                println!("    {}: {}", preview_line(name), preview_line(value));
             }
             summarise_body(body);
             if let Some(trailing) = &trailing {
@@ -1097,22 +1097,22 @@ pub fn diff(
     );
     println!("  alike    : {:.3}", difference.similarity);
     for name in &difference.headers_added {
-        println!("  + header : {}", printable(name));
+        println!("  + header : {}", preview_line(name));
     }
     for name in &difference.headers_removed {
-        println!("  - header : {}", printable(name));
+        println!("  - header : {}", preview_line(name));
     }
     for name in &difference.headers_changed {
-        println!("  ~ header : {}", printable(name));
+        println!("  ~ header : {}", preview_line(name));
     }
     for change in &difference.json_changes {
         let from = change.from.as_deref().unwrap_or("(absent)");
         let to = change.to.as_deref().unwrap_or("(absent)");
         println!(
             "  ~ {} : {} → {}",
-            printable(&change.path),
-            printable(from),
-            printable(to)
+            preview_line(&change.path),
+            preview_line(from),
+            preview_line(to)
         );
     }
     for change in &difference.line_changes {
@@ -1448,7 +1448,12 @@ fn look(
                 one.expr
             );
             for capture in &one.captures {
-                println!("      {}", printable(capture));
+                // Bounded in the human view for the reason a body line is: the
+                // target chooses how much text sits between a pattern's
+                // anchors, so `--regex 'flag=(.*)'` over a one-line page
+                // captures the page. `--json` still carries it whole, because
+                // that is the channel a script reads a token out of.
+                println!("      {}", preview_line(capture));
             }
         }
     }
@@ -1694,12 +1699,12 @@ pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::R
             let params = if endpoint.params.is_empty() {
                 String::new()
             } else {
-                format!("  ?{}", printable(&endpoint.params.join("&")))
+                format!("  ?{}", preview_line(&endpoint.params.join("&")))
             };
             let mark = if endpoint.navigated { "*" } else { " " };
             println!(
                 "  {mark} {:<32} {:<8} {:<12} x{}{params}",
-                printable(&endpoint.path),
+                preview_line(&endpoint.path),
                 methods,
                 statuses,
                 endpoint.hits
@@ -1710,7 +1715,7 @@ pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::R
         println!();
         println!("  refused by policy:");
         for url in &map.denied {
-            println!("    {}", printable(url));
+            println!("    {}", preview_line(url));
         }
     }
     Ok(())
@@ -2038,7 +2043,7 @@ pub fn sequence(
         for step in &ran {
             let label = step.name.clone().unwrap_or_else(|| format!("resend {}", step.resend));
             match (&step.error, step.status) {
-                (Some(why), _) => println!("  ✘ {label}: {}", printable(why)),
+                (Some(why), _) => println!("  ✘ {label}: {}", preview_line(why)),
                 (None, Some(status)) => {
                     let bound = if step.bound.is_empty() {
                         String::new()
@@ -2397,6 +2402,23 @@ mod tests {
         // A line that fits is untouched, and still inert.
         assert_eq!(preview_line("<p>hello</p>"), "<p>hello</p>");
         assert!(!preview_line("a\u{1b}[2Jb").contains('\u{1b}'));
+    }
+
+    /// The same bound, everywhere a target's text reaches the terminal. A
+    /// capture is the clearest case: the target chooses how much page sits
+    /// between a pattern's anchors, so `--regex 'flag=(.*)'` over a page with
+    /// no newlines in it captures the page.
+    #[test]
+    fn a_capture_over_a_whole_page_is_bounded_in_the_human_view() {
+        let stored = response(200, "text/html");
+        let page = format!("flag={}", "A".repeat(2_000_000));
+        let body = Text::Utf8(page);
+        let found = evaluate(&Condition::Regex("flag=(.*)".to_string()), &stored, &body);
+        assert!(found.matched);
+        // Whole in the machine channel, which is where a token is read from.
+        assert_eq!(found.captures[0].len(), 2_000_000);
+        // Bounded on the way to a terminal.
+        assert!(preview_line(&found.captures[0]).chars().count() < MAX_PREVIEW_LINE + 80);
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -108,6 +108,52 @@ impl Text {
     }
 }
 
+/// Target text with what a terminal would act on made visible instead.
+///
+/// Every string in this module that came off the wire is printed to a terminal
+/// by the human view: a header value, a body line, a captured group, a query
+/// parameter name. An escape sequence in one of them repaints the screen —
+/// it can erase the line naming which request this was, or draw a status that
+/// never arrived, which is the one thing a workbench must not let a target do
+/// to the report of what the target did.
+///
+/// Escaped rather than dropped, so a `\u{1b}` in a response is still visible as
+/// one, and still countable. Bidi controls go the same way: `char::is_control`
+/// is false for every one of them and they reorder the line around them without
+/// being seen. `--raw`, `--body-to` and `--json` are untouched, and that is
+/// where exact bytes belong: the first two are the byte channels, and JSON
+/// escapes a control character on the way out by itself.
+fn printable(text: &str) -> String {
+    if !text
+        .chars()
+        .any(|c| c.is_control() || is_bidi_control(c))
+    {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if ch.is_control() || is_bidi_control(ch) {
+            out.extend(ch.escape_debug());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Bidirectional formatting characters, which reorder the text *around* them.
+///
+/// The overrides, embeddings and isolates only; `U+200C`/`U+200D` carry no
+/// reordering power and are ordinary text. The same set the engine drops from
+/// page text in `snapshot.rs`.
+fn is_bidi_control(c: char) -> bool {
+    matches!(c,
+        '\u{200E}' | '\u{200F}'
+        | '\u{202A}'..='\u{202E}'
+        | '\u{2066}'..='\u{2069}'
+    )
+}
+
 /// Exact stored body bytes, or `None` when unavailable.
 fn body_bytes(dir: &Path, body: &Body) -> Option<Vec<u8>> {
     match body {
@@ -347,7 +393,7 @@ pub fn show(
             println!("  request  : {} {}", request.method, request.url);
             println!("  at       : {}", request.at);
             for (name, value) in &request.headers {
-                println!("    {name}: {value}");
+                println!("    {}: {}", printable(name), printable(value));
             }
             summarise_body(body);
         }
@@ -372,7 +418,7 @@ pub fn show(
                 None => println!("  response : (none: the request did not complete)"),
             }
             for (name, value) in &response.headers {
-                println!("    {name}: {value}");
+                println!("    {}: {}", printable(name), printable(value));
             }
             summarise_body(body);
             if let Some(trailing) = &trailing {
@@ -392,7 +438,7 @@ fn summarise_body(body: &Text) {
         Text::Utf8(text) => {
             println!("  body     : {} bytes", text.len());
             for line in text.lines().take(20) {
-                println!("    {line}");
+                println!("    {}", printable(line));
             }
             if text.lines().count() > 20 {
                 println!("    … {} more lines", text.lines().count() - 20);
@@ -405,7 +451,7 @@ fn summarise_body(body: &Text) {
         } => {
             println!("  body     : {bytes} bytes, not text (sha256 {sha256})");
             for line in text.lines().take(20) {
-                println!("    {line}");
+                println!("    {}", printable(line));
             }
         }
         Text::Missing(why) => println!("  body     : not stored ({why})"),
@@ -814,22 +860,27 @@ pub fn diff(
     );
     println!("  alike    : {:.3}", difference.similarity);
     for name in &difference.headers_added {
-        println!("  + header : {name}");
+        println!("  + header : {}", printable(name));
     }
     for name in &difference.headers_removed {
-        println!("  - header : {name}");
+        println!("  - header : {}", printable(name));
     }
     for name in &difference.headers_changed {
-        println!("  ~ header : {name}");
+        println!("  ~ header : {}", printable(name));
     }
     for change in &difference.json_changes {
         let from = change.from.as_deref().unwrap_or("(absent)");
         let to = change.to.as_deref().unwrap_or("(absent)");
-        println!("  ~ {} : {from} → {to}", change.path);
+        println!(
+            "  ~ {} : {} → {}",
+            printable(&change.path),
+            printable(from),
+            printable(to)
+        );
     }
     for change in &difference.line_changes {
         let mark = if change.side == "added" { '+' } else { '-' };
-        println!("  {mark} {}", change.text);
+        println!("  {mark} {}", printable(&change.text));
     }
     Ok(())
 }
@@ -1119,7 +1170,7 @@ fn look(
                 one.expr
             );
             for capture in &one.captures {
-                println!("      {capture}");
+                println!("      {}", printable(capture));
             }
         }
     }
@@ -1333,12 +1384,15 @@ pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::R
             let params = if endpoint.params.is_empty() {
                 String::new()
             } else {
-                format!("  ?{}", endpoint.params.join("&"))
+                format!("  ?{}", printable(&endpoint.params.join("&")))
             };
             let mark = if endpoint.navigated { "*" } else { " " };
             println!(
                 "  {mark} {:<32} {:<8} {:<12} x{}{params}",
-                endpoint.path, methods, statuses, endpoint.hits
+                printable(&endpoint.path),
+                methods,
+                statuses,
+                endpoint.hits
             );
         }
     }
@@ -1346,7 +1400,7 @@ pub fn sitemap(root: &Path, selector: Option<&str>, json_out: bool) -> anyhow::R
         println!();
         println!("  refused by policy:");
         for url in &map.denied {
-            println!("    {url}");
+            println!("    {}", printable(url));
         }
     }
     Ok(())
@@ -1652,7 +1706,7 @@ pub fn sequence(
         for step in &ran {
             let label = step.name.clone().unwrap_or_else(|| format!("resend {}", step.resend));
             match (&step.error, step.status) {
-                (Some(why), _) => println!("  ✘ {label}: {why}"),
+                (Some(why), _) => println!("  ✘ {label}: {}", printable(why)),
                 (None, Some(status)) => {
                     let bound = if step.bound.is_empty() {
                         String::new()
@@ -1732,6 +1786,22 @@ mod tests {
         let refused = carried_body(&dir, 42, &cut).expect_err("a cut body is not replayable");
         assert!(refused.to_string().contains("not the one recorded"), "{refused}");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A header value and a body line are strings the target wrote, and the
+    /// human view prints them to a terminal. An escape sequence in one repaints
+    /// the screen: `\r` alone rewrites the line that says which request this
+    /// was, and `ESC[2J` clears what came before it.
+    #[test]
+    fn what_a_terminal_would_act_on_is_shown_rather_than_obeyed() {
+        let hostile = "ok\u{1b}[2J\rHTTP/1.1 200 forged\u{202e}";
+        let safe = printable(hostile);
+        assert!(!safe.contains('\u{1b}'), "{safe:?}");
+        assert!(!safe.contains('\r'), "{safe:?}");
+        assert!(!safe.contains('\u{202e}'), "{safe:?}");
+        assert!(safe.contains("forged"), "the evidence survives: {safe:?}");
+        assert!(safe.contains("u{1b}"), "and says what was there: {safe:?}");
+        assert_eq!(printable("ordinary text"), "ordinary text");
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {

--- a/src/cli/websec.rs
+++ b/src/cli/websec.rs
@@ -569,7 +569,20 @@ pub struct Difference {
     /// on, and the reason this verb is not just a printed diff: reading two
     /// HTML pages per candidate character through a model is the expensive way
     /// to answer "true page or false page".
+    ///
+    /// Only meaningful when [`Difference::bodies_compared`] is set.
     pub similarity: f64,
+    /// Whether there were two bodies to compare at all.
+    ///
+    /// A body that is not in the store reads as the empty string, so two
+    /// responses whose bodies were skipped compared as identical: `same`,
+    /// `similarity` 1.0, nothing to see. That is the mistake `match` refuses to
+    /// make, and it is reachable on purpose — the store refuses new bodies once
+    /// it is full, and a target that answers with 512 MiB of anything, or
+    /// serves its pages as `font/woff`, turns every later comparison into
+    /// "these are the same page". The oracle then says "false page" for every
+    /// candidate character, which is the shape of a finding that is not there.
+    pub bodies_compared: bool,
     pub headers_added: Vec<String>,
     pub headers_removed: Vec<String>,
     pub headers_changed: Vec<String>,
@@ -640,13 +653,19 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
         }
     }
 
+    // Two bodies, or none of this is a comparison. `Text::Missing` reads as the
+    // empty string, which made "neither body was kept" indistinguishable from
+    // "both bodies were empty".
+    let bodies_compared =
+        !matches!(a_body, Text::Missing(_)) && !matches!(b_body, Text::Missing(_));
     let left_text = a_body.as_str();
     let right_text = b_body.as_str();
     let (json_changes, line_changes) = body_changes(a, b, left_text, right_text);
 
     let bytes = (left_text.len() as u64, right_text.len() as u64);
     Difference {
-        same: a.status == b.status
+        same: bodies_compared
+            && a.status == b.status
             && added.is_empty()
             && removed.is_empty()
             && changed.is_empty()
@@ -655,7 +674,14 @@ pub fn compare(left: (&StoredResponse, &Text), right: (&StoredResponse, &Text)) 
         status_changed: a.status != b.status,
         bytes,
         length_delta: bytes.1 as i64 - bytes.0 as i64,
-        similarity: similarity(left_text, right_text),
+        // Zero rather than one, so a caller that reads the number without the
+        // flag beside it errs towards looking again.
+        similarity: if bodies_compared {
+            similarity(left_text, right_text)
+        } else {
+            0.0
+        },
+        bodies_compared,
         headers_added: added,
         headers_removed: removed,
         headers_changed: changed,
@@ -839,6 +865,26 @@ pub fn diff(
     let (a, a_body) = read(left)?;
     let (b, b_body) = read(right)?;
     let difference = compare((&a, &a_body), (&b, &b_body));
+
+    // The same discipline `match` applies: a body that is not in the store
+    // cannot be compared, and answering with a number anyway would report an
+    // absence as a measurement.
+    if !difference.bodies_compared {
+        let why = |seq: u64, body: &Text| match body {
+            Text::Missing(reason) => Some(format!("{seq}'s body is not in the store ({reason})")),
+            _ => None,
+        };
+        let missing: Vec<String> = [why(left, &a_body), why(right, &b_body)]
+            .into_iter()
+            .flatten()
+            .collect();
+        anyhow::bail!(
+            "response {}, so these two cannot be compared by body. \
+             `message` shows what the store does hold; a session opened with `--capture` \
+             that has not run out of room keeps them",
+            missing.join(", and response ")
+        );
+    }
 
     if json_out {
         println!("{}", serde_json::to_string_pretty(&difference)?);
@@ -1802,6 +1848,38 @@ mod tests {
         assert!(safe.contains("forged"), "the evidence survives: {safe:?}");
         assert!(safe.contains("u{1b}"), "and says what was there: {safe:?}");
         assert_eq!(printable("ordinary text"), "ordinary text");
+    }
+
+    /// A body that is not in the store reads as the empty string, so two
+    /// responses whose bodies the store skipped compared as identical:
+    /// `same`, similarity 1.0. The store refuses new bodies once it is full and
+    /// skips media outright, so a target can reach that state on purpose and
+    /// turn every later comparison into "the same page" — which is the answer a
+    /// blind-injection loop reads as "false" for every candidate character.
+    #[test]
+    fn two_bodies_that_were_never_kept_are_not_the_same_page() {
+        let left = response(200, "text/html");
+        let right = response(200, "text/html");
+        let absent = Text::Missing("store-full (2000000 bytes)".to_string());
+        let difference = compare((&left, &absent), (&right, &absent));
+        assert!(!difference.bodies_compared, "there was nothing to compare");
+        assert!(!difference.same, "an absence is not a match");
+        assert!(
+            difference.similarity < 0.5,
+            "a number nobody could measure is not 1.0: {}",
+            difference.similarity
+        );
+    }
+
+    /// An empty body is a real body, and two of them are still the same page.
+    #[test]
+    fn two_empty_bodies_are_still_compared() {
+        let left = response(204, "text/html");
+        let right = response(204, "text/html");
+        let empty = Text::Utf8(String::new());
+        let difference = compare((&left, &empty), (&right, &empty));
+        assert!(difference.bodies_compared);
+        assert!(difference.same);
     }
 
     fn response(status: u16, kind: &str) -> StoredResponse {


### PR DESCRIPTION
One confirmed defect per commit, each with a regression test that fails against
the old code.

- **Panics a target can trigger** — chunked size overflow on the raw path; a
  malformed multipart body slicing backwards.
- **Verdicts from bodies nobody read** — `diff` called two unstored bodies "the
  same page" (similarity 1.0); `match` answered "did not match" from the first
  64 KiB; a body cut at the store's 8 MiB cap read as whole. All reachable on
  purpose.
- **Replays that were not the recorded request** — `\` traversal past the
  dot-segment guard; query, form and cookie edits rewriting fields nobody named;
  JSON keys sorted; the `User-Agent` the store never recorded, which the
  documented `message --raw` → `--raw-request` round trip then sent without.
- **Evidence gaps** — the `--since` cursor skipped a response whose request was
  still in flight; replays were logged as navigations, so the site map marked
  them as pages the browser had visited; every reader refused a finished run
  when asked for it by name.
- **Credentials** — unchecked hash→path join in the store reader; store mode
  applied only on create and following symlinks; CORS `Allow-Headers: *`
  covering `Authorization`; `close --capture-drop`, which the design promised
  and nothing had built.

Also ships `h5i-websec` in the release, so `plugin install --from` has a file to
point at without a source tree.

Suite green apart from three pre-existing `env_integration` host-drift failures.
