### PR TITLE
SHOWCASE: h5i-audit-report

### DIFF
--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -4,3 +4,4 @@
 - [h5i-fastapi-starter](https://github.com/SumedhAnupSupe/h5i-fastapi-starter): A small FastAPI application with a simple HTML UI, designed to run inside an h5i box.
 - [h5i-egress-advisor](https://github.com/AniketR10/h5i-egress-advisor): Reads a box's receipts and turns the egress its allowlist refused into `h5i box allow` lines to review — or a `[profile.X.net]` block for the tiers `h5i box allow` cannot reach.
 - [h5i-git-hooks](https://github.com/VedantMadane/h5i-git-hooks): Git hooks that run your test suite inside an h5i box (pre-commit on the staged tree, pre-push on the tip).
+- [h5i-audit-report](https://github.com/Pewpenguin/h5i-audit-report): Turns `h5i browser audit --json` into a self-contained HTML report for archiving and sharing.


### PR DESCRIPTION
Closes #575 .

Adds `h5i-audit-report` to the h5i showcase.

It is a standalone Rust CLI that converts `h5i browser audit --json` output into a self-contained HTML report.

Features:
- session metadata and policy digest
- ordered browser/request/lifecycle timeline
- allowed/denied request distinction and denial reasons
- event and request-decision filters
- summary counts
- HTML escaping and no remote assets

Repository: https://github.com/Pewpenguin/h5i-audit-report

Validated against a real `h5i browser audit --json` capture. Tests, formatting, and Clippy all pass.

<img width="1920" height="1322" alt="h5i audit report" src="https://github.com/user-attachments/assets/7dbe4d98-c38d-4fe4-a2d3-1a4e4c78abd6" />
