### PR TITLE
fix the windows release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,9 +174,12 @@ jobs:
       - name: Build
         env:
           H5I_SKIP_WEB_BUILD: "1"
-        run: |
-          cargo build --release --locked --target ${{ matrix.target }} \
-            -p ${{ env.BINARY_NAME }} -p ${{ env.PLUGIN_NAME }}
+        # Folded (`>-`): YAML joins these into one line before any shell sees
+        # them. This step sets no `shell:`, so Windows runs PowerShell, where a
+        # `\` continuation is not one — it reached cargo as an argument in v0.4.1.
+        run: >-
+          cargo build --release --locked --target ${{ matrix.target }}
+          -p ${{ env.BINARY_NAME }} -p ${{ env.PLUGIN_NAME }}
 
       # ── Package ───────────────────────────────────────────────────────────
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -359,7 +359,7 @@ jobs:
   # caught BEFORE a tag is cut — not in `release.yaml`, which only runs on tags.
   # `cargo check` (not a full build) is enough: every such failure is a
   # front-end compile/type/cfg error. Keep this matrix in sync with
-  # `release.yaml`'s build matrix — and check both products it ships, because
+  # `release.yaml`'s build matrix — and check every product it ships, because
   # this job checked only `h5i` while the release built the engine too, and so
   # let two separate engine-only failures through to the v0.3.5 tag.
   cross-check:
@@ -413,3 +413,4 @@ jobs:
         run: |
           cargo check --locked --target ${{ matrix.target }}
           cargo check --locked --target ${{ matrix.target }} -p h5i-browser
+          cargo check --locked --target ${{ matrix.target }} -p h5i-websec


### PR DESCRIPTION
The v0.4.1 release failed on `x86_64-pc-windows-msvc` after 38s, so no release was published.

`8ef320774` split the release build across two lines with a `\` continuation. The `Build` step sets no `shell:`, so the Windows runner is PowerShell, which has no `\` continuation: cargo got a literal `\` (`error: unexpected argument '\' found`) and pwsh then tried to run `-p` as a command. At v0.4.0 the step was one line, which is why it built.

Folded (`>-`) rather than a `\`, so YAML joins the lines before any shell sees them and the step works under both pwsh and bash.

Also adds `h5i-websec` to `cross-check`. It is a standalone bin, not a dependency of `h5i`, so the root `cargo check` never touched it — the release built it on four targets while no CI job compiled it anywhere. That is the gap the job's own comment records letting two engine-only failures through to the v0.3.5 tag.